### PR TITLE
PIC-313: Keep Insights usable with oversized unused EXIF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to Pictaria Server are documented here. This project follows
 
 ## Unreleased
 
+### Fixed
+
+- Insights ignores oversized Immich EXIF fields it does not store, while
+  retaining strict bounds for metadata it uses. Malformed numeric metadata is
+  left blank, counted, and reported without dropping the asset or the sweep.
+  Refresh failures remain visible even when a run ends before the first status
+  poll observes it.
+
 ## 1.0.0 - 2026-08-28
 
 The first public release of Pictaria Server: a self-hosted companion for

--- a/public/insights.html
+++ b/public/insights.html
@@ -16,6 +16,15 @@
     .intro { color: var(--p-muted); font-size: 13px; margin: -10px 0 18px; line-height: 1.5; }
     .page-head h1 { font-size: 20px; font-weight: 800; letter-spacing: 0.2px; margin: 0; }
     .freshness { color: var(--p-muted); font-size: 13px; }
+    .refresh-error {
+      margin: 0 0 16px;
+      padding: 10px 12px;
+      border: 1px solid color-mix(in srgb, var(--p-danger) 55%, transparent);
+      border-radius: 8px;
+      color: var(--p-danger);
+      background: color-mix(in srgb, var(--p-danger) 8%, transparent);
+      font-size: 13px;
+    }
     .hero-tiles { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 12px; margin-bottom: 22px; }
     .tile { padding: 14px 16px; }
     .tile .num { font-size: 24px; font-weight: 800; letter-spacing: 0.2px; }
@@ -377,6 +386,7 @@
       or location to see details and send groups to
       <a href="/enrich.html" style="color: var(--p-accent)">Enrich</a> or
       <a href="/curate.html" style="color: var(--p-accent)">Curate</a>.</p>
+    <p id="refreshError" class="refresh-error" role="alert" hidden></p>
 
     <div id="empty" class="p-panel empty" hidden>
       <h2>No snapshot yet</h2>

--- a/public/insights.js
+++ b/public/insights.js
@@ -1,5 +1,7 @@
 const state = {
   polling: null,
+  refreshPending: false,
+  lastRefreshError: null,
   immichUrl: null,
   snapshot: null,
   browser: null, // { slice, items, nextPage, loading }
@@ -2552,11 +2554,43 @@ function renderSweepBanner(snapshot) {
     + 'Raise INSIGHTS_MAX_SWEEP_PAGES in the server environment and refresh to cover everything.';
 }
 
+function renderMetadataOmissionBanner(snapshot) {
+  let banner = el('metadataOmissionBanner');
+  const omission = snapshot.metadataOmissions;
+  const total = Number(omission?.total ?? 0);
+  if (!Number.isSafeInteger(total) || total < 1) {
+    if (banner) banner.hidden = true;
+    return;
+  }
+  if (!banner) {
+    banner = document.createElement('div');
+    banner.id = 'metadataOmissionBanner';
+    banner.className = 'p-panel';
+    banner.setAttribute('role', 'status');
+    banner.style.cssText = 'padding: 10px 16px; margin-bottom: 14px; font-size: 13px; '
+      + 'line-height: 1.5; color: var(--p-gold); border-color: #6d5410;';
+    el('content').prepend(banner);
+  }
+  const labels = {
+    fileSizeInByte: 'file size',
+    latitude: 'latitude',
+    longitude: 'longitude',
+  };
+  const detail = Object.entries(omission.fields ?? {})
+    .filter(([field, count]) => labels[field] && Number.isSafeInteger(count) && count > 0)
+    .map(([field, count]) => `${labels[field]}: ${fmt(count)}`)
+    .join(', ');
+  banner.hidden = false;
+  banner.textContent = `Insights left ${fmt(total)} invalid metadata ${total === 1 ? 'value' : 'values'} blank while scanning`
+    + `${detail ? ` (${detail})` : ''}. All photos were still counted.`;
+}
+
 function render(snapshot) {
   state.snapshot = snapshot;
   el('content').hidden = false;
   el('empty').hidden = true;
   renderSweepBanner(snapshot);
+  renderMetadataOmissionBanner(snapshot);
 
   const t = snapshot.totals;
   const spanYears = t.firstTakenAt && t.lastTakenAt
@@ -2664,27 +2698,41 @@ function describePhase(status) {
   }
 }
 
+function renderRefreshStatus(status, { notifyError = false } = {}) {
+  const chip = el('runChip');
+  chip.hidden = !status.running;
+  chip.textContent = status.running ? describePhase(status) : '';
+  el('refreshBtn').disabled = Boolean(status.running);
+
+  const message = status.phase === 'error' && status.error
+    ? `Refresh failed: ${status.error}`
+    : null;
+  const errorNode = el('refreshError');
+  errorNode.hidden = !message;
+  errorNode.textContent = message ?? '';
+  if (notifyError && message && message !== state.lastRefreshError) {
+    toast(message);
+  }
+  state.lastRefreshError = message;
+}
+
 async function poll() {
   try {
     const status = await api('/api/insights/status');
-    const chip = el('runChip');
+    renderRefreshStatus(status, { notifyError: true });
     if (status.running) {
-      chip.hidden = false;
-      chip.textContent = describePhase(status);
-      el('refreshBtn').disabled = true;
       if (!state.polling) {
         state.polling = setInterval(poll, 2500);
       }
       return;
     }
-    chip.hidden = true;
-    el('refreshBtn').disabled = false;
+    const shouldReload = Boolean(state.polling) || state.refreshPending;
     if (state.polling) {
       clearInterval(state.polling);
       state.polling = null;
-      if (status.phase === 'error' && status.error) {
-        toast(`Refresh failed: ${status.error}`);
-      }
+    }
+    state.refreshPending = false;
+    if (shouldReload) {
       await load();
     }
   } catch {
@@ -2693,11 +2741,15 @@ async function poll() {
 }
 
 async function refresh() {
+  state.refreshPending = true;
+  renderRefreshStatus({ running: true, phase: 'starting', progress: {} });
   try {
     await api('/api/insights/refresh', { method: 'POST' });
     toast('Refresh started');
     await poll();
   } catch (error) {
+    state.refreshPending = false;
+    renderRefreshStatus({ running: false, phase: 'error', error: 'Could not start refresh.' });
     if (error.unauthorized) { showLogin(); return; }
     toast('Could not start refresh');
   }
@@ -2716,6 +2768,7 @@ async function load() {
       el('empty').hidden = false;
       el('content').hidden = true;
     }
+    renderRefreshStatus(status);
     if (status.running) {
       await poll();
     }

--- a/src/insights/collector.mjs
+++ b/src/insights/collector.mjs
@@ -18,7 +18,6 @@ const PEOPLE_TRAVERSAL_TIMEOUT_MS = 60_000;
 
 export const MAX_INSIGHTS_IDENTIFIER_LENGTH = 128;
 export const MAX_INSIGHTS_PEOPLE_PER_ASSET = 100;
-export const MAX_INSIGHTS_METADATA_ITEMS_PER_ASSET = 128;
 export const MAX_INSIGHTS_METADATA_FIELD_BYTES = 4 * 1024;
 // Immich's PersonWithFaces response carries roughly twenty structural items
 // per recognized face. These per-record ceilings leave useful margin above
@@ -195,7 +194,7 @@ export class InsightsCollector {
     const startedMs = Date.now();
     const sweepBudget = createInsightsSweepBudget(this.sweepBudgetLimits);
     try {
-      const { truncated } = await this.#sweepAssets(sweepBudget);
+      const { truncated, metadataOmissions } = await this.#sweepAssets(sweepBudget);
       this.#checkCancelled();
       const people = await this.#collectPeople(sweepBudget);
       this.#checkCancelled();
@@ -208,7 +207,7 @@ export class InsightsCollector {
       const favoritesTag = await this.#refreshFavoritesTag();
       this.#checkCancelled();
       this.#requireSweepDiskHeadroom(sweepBudget);
-      const snapshot = this.#publish({ startedMs, truncated, people, tags, favoritesTag });
+      const snapshot = this.#publish({ startedMs, truncated, metadataOmissions, people, tags, favoritesTag });
       if (await this.#labelHomeArea(snapshot)) {
         // Best-effort decoration of the generation just published — a crash
         // between commit and here leaves a complete snapshot, just unlabeled.
@@ -264,6 +263,7 @@ export class InsightsCollector {
     let page = 1;
     let swept = 0;
     let truncated = false;
+    const metadataOmissions = { total: 0, fields: {} };
     const budget = createTraversalBudget({
       label: 'Immich asset sweep',
       maxPages: this.config.maxSweepPages,
@@ -297,10 +297,16 @@ export class InsightsCollector {
       // therefore cannot leave a partial page, and the outer run catch drops
       // every earlier staging page while preserving the live generation.
       const rows = items.map((asset) => mapAsset(asset, { budget: sweepBudget }));
+      for (const row of rows) {
+        for (const field of row.omittedMetadataFields) {
+          metadataOmissions.total += 1;
+          metadataOmissions.fields[field] = (metadataOmissions.fields[field] ?? 0) + 1;
+        }
+      }
       this.#requireSweepDiskHeadroom(sweepBudget);
       this.repo.insertAssets(rows, { staging: true });
       swept += items.length;
-      this.#setPhase('assets', { assetsSwept: swept });
+      this.#setPhase('assets', { assetsSwept: swept, metadataOmissions: metadataOmissions.total });
       const nextPage = response?.assets?.nextPage;
       page = parseProgressingPage(nextPage, page, { label: 'Immich asset sweep' });
       if (items.length === 0) {
@@ -310,7 +316,13 @@ export class InsightsCollector {
     this.log(
       `insights sweep cached ${swept} assets${truncated ? ` (TRUNCATED at ${this.config.maxSweepPages} pages — raise INSIGHTS_MAX_SWEEP_PAGES to cover the whole library)` : ''}`,
     );
-    return { swept, truncated };
+    if (metadataOmissions.total > 0) {
+      const fields = Object.entries(metadataOmissions.fields)
+        .map(([field, count]) => `${field}: ${count}`)
+        .join(', ');
+      this.log(`insights sweep omitted ${metadataOmissions.total} invalid metadata values (${fields})`);
+    }
+    return { swept, truncated, metadataOmissions };
   }
 
   // Names come from /people (a handful of paged calls); the counts come from
@@ -493,7 +505,7 @@ export class InsightsCollector {
   // and everything #computeSnapshot aggregates — see the new generation:
   // one process, one connection, so this connection reads its own
   // uncommitted writes. Rollback on any failure leaves generation N live.
-  #publish({ startedMs, truncated, people, tags, favoritesTag }) {
+  #publish({ startedMs, truncated, metadataOmissions, people, tags, favoritesTag }) {
     return this.repo.transaction(() => {
       this.repo.commitSweepStaging();
       this.repo.replacePeople(people.counted);
@@ -504,13 +516,13 @@ export class InsightsCollector {
       if (favoritesTag) {
         this.repo.setMeta('favoritesTag', favoritesTag);
       }
-      const snapshot = this.#computeSnapshot(Date.now() - startedMs, truncated);
+      const snapshot = this.#computeSnapshot(Date.now() - startedMs, truncated, metadataOmissions);
       this.repo.setMeta('snapshot', snapshot);
       return snapshot;
     });
   }
 
-  #computeSnapshot(sweepDurationMs, sweepTruncated = false) {
+  #computeSnapshot(sweepDurationMs, sweepTruncated = false, metadataOmissions = { total: 0, fields: {} }) {
     const totals = this.repo.sweepTotals();
     const peopleTotals = this.repo.getMeta('peopleTotals') ?? { named: 0, total: 0 };
     const enrichedTotal = this.enrichRepo ? this.enrichRepo.libraryStats().enrichedTotal : null;
@@ -527,6 +539,7 @@ export class InsightsCollector {
       // True when the page cap ended the sweep early: the numbers below
       // describe a bounded slice of the library, not all of it.
       sweepTruncated,
+      metadataOmissions,
       totals: {
         ...totals,
         peopleNamed: peopleTotals.named,
@@ -784,11 +797,6 @@ export function mapAsset(asset, { budget = null } = {}) {
   if (!exif || typeof exif !== 'object' || Array.isArray(exif)) {
     throw new UpstreamPaginationError(`Immich asset ${id} returned invalid EXIF metadata.`);
   }
-  const exifMeasure = measureJsonMetadata(exif, `EXIF metadata on asset ${id}`, {
-    maxItems: MAX_INSIGHTS_METADATA_ITEMS_PER_ASSET,
-    maxBytes: MAX_INSIGHTS_DECODED_BYTES_PER_ASSET,
-    itemLimitLabel: 'metadata-item',
-  });
   const rawPeople = asset.people ?? [];
   if (!Array.isArray(rawPeople)) {
     throw new UpstreamPaginationError(`Immich asset ${id} returned invalid people metadata.`);
@@ -799,8 +807,8 @@ export function mapAsset(asset, { budget = null } = {}) {
     );
   }
 
-  let decodedBytes = utf8Bytes(id) + exifMeasure.bytes;
-  let nestedItems = exifMeasure.items;
+  let decodedBytes = utf8Bytes(id);
+  let nestedItems = 0;
 
   const type = boundedMetadataString(asset.type ?? 'IMAGE', `type on asset ${id}`, { required: true });
   const rawTakenAt = exif.dateTimeOriginal ?? asset.localDateTime ?? asset.fileCreatedAt ?? null;
@@ -823,10 +831,47 @@ export function mapAsset(asset, { budget = null } = {}) {
   const make = boundedMetadataString(exif.make, `camera make on asset ${id}`);
   const model = boundedMetadataString(exif.model, `camera model on asset ${id}`);
   const lens = boundedMetadataString(exif.lensModel, `camera lens on asset ${id}`);
-  // Charge the original bounded timestamp even when it normalizes to null so
-  // invalid strings cannot evade the decoded-byte sweep budget.
-  for (const value of [type, boundedTakenAt, city, state, country, make, model, lens]) {
-    if (value !== null) decodedBytes += utf8Bytes(value);
+  const omittedMetadataFields = [];
+  const fileSize = boundedMetadataNumber(exif.fileSizeInByte, `file size on asset ${id}`, {
+    field: 'fileSizeInByte',
+    min: 0,
+    onOmitted: (field) => omittedMetadataFields.push(field),
+  });
+  let lat = boundedMetadataNumber(exif.latitude, `latitude on asset ${id}`, {
+    field: 'latitude',
+    min: -90,
+    max: 90,
+    onOmitted: (field) => omittedMetadataFields.push(field),
+  });
+  let lon = boundedMetadataNumber(exif.longitude, `longitude on asset ${id}`, {
+    field: 'longitude',
+    min: -180,
+    max: 180,
+    onOmitted: (field) => omittedMetadataFields.push(field),
+  });
+
+  decodedBytes += utf8Bytes(type);
+  // Only the fixed EXIF projection Insights stores or expands is admitted to
+  // the per-asset and aggregate sweep budgets. Immich can legitimately carry
+  // large descriptions, profile metadata, and future fields that Insights
+  // never reads; measuring those values made an unused field able to abort the
+  // entire staged sweep. The field name is charged as well as the bounded
+  // value so retained metadata remains fully accounted for.
+  for (const [field, value] of [
+    ['dateTimeOriginal', boundedTakenAt],
+    ['city', city],
+    ['state', state],
+    ['country', country],
+    ['make', make],
+    ['model', model],
+    ['lensModel', lens],
+    ['fileSizeInByte', fileSize],
+    ['latitude', lat],
+    ['longitude', lon],
+  ]) {
+    if (value === null) continue;
+    nestedItems += 1;
+    decodedBytes += utf8Bytes(field) + utf8Bytes(String(value));
   }
   const personIds = [];
   const seenPeople = new Set();
@@ -868,13 +913,11 @@ export function mapAsset(asset, { budget = null } = {}) {
 
   const year = takenAt ? Number(takenAt.slice(0, 4)) : null;
   const day = takenAt ? takenAt.slice(0, 10) : null;
-  // Number(null) is 0, and cameras without a GPS fix also write 0,0 — either
-  // way (0,0) is "no location", not a photo in the Gulf of Guinea.
-  let lat = exif.latitude === null || exif.latitude === undefined ? NaN : Number(exif.latitude);
-  let lon = exif.longitude === null || exif.longitude === undefined ? NaN : Number(exif.longitude);
+  // Cameras without a GPS fix can write 0,0. That pair means "no location",
+  // not a photo in the Gulf of Guinea.
   if (lat === 0 && lon === 0) {
-    lat = NaN;
-    lon = NaN;
+    lat = null;
+    lon = null;
   }
   return {
     id,
@@ -890,10 +933,11 @@ export function mapAsset(asset, { budget = null } = {}) {
     lens,
     isFavorite: Boolean(asset.isFavorite),
     isArchived: Boolean(asset.isArchived),
-    fileSize: Number.isFinite(Number(exif.fileSizeInByte)) ? Number(exif.fileSizeInByte) : null,
-    lat: Number.isFinite(lat) ? lat : null,
-    lon: Number.isFinite(lon) ? lon : null,
+    fileSize,
+    lat,
+    lon,
     personIds,
+    omittedMetadataFields,
   };
 }
 
@@ -929,6 +973,30 @@ function boundedMetadataString(value, label, { required = false, trim = false } 
     throw new UpstreamPaginationError(`Immich returned an oversized or empty ${label}.`);
   }
   return text;
+}
+
+function boundedMetadataNumber(value, label, {
+  field,
+  min = -Infinity,
+  max = Infinity,
+  onOmitted = () => {},
+} = {}) {
+  if (value === null || value === undefined) return null;
+  if (!['string', 'number'].includes(typeof value)) {
+    onOmitted(field);
+    return null;
+  }
+  // Oversized retained input is still a resource-limit violation. Ordinary
+  // malformed or out-of-range numeric metadata is instead omitted: Immich has
+  // historically emitted values Number() could not use, and one such field
+  // must not discard the entire staged library sweep.
+  const text = boundedMetadataString(value, label, { trim: true });
+  const number = Number(text);
+  if (text === '' || !Number.isFinite(number) || number < min || number > max) {
+    onOmitted(field);
+    return null;
+  }
+  return number;
 }
 
 function boundedMetadataBytes(value, label) {

--- a/test/browser/smoke.test.mjs
+++ b/test/browser/smoke.test.mjs
@@ -43,7 +43,7 @@ const INSIGHTS_CONFIG = {
   favoritesTagValue: '',
 };
 
-function makeAsset(id, city, country, takenAt) {
+function makeAsset(id, city, country, takenAt, exifOverrides = {}) {
   return {
     id,
     type: 'IMAGE',
@@ -59,6 +59,7 @@ function makeAsset(id, city, country, takenAt) {
       model: 'iPhone 12',
       lensModel: 'wide',
       fileSizeInByte: 1000,
+      ...exifOverrides,
     },
   };
 }
@@ -110,7 +111,7 @@ const FILLER_PLACES = [
 ];
 
 const LIBRARY_ASSETS = [
-  makeAsset('vienna-1', 'Vienna', 'Austria', '2019-05-02T10:00:00.000Z'),
+  makeAsset('vienna-1', 'Vienna', 'Austria', '2019-05-02T10:00:00.000Z', { fileSizeInByte: 'unknown' }),
   ...FILLER_PLACES.flatMap(([city, country], index) => [
     makeAsset(`${city.toLowerCase()}-1`, city, country, `202${index % 5}-03-0${(index % 8) + 1}T10:00:00.000Z`),
     makeAsset(`${city.toLowerCase()}-2`, city, country, `202${index % 5}-06-0${(index % 8) + 1}T10:00:00.000Z`),
@@ -515,6 +516,10 @@ test('admin UI smoke: gate, Insights lens, Curate, Smart Albums', { timeout: 120
       'document.getElementById("lensBtn") && !document.querySelector(".gate-backdrop")',
       { label: 'insights page ready' },
     );
+    assert.equal(
+      await page.evaluate('document.getElementById("metadataOmissionBanner")?.textContent'),
+      'Insights left 1 invalid metadata value blank while scanning (file size: 1). All photos were still counted.',
+    );
 
     await page.evaluate('document.getElementById("lensBtn").click()');
     await page.waitFor(
@@ -540,6 +545,70 @@ test('admin UI smoke: gate, Insights lens, Curate, Smart Albums', { timeout: 120
       '[...document.querySelectorAll("#lensResults button")].some((b) => b.textContent.includes("Austria"))',
       { label: 'Austria appears in lens results' },
     );
+  });
+
+  await t.test('Insights keeps a first-poll refresh failure visible', async () => {
+    await page.navigate(`${server.base}/insights.html`);
+    await page.waitFor(
+      'document.getElementById("refreshBtn") && !document.querySelector(".gate-backdrop")',
+      { label: 'insights refresh controls ready' },
+    );
+
+    const result = await page.evaluate(`(async () => {
+      const realFetch = window.fetch;
+      const terminal = {
+        running: false,
+        phase: 'error',
+        error: 'Immich returned an oversized city on asset test-asset.',
+        progress: { assetsSwept: 0 },
+      };
+      window.fetch = (input, init) => {
+        const url = new URL(typeof input === 'string' ? input : input.url, location.href);
+        if (url.pathname === '/api/insights/refresh') {
+          return Promise.resolve(new Response(JSON.stringify({ running: true, phase: 'assets' }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }));
+        }
+        if (url.pathname === '/api/insights/status') {
+          return Promise.resolve(new Response(JSON.stringify(terminal), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }));
+        }
+        if (url.pathname === '/api/insights') {
+          return Promise.resolve(new Response(JSON.stringify({
+            snapshot: null,
+            status: terminal,
+            immichUrl: null,
+            favoritesTag: null,
+            locationGroups: [],
+          }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }));
+        }
+        return realFetch(input, init);
+      };
+      await refresh();
+      const error = document.getElementById('refreshError');
+      const observed = {
+        hidden: error.hidden,
+        text: error.textContent,
+        refreshDisabled: document.getElementById('refreshBtn').disabled,
+        polling: state.polling !== null,
+      };
+      window.fetch = realFetch;
+      await load();
+      return observed;
+    })()`);
+
+    assert.deepEqual(result, {
+      hidden: false,
+      text: 'Refresh failed: Immich returned an oversized city on asset test-asset.',
+      refreshDisabled: false,
+      polling: false,
+    });
   });
 
   await t.test('Insights month drill scopes People/Places; a failed month never wears another scope\'s data', async () => {

--- a/test/insights.test.mjs
+++ b/test/insights.test.mjs
@@ -11,7 +11,6 @@ import {
   MAX_INSIGHTS_DECODED_BYTES_PER_ASSET,
   MAX_INSIGHTS_IDENTIFIER_LENGTH,
   MAX_INSIGHTS_METADATA_FIELD_BYTES,
-  MAX_INSIGHTS_METADATA_ITEMS_PER_ASSET,
   MAX_INSIGHTS_NESTED_ITEMS_PER_ASSET,
   MAX_INSIGHTS_PEOPLE_PER_ASSET,
   MIN_INSIGHTS_SWEEP_FREE_BYTES,
@@ -366,19 +365,59 @@ test('asset metadata and relationships enforce exact per-asset boundaries before
     new RegExp(`${MAX_INSIGHTS_NESTED_ITEMS_PER_ASSET}-nested-item limit`),
   );
   assert.throws(
-    () => mapAsset(makeAsset('too-many-metadata', {
-      exifInfo: Object.fromEntries(
-        Array.from({ length: MAX_INSIGHTS_METADATA_ITEMS_PER_ASSET + 1 }, (_, index) => [`field${index}`, index]),
-      ),
+    () => mapAsset(makeAsset('decoded-person-row', {
+      people: [{
+        id: 'p1',
+        ...Object.fromEntries(
+          Array.from({ length: 33 }, (_, index) => [`field${index}`, 'x'.repeat(MAX_INSIGHTS_METADATA_FIELD_BYTES)]),
+        ),
+      }],
     })),
-    /128-metadata-item limit/,
+    new RegExp(`${MAX_INSIGHTS_DECODED_BYTES_PER_ASSET}-decoded-byte limit`),
+  );
+  const unusedExif = Object.fromEntries(
+    Array.from({ length: 256 }, (_, index) => [`unusedField${index}`, 'x'.repeat(8192)]),
+  );
+  const cleanBudget = createInsightsSweepBudget();
+  const unusedBudget = createInsightsSweepBudget();
+  mapAsset(makeAsset('same-size-id', { exifInfo: {} }), { budget: cleanBudget });
+  const ignored = mapAsset(makeAsset('same-size-id', {
+    exifInfo: {
+      ...unusedExif,
+      description: 'x'.repeat(MAX_INSIGHTS_METADATA_FIELD_BYTES + 1),
+      profileDescription: 'y'.repeat(MAX_INSIGHTS_METADATA_FIELD_BYTES + 1),
+    },
+  }), { budget: unusedBudget });
+  assert.equal(ignored.city, 'San Francisco');
+  assert.deepEqual(
+    unusedBudget.status(),
+    cleanBudget.status(),
+    'unused EXIF fields do not consume the retained-data sweep budget',
   );
 
   const exactUtf8 = '🙂'.repeat(MAX_INSIGHTS_METADATA_FIELD_BYTES / 4);
   assert.equal(mapAsset(makeAsset('utf8-exact', { exifInfo: { city: exactUtf8 } })).city, exactUtf8);
   assert.throws(
     () => mapAsset(makeAsset('utf8-over', { exifInfo: { city: `${exactUtf8}🙂` } })),
-    /oversized EXIF metadata/,
+    /oversized or empty city/,
+  );
+  assert.throws(
+    () => mapAsset(makeAsset('malformed-city', { exifInfo: { city: { nested: true } } })),
+    /invalid city on asset malformed-city/,
+  );
+  const malformedNumbers = mapAsset(makeAsset('malformed-numbers', {
+    exifInfo: {
+      latitude: 'north',
+      longitude: 181,
+      fileSizeInByte: 'unknown',
+    },
+  }));
+  assert.equal(malformedNumbers.lat, null);
+  assert.equal(malformedNumbers.lon, null);
+  assert.equal(malformedNumbers.fileSize, null);
+  assert.deepEqual(
+    malformedNumbers.omittedMetadataFields,
+    ['fileSizeInByte', 'latitude', 'longitude'],
   );
 
   for (const asset of [
@@ -390,17 +429,76 @@ test('asset metadata and relationships enforce exact per-asset boundaries before
     assert.throws(() => mapAsset(asset), /invalid .* identifier/);
   }
 
-  const metadataFieldsToExceedAssetBytes = Math.floor(
-    MAX_INSIGHTS_DECODED_BYTES_PER_ASSET / MAX_INSIGHTS_METADATA_FIELD_BYTES,
-  ) + 1;
-  const manyFields = Object.fromEntries(Array.from({ length: metadataFieldsToExceedAssetBytes }, (_, index) => [
-    `field${index}`,
-    'x'.repeat(MAX_INSIGHTS_METADATA_FIELD_BYTES),
-  ]));
-  assert.throws(
-    () => mapAsset({ id: 'asset-bytes', type: 'IMAGE', exifInfo: manyFields }),
-    new RegExp(`${MAX_INSIGHTS_DECODED_BYTES_PER_ASSET}-decoded-byte limit`),
-  );
+});
+
+test('collector publishes assets with oversized unused EXIF fields', async () => {
+  await withRepoAsync(async (repo) => {
+    const asset = makeAsset('long-unused-exif', {
+      exifInfo: {
+        description: 'x'.repeat(MAX_INSIGHTS_METADATA_FIELD_BYTES * 4),
+        profileDescription: 'y'.repeat(MAX_INSIGHTS_METADATA_FIELD_BYTES * 4),
+      },
+    });
+    const collector = new InsightsCollector({ repo, immich: new FakeImmich([asset], []), config: CONFIG });
+    collector.start();
+    await waitForIdle(collector);
+
+    assert.equal(collector.status().phase, 'done');
+    assert.equal(repo.sweepTotals().assetsSwept, 1);
+    assert.deepEqual(collector.snapshot().metadataOmissions, { total: 0, fields: {} });
+  });
+});
+
+test('collector omits malformed numeric EXIF, counts it, and still publishes every asset', async () => {
+  await withRepoAsync(async (repo) => {
+    const assets = [
+      makeAsset('invalid-numbers', {
+        exifInfo: { latitude: 'north', longitude: 181, fileSizeInByte: 'unknown' },
+      }),
+      makeAsset('valid-neighbor'),
+    ];
+    const messages = [];
+    const collector = new InsightsCollector({
+      repo,
+      immich: new FakeImmich(assets, []),
+      config: CONFIG,
+      log: (message) => messages.push(message),
+    });
+    collector.start();
+    await waitForIdle(collector);
+
+    assert.equal(collector.status().phase, 'done');
+    assert.equal(collector.status().progress.metadataOmissions, 3);
+    assert.equal(repo.sweepTotals().assetsSwept, 2);
+    assert.deepEqual(collector.snapshot().metadataOmissions, {
+      total: 3,
+      fields: { fileSizeInByte: 1, latitude: 1, longitude: 1 },
+    });
+    assert.ok(messages.some((message) => /omitted 3 invalid metadata values/.test(message)));
+  });
+});
+
+test('collector names malformed used EXIF fields and removes staging without replacing a snapshot', async () => {
+  await withRepoAsync(async (repo) => {
+    const seed = new InsightsCollector({ repo, immich: new FakeImmich([makeAsset('old')], []), config: CONFIG });
+    seed.start();
+    await waitForIdle(seed);
+    const baseline = repo.getMeta('snapshot');
+
+    const malformed = makeAsset('bad-city', {
+      exifInfo: { city: 'x'.repeat(MAX_INSIGHTS_METADATA_FIELD_BYTES + 1) },
+    });
+    const collector = new InsightsCollector({ repo, immich: new FakeImmich([malformed], []), config: CONFIG });
+    collector.start();
+    await waitForIdle(collector);
+
+    assert.equal(collector.status().phase, 'error');
+    assert.match(collector.status().error, /oversized or empty city on asset bad-city/);
+    assert.deepEqual(repo.getMeta('snapshot'), baseline);
+    assert.equal(repo.sweepTotals().assetsSwept, 1);
+    const staging = repo.db.prepare("SELECT COUNT(*) AS n FROM sqlite_master WHERE name LIKE '%_staging'").get().n;
+    assert.equal(staging, 0);
+  });
 });
 
 test('aggregate Insights sweep budgets reject before the failing page write and clean staging', async () => {


### PR DESCRIPTION
## Outcome

Insights no longer rejects an otherwise valid Immich asset because an EXIF field that Pictaria never stores is large. Malformed numeric EXIF is left blank, counted, and surfaced without losing the photo or aborting the sweep. Refresh failures also stay visible when a run finishes before the browser observes its running state.

## Changes

- Project Immich EXIF to the fixed Insights fields before applying per-asset and aggregate budgets.
- Keep strict size, type, people, response, pagination, aggregate, generated-row, and disk-headroom checks on data Insights actually retains or expands.
- Omit malformed or out-of-range numeric metadata, count fixed field names only, and show a durable sanitized notice in Insights.
- Name malformed retained string fields in sanitized diagnostics; do not log their values.
- Preserve the last published snapshot and clear staging after a retained-field failure.
- Add a persistent refresh-error notice and remove the first-poll race without producing repeated toasts.
- Document the correction under Unreleased.

## Validation

- node --test test/insights.test.mjs — 44 passed
- node --test test/browser/smoke.test.mjs — 20 passed
- npm test — passed
- npm run check:publication
- git diff --check

## Risk and rollback

The projection deliberately ignores only EXIF fields Insights does not consume. Malformed numeric values are bounded omissions and cannot grow memory with arbitrary field names or values. Retained strings and expanded relationships remain fail-visible and bounded. Rolling back this commit restores the prior full-EXIF admission behavior; no schema or persisted-state migration is involved.

## Remaining work

After merge, reply on GitHub issue #3 and ask the reporter to verify the fix against the asset that currently blocks their sweep.

## Authorship

Implemented and tested by Codex. No independent agent review has yet been performed.

Related to PIC-313
