### PR TITLE
PIC-310: Keep Insights usable for crowd photos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to Pictaria Server are documented here. This project follows
 
 ### Fixed
 
+- Insights keeps legitimate crowd photos in the library sweep when Immich
+  reports more than 100 people. People relationships remain capped and excess
+  entries are counted and surfaced instead of aborting the complete snapshot.
 - Insights ignores oversized Immich EXIF fields it does not store, while
   retaining strict bounds for metadata it uses. Malformed numeric metadata is
   left blank, counted, and reported without dropping the asset or the sweep.

--- a/docs/INSIGHTS.md
+++ b/docs/INSIGHTS.md
@@ -33,18 +33,22 @@ limit; people collection stops at 100 pages, 50,000 entries, or 60 seconds;
 and slice resolution stops at 1,000 upstream calls, 250,000 scanned entries,
 or two minutes. Invalid, repeated, and non-progressing Immich page metadata
 fails the operation without publishing a partial Insights generation.
-The asset sweep additionally accepts at most 100 face relationships and 128
-EXIF fields per asset, 4 KiB per metadata field, 4,096 nested metadata items,
-and 128 KiB of decoded metadata per asset. The same structural and byte limits
-bound each people-directory record. That envelope leaves margin above the full
-`PersonWithFaces` records returned by supported Immich versions. Asset and
-person identifiers are restricted to 128 safe opaque characters. One
+The asset sweep retains at most 100 unique people relationships per photo,
+along with its fixed EXIF projection, 4 KiB per retained metadata field, 4,096
+nested metadata items, and 128 KiB of decoded metadata per asset. A crowd photo
+with more than 100 relationships remains in every ordinary photo, date, place,
+camera, and storage statistic; Insights keeps the first 100 relationships and
+shows a persistent notice that people and pair statistics were truncated for
+that photo. Only the bounded person ID Pictaria stores is admitted—not names,
+face boxes, or other fields on Immich's `PersonWithFaces` relationship object.
+The same structural and byte limits still bound each people-directory record.
+Asset and person identifiers are restricted to 128 safe opaque characters. One
 refresh may admit at most 20 million nested items, 512 MiB of decoded metadata,
 and 5 million generated asset/relationship/people rows. Complete people
-relationship and directory records count before filtering or deduplication,
-including hidden and unnamed entries. Every page is fully admitted before its
-first staging write; a limit failure drops staging and keeps the previous
-snapshot intact.
+retained relationship and complete directory records count toward those
+budgets, including hidden and unnamed entries. Every page is fully admitted
+before its first staging write; a limit failure drops staging and keeps the
+previous snapshot intact.
 
 Insights also reserves filesystem headroom for the overlap between the live
 generation, staging tables, the indexed publish copy, and SQLite's WAL. A
@@ -106,6 +110,9 @@ camera slices.
 ```json
 {
   "generatedAt": "…",
+  "peopleTruncation": {
+    "assets": 0, "relationshipsOmitted": 0, "perAssetLimit": 100
+  },
   "totals": { "photos": 0, "videos": 0, "favorites": 0, "storageBytes": 0,
               "firstTakenAt": "…", "lastTakenAt": "…",
               "peopleNamed": 0, "peopleTotal": 0 },

--- a/public/insights.js
+++ b/public/insights.js
@@ -2585,12 +2585,42 @@ function renderMetadataOmissionBanner(snapshot) {
     + `${detail ? ` (${detail})` : ''}. All photos were still counted.`;
 }
 
+function renderPeopleTruncationBanner(snapshot) {
+  let banner = el('peopleTruncationBanner');
+  const truncation = snapshot.peopleTruncation;
+  const assets = Number(truncation?.assets ?? 0);
+  const omitted = Number(truncation?.relationshipsOmitted ?? 0);
+  const limit = Number(truncation?.perAssetLimit ?? 0);
+  if (
+    !Number.isSafeInteger(assets) || assets < 1
+    || !Number.isSafeInteger(omitted) || omitted < 1
+    || !Number.isSafeInteger(limit) || limit < 1
+  ) {
+    if (banner) banner.hidden = true;
+    return;
+  }
+  if (!banner) {
+    banner = document.createElement('div');
+    banner.id = 'peopleTruncationBanner';
+    banner.className = 'p-panel';
+    banner.setAttribute('role', 'status');
+    banner.style.cssText = 'padding: 10px 16px; margin-bottom: 14px; font-size: 13px; '
+      + 'line-height: 1.5; color: var(--p-gold); border-color: #6d5410;';
+    el('content').prepend(banner);
+  }
+  banner.hidden = false;
+  banner.textContent = `Insights limited people relationships to ${fmt(limit)} on `
+    + `${fmt(assets)} ${assets === 1 ? 'photo' : 'photos'} and left ${fmt(omitted)} additional `
+    + `${omitted === 1 ? 'entry' : 'entries'} out. Every photo and all non-people statistics were still counted.`;
+}
+
 function render(snapshot) {
   state.snapshot = snapshot;
   el('content').hidden = false;
   el('empty').hidden = true;
   renderSweepBanner(snapshot);
   renderMetadataOmissionBanner(snapshot);
+  renderPeopleTruncationBanner(snapshot);
 
   const t = snapshot.totals;
   const spanYears = t.firstTakenAt && t.lastTakenAt

--- a/src/insights/collector.mjs
+++ b/src/insights/collector.mjs
@@ -194,7 +194,7 @@ export class InsightsCollector {
     const startedMs = Date.now();
     const sweepBudget = createInsightsSweepBudget(this.sweepBudgetLimits);
     try {
-      const { truncated, metadataOmissions } = await this.#sweepAssets(sweepBudget);
+      const { truncated, metadataOmissions, peopleTruncation } = await this.#sweepAssets(sweepBudget);
       this.#checkCancelled();
       const people = await this.#collectPeople(sweepBudget);
       this.#checkCancelled();
@@ -207,7 +207,15 @@ export class InsightsCollector {
       const favoritesTag = await this.#refreshFavoritesTag();
       this.#checkCancelled();
       this.#requireSweepDiskHeadroom(sweepBudget);
-      const snapshot = this.#publish({ startedMs, truncated, metadataOmissions, people, tags, favoritesTag });
+      const snapshot = this.#publish({
+        startedMs,
+        truncated,
+        metadataOmissions,
+        peopleTruncation,
+        people,
+        tags,
+        favoritesTag,
+      });
       if (await this.#labelHomeArea(snapshot)) {
         // Best-effort decoration of the generation just published — a crash
         // between commit and here leaves a complete snapshot, just unlabeled.
@@ -264,6 +272,11 @@ export class InsightsCollector {
     let swept = 0;
     let truncated = false;
     const metadataOmissions = { total: 0, fields: {} };
+    const peopleTruncation = {
+      assets: 0,
+      relationshipsOmitted: 0,
+      perAssetLimit: MAX_INSIGHTS_PEOPLE_PER_ASSET,
+    };
     const budget = createTraversalBudget({
       label: 'Immich asset sweep',
       maxPages: this.config.maxSweepPages,
@@ -302,11 +315,19 @@ export class InsightsCollector {
           metadataOmissions.total += 1;
           metadataOmissions.fields[field] = (metadataOmissions.fields[field] ?? 0) + 1;
         }
+        if (row.omittedPeopleRelationships > 0) {
+          peopleTruncation.assets += 1;
+          peopleTruncation.relationshipsOmitted += row.omittedPeopleRelationships;
+        }
       }
       this.#requireSweepDiskHeadroom(sweepBudget);
       this.repo.insertAssets(rows, { staging: true });
       swept += items.length;
-      this.#setPhase('assets', { assetsSwept: swept, metadataOmissions: metadataOmissions.total });
+      this.#setPhase('assets', {
+        assetsSwept: swept,
+        metadataOmissions: metadataOmissions.total,
+        peopleRelationshipsOmitted: peopleTruncation.relationshipsOmitted,
+      });
       const nextPage = response?.assets?.nextPage;
       page = parseProgressingPage(nextPage, page, { label: 'Immich asset sweep' });
       if (items.length === 0) {
@@ -322,7 +343,13 @@ export class InsightsCollector {
         .join(', ');
       this.log(`insights sweep omitted ${metadataOmissions.total} invalid metadata values (${fields})`);
     }
-    return { swept, truncated, metadataOmissions };
+    if (peopleTruncation.assets > 0) {
+      this.log(
+        `insights sweep limited people relationships on ${peopleTruncation.assets} asset(s); `
+        + `${peopleTruncation.relationshipsOmitted} relationship entries were omitted`,
+      );
+    }
+    return { swept, truncated, metadataOmissions, peopleTruncation };
   }
 
   // Names come from /people (a handful of paged calls); the counts come from
@@ -505,7 +532,7 @@ export class InsightsCollector {
   // and everything #computeSnapshot aggregates — see the new generation:
   // one process, one connection, so this connection reads its own
   // uncommitted writes. Rollback on any failure leaves generation N live.
-  #publish({ startedMs, truncated, metadataOmissions, people, tags, favoritesTag }) {
+  #publish({ startedMs, truncated, metadataOmissions, peopleTruncation, people, tags, favoritesTag }) {
     return this.repo.transaction(() => {
       this.repo.commitSweepStaging();
       this.repo.replacePeople(people.counted);
@@ -516,13 +543,27 @@ export class InsightsCollector {
       if (favoritesTag) {
         this.repo.setMeta('favoritesTag', favoritesTag);
       }
-      const snapshot = this.#computeSnapshot(Date.now() - startedMs, truncated, metadataOmissions);
+      const snapshot = this.#computeSnapshot(
+        Date.now() - startedMs,
+        truncated,
+        metadataOmissions,
+        peopleTruncation,
+      );
       this.repo.setMeta('snapshot', snapshot);
       return snapshot;
     });
   }
 
-  #computeSnapshot(sweepDurationMs, sweepTruncated = false, metadataOmissions = { total: 0, fields: {} }) {
+  #computeSnapshot(
+    sweepDurationMs,
+    sweepTruncated = false,
+    metadataOmissions = { total: 0, fields: {} },
+    peopleTruncation = {
+      assets: 0,
+      relationshipsOmitted: 0,
+      perAssetLimit: MAX_INSIGHTS_PEOPLE_PER_ASSET,
+    },
+  ) {
     const totals = this.repo.sweepTotals();
     const peopleTotals = this.repo.getMeta('peopleTotals') ?? { named: 0, total: 0 };
     const enrichedTotal = this.enrichRepo ? this.enrichRepo.libraryStats().enrichedTotal : null;
@@ -540,6 +581,7 @@ export class InsightsCollector {
       // describe a bounded slice of the library, not all of it.
       sweepTruncated,
       metadataOmissions,
+      peopleTruncation,
       totals: {
         ...totals,
         peopleNamed: peopleTotals.named,
@@ -801,12 +843,6 @@ export function mapAsset(asset, { budget = null } = {}) {
   if (!Array.isArray(rawPeople)) {
     throw new UpstreamPaginationError(`Immich asset ${id} returned invalid people metadata.`);
   }
-  if (rawPeople.length > MAX_INSIGHTS_PEOPLE_PER_ASSET) {
-    throw new UpstreamPaginationError(
-      `Immich asset ${id} exceeded its ${MAX_INSIGHTS_PEOPLE_PER_ASSET}-person limit.`,
-    );
-  }
-
   let decodedBytes = utf8Bytes(id);
   let nestedItems = 0;
 
@@ -875,30 +911,25 @@ export function mapAsset(asset, { budget = null } = {}) {
   }
   const personIds = [];
   const seenPeople = new Set();
-  for (const person of rawPeople) {
-    const measured = measureJsonMetadata(person, `person relationship on asset ${id}`, {
-      maxItems: MAX_INSIGHTS_NESTED_ITEMS_PER_ASSET,
-      maxBytes: MAX_INSIGHTS_DECODED_BYTES_PER_ASSET,
-    });
-    nestedItems += 1 + measured.items;
-    decodedBytes += measured.bytes;
-    if (nestedItems > MAX_INSIGHTS_NESTED_ITEMS_PER_ASSET) {
-      throw new UpstreamPaginationError(
-        `Immich asset ${id} exceeded its ${MAX_INSIGHTS_NESTED_ITEMS_PER_ASSET}-nested-item limit.`,
-      );
-    }
-    if (decodedBytes > MAX_INSIGHTS_DECODED_BYTES_PER_ASSET) {
-      throw new UpstreamPaginationError(
-        `Immich asset ${id} exceeded its ${MAX_INSIGHTS_DECODED_BYTES_PER_ASSET}-decoded-byte limit.`,
-      );
-    }
+  let omittedPeopleRelationships = 0;
+  for (let index = 0; index < rawPeople.length; index += 1) {
+    const person = rawPeople[index];
     const candidate = person?.id ?? person?.personId ?? person?.person?.id ?? null;
     if (candidate === null || candidate === undefined || candidate === '') continue;
     const personId = requireImmichId(candidate, `person relationship on asset ${id}`);
-    if (!seenPeople.has(personId)) {
-      seenPeople.add(personId);
-      personIds.push(personId);
+    if (seenPeople.has(personId)) continue;
+    if (personIds.length >= MAX_INSIGHTS_PEOPLE_PER_ASSET) {
+      // The cap bounds relationship rows and pair expansion. Stop inspecting
+      // the remainder as soon as the first additional unique relationship is
+      // found: unused PersonWithFaces fields must not consume sweep resources
+      // or turn a legitimate crowd photo into a whole-library failure.
+      omittedPeopleRelationships = rawPeople.length - index;
+      break;
     }
+    seenPeople.add(personId);
+    personIds.push(personId);
+    nestedItems += 1;
+    decodedBytes += utf8Bytes('personId') + utf8Bytes(personId);
   }
   if (decodedBytes > MAX_INSIGHTS_DECODED_BYTES_PER_ASSET) {
     throw new UpstreamPaginationError(
@@ -937,6 +968,7 @@ export function mapAsset(asset, { budget = null } = {}) {
     lat,
     lon,
     personIds,
+    omittedPeopleRelationships,
     omittedMetadataFields,
   };
 }

--- a/test/browser/smoke.test.mjs
+++ b/test/browser/smoke.test.mjs
@@ -43,7 +43,7 @@ const INSIGHTS_CONFIG = {
   favoritesTagValue: '',
 };
 
-function makeAsset(id, city, country, takenAt, exifOverrides = {}) {
+function makeAsset(id, city, country, takenAt, exifOverrides = {}, assetOverrides = {}) {
   return {
     id,
     type: 'IMAGE',
@@ -61,6 +61,7 @@ function makeAsset(id, city, country, takenAt, exifOverrides = {}) {
       fileSizeInByte: 1000,
       ...exifOverrides,
     },
+    ...assetOverrides,
   };
 }
 
@@ -111,7 +112,14 @@ const FILLER_PLACES = [
 ];
 
 const LIBRARY_ASSETS = [
-  makeAsset('vienna-1', 'Vienna', 'Austria', '2019-05-02T10:00:00.000Z', { fileSizeInByte: 'unknown' }),
+  makeAsset(
+    'vienna-1',
+    'Vienna',
+    'Austria',
+    '2019-05-02T10:00:00.000Z',
+    { fileSizeInByte: 'unknown' },
+    { people: Array.from({ length: 102 }, (_, index) => ({ id: `crowd-${index}` })) },
+  ),
   ...FILLER_PLACES.flatMap(([city, country], index) => [
     makeAsset(`${city.toLowerCase()}-1`, city, country, `202${index % 5}-03-0${(index % 8) + 1}T10:00:00.000Z`),
     makeAsset(`${city.toLowerCase()}-2`, city, country, `202${index % 5}-06-0${(index % 8) + 1}T10:00:00.000Z`),
@@ -519,6 +527,10 @@ test('admin UI smoke: gate, Insights lens, Curate, Smart Albums', { timeout: 120
     assert.equal(
       await page.evaluate('document.getElementById("metadataOmissionBanner")?.textContent'),
       'Insights left 1 invalid metadata value blank while scanning (file size: 1). All photos were still counted.',
+    );
+    assert.equal(
+      await page.evaluate('document.getElementById("peopleTruncationBanner")?.textContent'),
+      'Insights limited people relationships to 100 on 1 photo and left 2 additional entries out. Every photo and all non-people statistics were still counted.',
     );
 
     await page.evaluate('document.getElementById("lensBtn").click()');

--- a/test/insights.test.mjs
+++ b/test/insights.test.mjs
@@ -323,38 +323,52 @@ test('asset metadata and relationships enforce exact per-asset boundaries before
   const budget = createInsightsSweepBudget();
   const mapped = mapAsset(makeAsset('bounded-asset', { people: exactlyMaxPeople }), { budget });
   assert.equal(mapped.personIds.length, MAX_INSIGHTS_PEOPLE_PER_ASSET);
-  assert.equal(budget.status().nestedItems, 2008);
+  assert.equal(mapped.omittedPeopleRelationships, 0);
+  assert.equal(budget.status().nestedItems, 108);
   assert.equal(budget.status().generatedRows, 1 + MAX_INSIGHTS_PEOPLE_PER_ASSET);
 
-  const expandedPerson = mapAsset(makeAsset('expanded-person-row', {
+  const barePersonBudget = createInsightsSweepBudget();
+  const expandedPersonBudget = createInsightsSweepBudget();
+  mapAsset(makeAsset('same-person-id', { people: [{ id: 'p1' }] }), { budget: barePersonBudget });
+  const expandedPerson = mapAsset(makeAsset('same-person-id', {
     people: [{
       id: 'p1',
       detail: Object.fromEntries(Array.from({ length: 2500 }, (_, index) => [`field${index}`, index])),
     }],
-  }));
+  }), { budget: expandedPersonBudget });
   assert.deepEqual(expandedPerson.personIds, ['p1']);
+  assert.deepEqual(
+    expandedPersonBudget.status(),
+    barePersonBudget.status(),
+    'unused PersonWithFaces fields do not consume the retained-data sweep budget',
+  );
 
   const duplicateBudget = createInsightsSweepBudget();
   const duplicateMapped = mapAsset(makeAsset('duplicate-people', {
     people: Array.from({ length: MAX_INSIGHTS_PEOPLE_PER_ASSET }, () => ({ id: 'p1' })),
   }), { budget: duplicateBudget });
   assert.deepEqual(duplicateMapped.personIds, ['p1']);
-  assert.equal(duplicateBudget.status().generatedRows, 2, 'raw duplicates consume work but generate one relationship row');
+  assert.equal(duplicateMapped.omittedPeopleRelationships, 0);
+  assert.equal(duplicateBudget.status().generatedRows, 2, 'raw duplicates generate one relationship row');
 
-  assert.throws(
-    () => mapAsset(makeAsset('too-many-people', {
-      people: Array.from({ length: MAX_INSIGHTS_PEOPLE_PER_ASSET + 1 }, () => ({ id: 'p1' })),
-    })),
-    /100-person limit/,
-  );
-  assert.throws(
-    () => mapAsset(makeAsset('oversized-person-row', {
+  const crowd = mapAsset(makeAsset('crowd-photo', {
+    people: Array.from(
+      { length: MAX_INSIGHTS_PEOPLE_PER_ASSET + 250 },
+      (_, index) => ({ id: `crowd-${index}` }),
+    ),
+  }));
+  assert.equal(crowd.personIds.length, MAX_INSIGHTS_PEOPLE_PER_ASSET);
+  assert.deepEqual(crowd.personIds, Array.from(
+    { length: MAX_INSIGHTS_PEOPLE_PER_ASSET },
+    (_, index) => `crowd-${index}`,
+  ));
+  assert.equal(crowd.omittedPeopleRelationships, 250);
+
+  for (const row of [
+    mapAsset(makeAsset('oversized-person-row', {
       people: [{ id: 'p1', name: 'x'.repeat(MAX_INSIGHTS_METADATA_FIELD_BYTES + 1) }],
     })),
-    /oversized person relationship/,
-  );
-  assert.throws(
-    () => mapAsset(makeAsset('nested-person-row', {
+    mapAsset(makeAsset('nested-person-row', {
       people: [{
         id: 'p1',
         detail: Object.fromEntries(
@@ -362,10 +376,7 @@ test('asset metadata and relationships enforce exact per-asset boundaries before
         ),
       }],
     })),
-    new RegExp(`${MAX_INSIGHTS_NESTED_ITEMS_PER_ASSET}-nested-item limit`),
-  );
-  assert.throws(
-    () => mapAsset(makeAsset('decoded-person-row', {
+    mapAsset(makeAsset('decoded-person-row', {
       people: [{
         id: 'p1',
         ...Object.fromEntries(
@@ -373,7 +384,13 @@ test('asset metadata and relationships enforce exact per-asset boundaries before
         ),
       }],
     })),
-    new RegExp(`${MAX_INSIGHTS_DECODED_BYTES_PER_ASSET}-decoded-byte limit`),
+  ]) {
+    assert.deepEqual(row.personIds, ['p1']);
+    assert.equal(row.omittedPeopleRelationships, 0);
+  }
+  assert.throws(
+    () => mapAsset(makeAsset('invalid-person-id', { people: [{ id: 'not valid!' }] })),
+    /invalid person relationship on asset invalid-person-id identifier/,
   );
   const unusedExif = Object.fromEntries(
     Array.from({ length: 256 }, (_, index) => [`unusedField${index}`, 'x'.repeat(8192)]),
@@ -446,6 +463,34 @@ test('collector publishes assets with oversized unused EXIF fields', async () =>
     assert.equal(collector.status().phase, 'done');
     assert.equal(repo.sweepTotals().assetsSwept, 1);
     assert.deepEqual(collector.snapshot().metadataOmissions, { total: 0, fields: {} });
+  });
+});
+
+test('collector keeps crowd photos, caps people relationships, and publishes a durable notice', async () => {
+  await withRepoAsync(async (repo) => {
+    const people = Array.from(
+      { length: MAX_INSIGHTS_PEOPLE_PER_ASSET + 250 },
+      (_, index) => ({ id: `crowd-${index}`, name: `Person ${index}` }),
+    );
+    const messages = [];
+    const collector = new InsightsCollector({
+      repo,
+      immich: new FakeImmich([makeAsset('crowd', { people }), makeAsset('neighbor')], []),
+      config: CONFIG,
+      log: (message) => messages.push(message),
+    });
+    collector.start();
+    await waitForIdle(collector);
+
+    assert.equal(collector.status().phase, 'done');
+    assert.equal(collector.status().progress.peopleRelationshipsOmitted, 250);
+    assert.equal(repo.sweepTotals().assetsSwept, 2);
+    assert.deepEqual(collector.snapshot().peopleTruncation, {
+      assets: 1,
+      relationshipsOmitted: 250,
+      perAssetLimit: MAX_INSIGHTS_PEOPLE_PER_ASSET,
+    });
+    assert.ok(messages.some((message) => /limited people relationships on 1 asset.*250 relationship entries/.test(message)));
   });
 });
 


### PR DESCRIPTION
## Outcome

A legitimate crowd photo with more than 100 Immich people relationships no longer aborts the complete Insights refresh. The photo and every non-people statistic remain available while people and pair data stay bounded.

## Changes

- Preserve the existing 100 unique-relationship ceiling per photo rather than raising it.
- Retain the first 100 unique people IDs and omit later relationship entries without rejecting the asset or staged sweep.
- Project each upstream PersonWithFaces relationship to the bounded ID Pictaria actually stores, so unused names, face boxes, and future upstream fields do not consume admission budgets.
- Count affected photos and omitted relationship entries in progress, sanitized logs, and the published snapshot.
- Show a persistent Insights notice explaining that people and pair statistics are partial while every photo and non-people statistic was counted.
- Document the behavior and record it under Unreleased.

## Validation

- node --test test/insights.test.mjs — 45 passed
- node --test test/browser/smoke.test.mjs — 20 passed
- npm test — passed
- npm run check:publication
- git diff --check

Coverage includes a 350-person photo, exact-boundary and duplicate relationships, oversized unused PersonWithFaces fields, invalid retained IDs, snapshot/progress/log counters, and the browser notice.

## Risk and rollback

People and pair statistics intentionally include at most 100 unique relationships from one photo, as before. The change affects only the consequence of exceeding that ceiling: excess relationships are visible truncation instead of a whole-library failure. Aggregate row, byte, traversal, response, and disk-headroom limits remain intact. Reverting restores the prior fail-closed behavior; no schema or persisted-state migration is involved.

## Remaining work

The separate tag setup and persistent synchronization report in the same GitHub thread is PIC-309. After this fix ships in a patch release, ask the reporter to refresh Insights against the original crowd photo.

## Authorship

Implemented and tested by Codex. No independent agent review has yet been performed.

Related to PIC-310
