### PR TITLE
PIC-309: clarify Immich tag sync failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to Pictaria Server are documented here. This project follows
 - Insights keeps legitimate crowd photos in the library sweep when Immich
   reports more than 100 people. People relationships remain capped and excess
   entries are counted and surfaced instead of aborting the complete snapshot.
+- Immich tag verification now distinguishes unavailable tag data from tags
+  that remain missing after a repair attempt, and reports the relevant Tags
+  feature, API-key permissions, and affected-photo writability checks.
 - Insights ignores oversized Immich EXIF fields it does not store, while
   retaining strict bounds for metadata it uses. Malformed numeric metadata is
   left blank, counted, and reported without dropping the asset or the sweep.

--- a/docs/ENRICH.md
+++ b/docs/ENRICH.md
@@ -32,8 +32,9 @@ For each photo, one *processing run*:
 
 Enrichment runs are always dry runs against Immich. Tags reach Immich only
 through Curate decisions, via a durable background sync worker that verifies
-and repairs Immich's tag state after writing (Immich has been observed
-dropping tags under rapid mutation).
+and repairs Immich's tag state after writing. For that sync, enable **Tags**
+under **Immich Account Settings → Features** for the account whose API key
+Pictaria uses, and grant that key `tag.read`, `tag.create`, and `tag.asset`.
 
 ## Providers
 
@@ -288,6 +289,15 @@ your approved tags on every request.
 
 ## When things go wrong
 
+- **Curate says Immich is still missing tags**: first confirm **Tags** is
+  enabled under **Immich Account Settings → Features** for the same account
+  whose API key Pictaria uses, and confirm the key has `tag.read`,
+  `tag.create`, and `tag.asset`. Retry the parked sync entry after correcting
+  either setting. If only some photos keep failing, test one owned by the
+  API-key account: a shared or otherwise read-only photo can be visible to the
+  account without being writable. If an owned photo still fails, confirm only
+  one Pictaria Server instance is using the data volume and check the Immich
+  and Pictaria logs for the affected request.
 - **LM Studio in Docker fails every photo with a WebP message**: Immich
   previews are WebP, which LM Studio cannot ingest. On macOS Pictaria
   converts them automatically (`sips`); inside the Docker image there is no
@@ -378,6 +388,9 @@ Enrich → Write captions to Immich descriptions** turned on (off by
 default), Pictaria copies each caption into the photo's description field in
 Immich — so your photos become searchable *in Immich itself* by what's
 actually in them, and the description shows up anywhere Immich shows one.
+Until that option is enabled, captions remain searchable inside Pictaria but
+Immich descriptions intentionally stay blank. After enabling it, use **Write
+existing captions now** to backfill captions produced earlier.
 
 The rule is **never knowingly overwrite a human**:
 

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -42,6 +42,13 @@ else waits on them.
   > `album.create` · `album.delete` · `albumAsset.create` ·
   > `albumAsset.delete` · `tag.read` · `tag.create` · `tag.asset`
 
+  Also enable **Tags** in Immich under **Account Settings → Features** for
+  the same Immich account that owns this API key. This account-level switch
+  and the API-key permissions are separate: turning Tags on does not require
+  a new key when the existing key already has `tag.read`, `tag.create`, and
+  `tag.asset`. If Pictaria reports one of those permissions missing, update or
+  replace the key and save the replacement in Settings → Server.
+
   Roughly: the reads power search, Insights, and image fetches; `album.*`
   is Smart Albums doing its job — `albumAsset.create`/`albumAsset.delete`
   re-sync each album to its rule on every run (photos that stop matching,
@@ -81,6 +88,10 @@ else waits on them.
   the provider for new runs. That choice is remembered across visits and
   server restarts. Ollama and LM Studio keep everything on your own hardware;
   OpenAI, OpenRouter, Venice, and Ollama's cloud models are the cloud routes.
+  Captions are stored in Pictaria by default; Immich descriptions remain
+  unchanged unless you separately turn on **Write captions to Immich
+  descriptions**. Use **Write existing captions now** to copy captions made
+  before enabling that option.
   ([Pipeline, providers, taxonomy.](ENRICH.md))
 
 - [ ] *Optional* — **Get a free Geoapify key** for place names. Weather

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -44,10 +44,11 @@ else waits on them.
 
   Also enable **Tags** in Immich under **Account Settings → Features** for
   the same Immich account that owns this API key. This account-level switch
-  and the API-key permissions are separate: turning Tags on does not require
-  a new key when the existing key already has `tag.read`, `tag.create`, and
-  `tag.asset`. If Pictaria reports one of those permissions missing, update or
-  replace the key and save the replacement in Settings → Server.
+  and the API-key permissions are separate. Turning Tags on normally does not
+  require a new key when the existing key already has `tag.read`,
+  `tag.create`, and `tag.asset`. If Pictaria still reports a missing permission
+  or synchronization continues to fail, recreate the key and save the
+  replacement in Settings → Server.
 
   Roughly: the reads power search, Insights, and image fetches; `album.*`
   is Smart Albums doing its job — `albumAsset.create`/`albumAsset.delete`

--- a/src/enrich/reviewService.mjs
+++ b/src/enrich/reviewService.mjs
@@ -439,10 +439,10 @@ export class ReviewService {
     await this.verifyAndRepairTags(job);
   }
 
-  // Immich has been observed dropping tags even from successful calls when
-  // mutations land close together. Verify the final state after a short settle
-  // and re-push once; if tags are still missing, throw so the durable queue
-  // retries the whole (idempotent) job.
+  // Immich can report a successful mutation before every requested tag is
+  // visible on the asset. Verify the final state after a short settle and
+  // re-push once; if tags are still missing, throw so the durable queue retries
+  // the whole (idempotent) job.
   async verifyAndRepairTags(job) {
     const localTagsByAsset = this.repo.loadAssetTagsFor(job.assetIds, { prefix: 'ai/' });
     const expectedByAsset = new Map(
@@ -454,9 +454,12 @@ export class ReviewService {
       const missingByAsset = new Map();
       for (const assetId of job.assetIds) {
         const remoteAsset = await this.immich.getAsset(assetId);
-        const remoteTags = new Set(
-          (Array.isArray(remoteAsset?.tags) ? remoteAsset.tags : []).map((tag) => tagValue(tag)).filter(Boolean),
-        );
+        if (!Array.isArray(remoteAsset?.tags)) {
+          throw new Error(
+            'Immich did not expose asset tags. Enable Tags under Account Settings → Features for the API-key account, confirm the key includes tag.read, tag.create, and tag.asset, then retry.',
+          );
+        }
+        const remoteTags = new Set(remoteAsset.tags.map((tag) => tagValue(tag)).filter(Boolean));
         const missing = (expectedByAsset.get(assetId) ?? []).filter((tag) => !remoteTags.has(tag));
         if (missing.length > 0) {
           missingByAsset.set(assetId, missing);
@@ -469,9 +472,11 @@ export class ReviewService {
         const summary = [...missingByAsset.entries()]
           .map(([assetId, tags]) => `${assetId}: ${tags.join(', ')}`)
           .join(' | ');
-        throw new Error(`Immich dropped tags after repair attempt: ${summary}`);
+        throw new Error(
+          `Immich did not retain all requested tags after a repair attempt. Confirm Tags is enabled for the API-key account and that the affected photos are owned by or writable to that account, then retry. Missing: ${summary}`,
+        );
       }
-      this.log(`immich dropped ${missingByAsset.size} asset(s) worth of tags; repairing`);
+      this.log(`immich is still missing tags on ${missingByAsset.size} asset(s); repairing`);
       const allMissing = [...new Set([...missingByAsset.values()].flat())].sort();
       const resolved = await ensureImmichTagIds(this.immich, allMissing);
       for (const [assetId, missing] of missingByAsset) {

--- a/test/enrich/reviewService.test.mjs
+++ b/test/enrich/reviewService.test.mjs
@@ -454,7 +454,7 @@ test('ai tag additions batch into one bulk call per shared tag set', async () =>
   });
 });
 
-test('a dropped tag is detected by verification and repaired', async () => {
+test('a temporarily missing tag is detected by verification and repaired', async () => {
   await withService(async ({ repo, immich, service }) => {
     seedAsset(repo, 'droppy', { decisions: TWO_AI_TAGS });
     // Simulate Immich dropping one tag on the first bulk write only.
@@ -477,6 +477,50 @@ test('a dropped tag is detected by verification and repaired', async () => {
     for (const tag of repo.loadAssetTagsFor(['droppy'], { prefix: 'ai/' }).droppy ?? []) {
       assert.ok(finalTags.has(tag), `expected repaired tag ${tag}`);
     }
+  });
+});
+
+test('missing Immich tag data reports the feature and API-key checks', async () => {
+  await withService(async ({ repo, immich, service }) => {
+    seedAsset(repo, 'no-tag-data', { decisions: TWO_AI_TAGS });
+    immich.getAsset = async (assetId) => ({ id: assetId });
+
+    const job = {
+      id: 1,
+      action: 'approve',
+      assetIds: ['no-tag-data'],
+      add: ['frame/eligible'],
+      remove: [],
+      attempts: 0,
+    };
+    await assert.rejects(
+      service.pushDecisionToImmich(job),
+      /Enable Tags under Account Settings → Features.*tag\.read, tag\.create, and tag\.asset/,
+    );
+  });
+});
+
+test('persistent missing tags report asset writability as a possible cause', async () => {
+  await withService(async ({ repo, immich, service }) => {
+    seedAsset(repo, 'read-only-photo', { decisions: TWO_AI_TAGS });
+    const originalGetAsset = immich.getAsset.bind(immich);
+    immich.getAsset = async (assetId) => {
+      const asset = await originalGetAsset(assetId);
+      return { ...asset, tags: asset.tags.filter(({ value }) => value !== 'frame/eligible') };
+    };
+
+    const job = {
+      id: 1,
+      action: 'approve',
+      assetIds: ['read-only-photo'],
+      add: ['frame/eligible'],
+      remove: [],
+      attempts: 0,
+    };
+    await assert.rejects(
+      service.pushDecisionToImmich(job),
+      /did not retain all requested tags.*owned by or writable to that account.*Missing: read-only-photo: frame\/eligible/,
+    );
   });
 });
 


### PR DESCRIPTION
## Outcome

Immich tag-sync failures now distinguish unavailable tag data from tags that remain missing after a repair attempt, with actionable setup and asset-writability guidance.

## Changes

- Report a focused error when Immich does not expose an asset tags array, pointing to the account-level Tags feature and the three API-key permissions.
- Replace the ambiguous “dropped tags” diagnostic with neutral wording and a persistent-failure message that includes owned/writable-photo checks.
- Document the Tags feature, API-key requirements, targeted troubleshooting, and the opt-in nature of caption writeback.
- Add regression coverage for unavailable tag data, persistent missing tags, and the existing successful repair path.

## Validation

- `node --test test/enrich/reviewService.test.mjs` — 56 passed
- `npm test -- --test-reporter=dot` — passed
- `npm run check:publication` — passed
- `npm run check:dco` — passed
- `git diff --check` — passed

## Risk

Low. The existing write, verification delay, one repair attempt, and durable retry behavior are unchanged. This only classifies malformed/unavailable tag data separately and improves diagnostics and documentation.

## Remaining

Related to PIC-309. Reporter validation on the affected Immich installation remains useful after this ships; if failures persist on photos owned by the API-key account, capture the bounded server/Immich diagnostics before changing retry behavior.

## Authorship

Implemented by Codex with product direction and review by David Rangel.