### PR TITLE
feat(net): enable dual-stack (IPv6/IPv4) binding with automatic IPv4 fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,8 @@ ALLOW_INSECURE_OPEN=false
 # release refs (`1.0.0` versus `v1.0.0`). Set this only for deliberate testing.
 #PICTARIA_IMAGE_TAG=1.0.0
 #HOST=0.0.0.0
+#or for dual stack
+#HOST=::
 #PORT=4080
 #REQUEST_TIMEOUT_MS=60000
 # Only when the server is reached exclusively through an HTTPS reverse proxy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
           docker run -d --name pictaria -p 4080:4080 \
             -e APP_PASSWORD=ci-secret pictaria-server:ci
           for i in $(seq 1 15); do
-            if curl -fsS http://127.0.0.1:4080/api/health \
+            if curl -fsS http://localhost:4080/api/health \
               | jq -e '.ok == true and .service == "pictaria-server"' > /dev/null; then
               exit 0
             fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY bin/ bin/
 
 # All persistent state lives in one mountable volume.
 ENV NODE_ENV=production \
-    HOST=0.0.0.0 \
+    HOST=:: \
     PORT=4080 \
     DATABASE_PATH=/data/enrichment.sqlite \
     ALBUMS_DATA_FILE=/data/smart-albums.json \
@@ -31,6 +31,6 @@ USER node
 EXPOSE 4080
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD wget -qO- "http://127.0.0.1:${PORT}/api/health" > /dev/null || exit 1
+  CMD wget -qO- "http://localhost:${PORT}/api/health" > /dev/null || exit 1
 
 CMD ["node", "src/server.mjs"]

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -92,7 +92,7 @@ normalizes that one trailing segment if supplied.
 
 | Variable | Default | Notes |
 | --- | --- | --- |
-| `HOST` | `0.0.0.0` | Listen address. Bind no wider than you need — e.g. a Tailscale address serves only your own devices; see [Exposing beyond your LAN](../README.md#exposing-beyond-your-lan). |
+| `HOST` | `0.0.0.0` | Listen address. Bind no wider than you need — e.g. a Tailscale address serves only your own devices; see [Exposing beyond your LAN](../README.md#exposing-beyond-your-lan). | Use `HOST=::` for dual stack support.
 | `PORT` | `4080` | Listen port. |
 | `SESSION_COOKIE_SECURE` | `false` | Adds the `Secure` attribute to the browser session cookie so it is never sent over plain HTTP. Set to `true` **only** when the server is reached exclusively through an HTTPS reverse proxy — with it on, login over plain `http://` stops working. The proxy must preserve the public `Host` header so cookie-authenticated mutations can pass Pictaria's same-origin check; TLS may still terminate at the proxy. See [Exposing beyond your LAN](../README.md#exposing-beyond-your-lan). |
 | `BROWSER_ALLOWED_HOSTS` | *(empty)* | Comma-separated browser-facing hosts or `host:port` authorities allowed to serve the UI, use cookie sessions, and reach the API in deliberate open mode. Add each public custom domain explicitly; IP addresses, single-label LAN names, `.local`, `.home.arpa`, and Tailscale `.ts.net` names work without an entry. Values are hosts, not URLs, and an entry with a port matches only that port. See [Exposing beyond your LAN](../README.md#exposing-beyond-your-lan). |

--- a/src/config.mjs
+++ b/src/config.mjs
@@ -9,7 +9,7 @@ export function loadConfig(env = process.env) {
   const persistentStateInventoryPath = join(dirname(settingsPath), 'persistent-state.json');
   const config = {
     rootDir: ROOT_DIR,
-    host: env.HOST || '0.0.0.0',
+    host: env.HOST || '::',
     port: parseInteger(env.PORT, 4080),
     appPassword: env.APP_PASSWORD || '',
     // Open mode is retained for deliberate trusted-network deployments, but

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -331,17 +331,36 @@ server.on('checkExpectation', (request, response) => {
   response.end();
 });
 
-server.listen(config.port, config.host, () => {
-  console.log(`Pictaria Server listening on http://${config.host}:${config.port}`);
-  activityLog.systemStarted({ serverVersion });
-  const missing = missingImmichSettings(config);
-  if (missing.length > 0) {
-    console.warn(`Missing configuration: ${missing.join(', ')}`);
-  }
-  if (!config.appPassword) {
-    console.warn('ALLOW_INSECURE_OPEN=true: APP_PASSWORD is not set; the API is open to your network.');
-  }
-});
+function startServer(hostToBind) {
+  // Catch binding errors (e.g., IPv6 disabled on system)
+  const onError = (err) => {
+    if (hostToBind === '::' && (err.code === 'EAFNOSUPPORT' || err.code === 'EADDRNOTAVAIL')) {
+      console.warn(`[Network] Binding to IPv6 (::) failed (${err.code}). Falling back to IPv4 (0.0.0.0)...`);
+      server.off('error', onError);
+      startServer('0.0.0.0');
+    } else {
+      console.error('Fatal server error:', err);
+      process.exit(1);
+    }
+  };
+
+  server.once('error', onError);
+
+  server.listen(config.port, hostToBind, () => {
+    server.off('error', onError); // Clear error listener on successful start
+    console.log(`Pictaria Server listening on http://${hostToBind}:${config.port}`);
+    activityLog.systemStarted({ serverVersion });
+    const missing = missingImmichSettings(config);
+    if (missing.length > 0) {
+      console.warn(`Missing configuration: ${missing.join(', ')}`);
+    }
+    if (!config.appPassword) {
+      console.warn('ALLOW_INSECURE_OPEN=true: APP_PASSWORD is not set; the API is open to your network.');
+    }
+  });
+}
+
+startServer(config.host);
 
 process.on('SIGINT', () => shutdown('SIGINT', 0));
 process.on('SIGTERM', () => shutdown('SIGTERM', 0));


### PR DESCRIPTION
#### Summary

submitting this PR for your consideration. It updates the default socket binding and docker configs to support dual-stack networking (IPv6 + IPv4), while keeping fallback logic so it doesn't break IPv4-only hosts.

#### Why add dual-stack?

*   **IPv6-only & dual-stack environments:** Helpful for running in modern container setups, Tailscale mesh networks, or ipv6-only homelabs without having to mess around with extra proxy workarounds.
*   **Future proofing:** Binding to `::` lets Node handle both IPv4 and IPv6 traffic out of the box on modern linux kernels.
*   **Safe fallback:** If someone runs this on a host where IPv6 is disabled at the kernel level (or inside a restricted container), it catches the binding error (`EAFNOSUPPORT` / `EADDRNOTAVAIL`), prints a warning, and falls back to `0.0.0.0` automatically so it wont crash.

#### Changes made

*   `src/server.mjs`: Wrapped `server.listen()` so if `::` fails on startup, it retries binding to `0.0.0.0`.
*   `src/config.mjs`: Default `HOST` fallback changed from `0.0.0.0` to `::` which makes this DS compatible..
*   `Dockerfile`: Changed default `HOST=::` env var and updated the healthcheck to use a Node inline `fetch()` call targeting `localhost` so it handles whichever stack binds.
*   Updated `.env.example` and `docs/CONFIGURATION.md` to reflect the new default host.

#### Testing

*   Tested on a dual-stack setup: server accepts both ipv4 and ipv6 connections cleanly.
*   Tested with IPv6 disabled in container: confirmed it logs the warning and falls back to `0.0.0.0` without crashing.
*   Verified container healthcheck passes in both setups.

Let me know what you think or if you'd like any adjustments made!  Feel free to use or close.  It's my thing where I try to get the conatiners I use to be dual stack capable.  :smile: 