### PR TITLE
PIC-314: Handle LM Studio schema output in reasoning_content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to Pictaria Server are documented here. This project follows
   left blank, counted, and reported without dropping the asset or the sweep.
   Refresh failures remain visible even when a run ends before the first status
   poll observes it.
+- LM Studio Enrich and Curate requests accept validated schema JSON when a
+  thinking-capable model returns it in `reasoning_content` with empty ordinary
+  content. Voice and other prose never expose that reasoning channel.
 
 ## 1.0.0 - 2026-08-28
 

--- a/docs/ENRICH.md
+++ b/docs/ENRICH.md
@@ -46,6 +46,12 @@ dropping tags under rapid mutation).
 | `cloud_ollama` | Cloud | API key + model under Settings → AI Providers |
 | `venice` | Cloud | API key + a vision-capable model under Settings → AI Providers (no default) |
 
+Thinking-capable LM Studio models can place a strict-schema Enrich or Curate
+answer in their `reasoning_content` response field while leaving ordinary
+`content` empty. Pictaria accepts and validates that channel only for requests
+whose entire output is constrained to the Pictaria JSON schema. Voice and other
+prose requests always ignore reasoning content.
+
 Connections and model identifiers live under **Settings → AI Providers**.
 Choose the active provider on the **Enrich** page: it is used for every new
 run and remembered across page visits and server restarts. `DEFAULT_PROVIDER`

--- a/src/enrich/providers.mjs
+++ b/src/enrich/providers.mjs
@@ -217,11 +217,22 @@ export class LmStudioProvider {
     }
     const headers = this.apiKey ? { Authorization: `Bearer ${this.apiKey}` } : {};
     const rawOutput = await postJson(this, appendHttpUrlPath(this.baseUrl, '/chat/completions'), body, headers);
-    const outputText = extractChoiceMessageContent(rawOutput);
+    const outputText = extractSchemaConstrainedChoiceContent(rawOutput);
     if (!outputText) {
       throw new Error('LM Studio response did not include message content');
     }
-    return { rawOutput, normalizedOutput: parseJsonContent(outputText) };
+    try {
+      return { rawOutput, normalizedOutput: parseJsonContent(outputText) };
+    } catch (error) {
+      // The fallback channel can contain private chain-of-thought rather than
+      // the requested schema JSON. JSON.parse errors quote the rejected input,
+      // so replace them with a fixed diagnostic when that channel was used.
+      const ordinaryContent = extractChoiceMessageContent(rawOutput);
+      if (!(typeof ordinaryContent === 'string' && ordinaryContent.trim())) {
+        throw new Error('LM Studio returned schema output that was not valid JSON');
+      }
+      throw error;
+    }
   }
 
   async generateProse({ systemPrompt, userPrompt, images = [], maxOutputTokens }) {
@@ -822,6 +833,23 @@ export function extractOpenAiProseText(response) {
 export function extractChoiceMessageContent(response) {
   const message = response?.choices?.[0]?.message;
   return typeof message?.content === 'string' ? message.content : null;
+}
+
+export function extractSchemaConstrainedChoiceContent(response) {
+  const content = extractChoiceMessageContent(response);
+  if (typeof content === 'string' && content.trim()) {
+    return content;
+  }
+  // Some thinking-capable models in LM Studio route the entire
+  // grammar-constrained JSON answer into reasoning_content while leaving
+  // content empty. This extractor is used only for strict-schema requests;
+  // prose continues to read content alone so genuine reasoning is never
+  // displayed or spoken.
+  const reasoningContent = response?.choices?.[0]?.message?.reasoning_content;
+  if (typeof reasoningContent === 'string' && reasoningContent.trim()) {
+    return reasoningContent;
+  }
+  return content;
 }
 
 export function extractOllamaMessageContent(response) {

--- a/test/enrich/providers.test.mjs
+++ b/test/enrich/providers.test.mjs
@@ -13,6 +13,7 @@ import {
   createProvider,
   extractChoiceMessageContent,
   extractOpenAiOutputText,
+  extractSchemaConstrainedChoiceContent,
   lmStudioSupportedImage,
 } from '../../src/enrich/providers.mjs';
 
@@ -47,6 +48,21 @@ test('choice message extraction reads openai-compatible responses', () => {
   assert.equal(extractChoiceMessageContent({ choices: [] }), null);
 });
 
+test('schema-constrained choice extraction uses reasoning_content only when content is empty', () => {
+  assert.equal(
+    extractSchemaConstrainedChoiceContent({
+      choices: [{ message: { content: '{"caption":"Content"}', reasoning_content: '{"caption":"Reasoning"}' } }],
+    }),
+    '{"caption":"Content"}',
+  );
+  assert.equal(
+    extractSchemaConstrainedChoiceContent({
+      choices: [{ message: { content: '  ', reasoning_content: '{"caption":"Reasoning"}' } }],
+    }),
+    '{"caption":"Reasoning"}',
+  );
+});
+
 test('openai output text extraction supports output_text and output list fallback', () => {
   assert.equal(extractOpenAiOutputText({ output_text: '{"a":1}' }), '{"a":1}');
   assert.equal(
@@ -69,7 +85,12 @@ test('lm studio posts an openai-compatible vision schema request', async () => {
     apiKey: '',
     maxTokens: 1234,
     temperature: 0.2,
-    fetchImpl: fakeFetch({ choices: [{ message: { content: '{"caption": "Lake"}' } }] }, { capture }),
+    fetchImpl: fakeFetch({
+      choices: [{ message: {
+        content: '{"caption": "Lake"}',
+        reasoning_content: '{"caption": "Wrong channel"}',
+      } }],
+    }, { capture }),
   });
 
   const result = await provider.analyzeImage(image, prompts);
@@ -86,6 +107,60 @@ test('lm studio posts an openai-compatible vision schema request', async () => {
   assert.ok(imagePart.image_url.url.startsWith('data:image/jpeg;base64,'));
   assert.equal(capture.options.headers.Authorization, undefined);
   assert.equal(capture.options.redirect, 'error');
+});
+
+test('lm studio reads strict-schema JSON from reasoning_content when content is empty', async () => {
+  const provider = new LmStudioProvider({
+    modelName: 'qwen3.5-4b-mlx',
+    fetchImpl: fakeFetch({
+      choices: [{
+        message: { content: '', reasoning_content: '{"caption": "Lake"}' },
+        finish_reason: 'stop',
+      }],
+    }),
+  });
+
+  const result = await provider.analyzeImage(image, prompts);
+
+  assert.deepEqual(result.normalizedOutput, { caption: 'Lake' });
+});
+
+test('lm studio rejects malformed schema output from reasoning_content', async () => {
+  const provider = new LmStudioProvider({
+    modelName: 'qwen3.5-4b-mlx',
+    fetchImpl: fakeFetch({
+      choices: [{
+        message: { content: '', reasoning_content: 'I think the answer is not JSON' },
+        finish_reason: 'stop',
+      }],
+    }),
+  });
+
+  await assert.rejects(
+    () => provider.analyzeImage(image, prompts),
+    (error) => {
+      assert.equal(error.message, 'LM Studio returned schema output that was not valid JSON');
+      assert.doesNotMatch(error.message, /I think/i);
+      return true;
+    },
+  );
+});
+
+test('lm studio prose never returns reasoning_content', async () => {
+  const provider = new LmStudioProvider({
+    modelName: 'qwen3.5-4b-mlx',
+    fetchImpl: fakeFetch({
+      choices: [{ message: { content: '', reasoning_content: 'private model reasoning' } }],
+    }),
+  });
+
+  const result = await provider.generateProse({
+    systemPrompt: 'system',
+    userPrompt: 'user',
+    maxOutputTokens: 100,
+  });
+
+  assert.equal(result.text, '');
 });
 
 test('lm studio keeps non-webp image payloads', () => {


### PR DESCRIPTION
## Outcome

LM Studio enrichment no longer discards valid strict-schema JSON when a thinking-capable model places the answer in message.reasoning_content and leaves message.content empty.

## Changes

- Add a schema-only choice extractor that prefers non-empty ordinary content and falls back to non-empty reasoning_content.
- Use the fallback only for LM Studio Enrich/Curate schema requests.
- Leave LM Studio Voice and all other prose paths content-only so model reasoning is never displayed or spoken.
- Continue parsing valid fallback output as JSON and passing it through the existing full enrichment-output validation pipeline.
- Replace malformed fallback parser errors with a fixed, content-free diagnostic so they cannot expose fragments of model reasoning.
- Document the compatibility behavior and add an Unreleased changelog entry.
- Cover content precedence, the reported empty-content response shape, malformed fallback JSON sanitization, and the prose boundary.

## Validation

- node --test test/enrich/providers.test.mjs test/voice/prose.test.mjs — passed
- npm test — passed
- npm run check:publication
- git diff --check

## Risk and rollback

The fallback is not shared with OpenRouter, Venice, or any prose path. It activates only when LM Studio ordinary content is empty during a strict-schema request. Valid JSON still receives full validation, while malformed fallback output fails with a fixed message. Reverting this commit restores the previous content-only behavior; there is no schema or persisted-state migration.

## Remaining work

After merge, ask the GitHub issue #5 reporter to verify the fix with the same Qwen and LM Studio setup.

## Authorship

Implemented and tested by Codex. No independent agent review has yet been performed.

Related to PIC-314
