### PR TITLE
PIC-312: Fix OpenRouter Gemini structured output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ All notable changes to Pictaria Server are documented here. This project follows
 - LM Studio Enrich and Curate requests accept validated schema JSON when a
   thinking-capable model returns it in `reasoning_content` with empty ordinary
   content. Voice and other prose never expose that reasoning channel.
+- OpenRouter Enrich and Curate requests adapt strict schemas to Google
+  Gemini's documented JSON Schema subset while retaining Pictaria's complete
+  local validation. Empty OpenRouter responses now expose bounded, sanitized
+  request and finish metadata instead of a context-free error.
 
 ## 1.0.0 - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,9 @@ All notable changes to Pictaria Server are documented here. This project follows
   content. Voice and other prose never expose that reasoning channel.
 - OpenRouter Enrich and Curate requests adapt strict schemas to Google
   Gemini's documented JSON Schema subset while retaining Pictaria's complete
-  local validation. OpenRouter failures now expose bounded, sanitized provider
-  and structured upstream error details; empty responses expose request and
-  finish metadata instead of a context-free error.
+  local validation. OpenRouter failures now expose bounded, credential-redacted
+  provider and structured upstream error details; empty responses expose
+  request and finish metadata instead of a context-free error.
 
 ## 1.0.0 - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,9 @@ All notable changes to Pictaria Server are documented here. This project follows
   content. Voice and other prose never expose that reasoning channel.
 - OpenRouter Enrich and Curate requests adapt strict schemas to Google
   Gemini's documented JSON Schema subset while retaining Pictaria's complete
-  local validation. Empty OpenRouter responses now expose bounded, sanitized
-  request and finish metadata instead of a context-free error.
+  local validation. OpenRouter failures now expose bounded, sanitized provider
+  and structured upstream error details; empty responses expose request and
+  finish metadata instead of a context-free error.
 
 ## 1.0.0 - 2026-08-28
 

--- a/docs/ENRICH.md
+++ b/docs/ENRICH.md
@@ -318,11 +318,13 @@ your approved tags on every request.
   change independently; an old model slug or a model with no endpoint that
   supports both requirements cannot run Enrich. Pictaria does not silently
   fall back to unconstrained text output. OpenRouter failure messages include
-  only bounded provider and structured upstream error fields that can be
-  shared for troubleshooting; unstructured raw metadata is ignored. If a
-  successful envelope has no answer, the message instead includes bounded
-  request and finish metadata. Neither path exposes prompts, images, reasoning
-  text, header values, debug objects, or credentials.
+  a bounded provider name plus structured upstream code, status, and message;
+  unstructured raw metadata and dedicated request, prompt, image, header, and
+  debug fields are ignored, and configured credentials are redacted. If a
+  successful envelope has no answer, the diagnostic instead includes bounded
+  request and finish metadata. The remaining message text is controlled by the
+  upstream provider, so review it before posting it publicly in case that
+  provider echoed request content in its message.
 - **Rate limits, outages, and timeouts never cost a photo anything.**
   Failures are classified by *whose fault they are*. A provider error that
   is clearly environmental — a timeout or dropped connection, an auth

--- a/docs/ENRICH.md
+++ b/docs/ENRICH.md
@@ -317,10 +317,12 @@ your approved tags on every request.
   available endpoint. OpenRouter model availability and endpoint capabilities
   change independently; an old model slug or a model with no endpoint that
   supports both requirements cannot run Enrich. Pictaria does not silently
-  fall back to unconstrained text output. If OpenRouter returns a successful
-  envelope with no answer, the failure message includes only bounded request,
-  provider, and finish metadata that can be shared for troubleshooting — never
-  prompts, images, reasoning text, or credentials.
+  fall back to unconstrained text output. OpenRouter failure messages include
+  only bounded provider and structured upstream error fields that can be
+  shared for troubleshooting; unstructured raw metadata is ignored. If a
+  successful envelope has no answer, the message instead includes bounded
+  request and finish metadata. Neither path exposes prompts, images, reasoning
+  text, header values, debug objects, or credentials.
 - **Rate limits, outages, and timeouts never cost a photo anything.**
   Failures are classified by *whose fault they are*. A provider error that
   is clearly environmental — a timeout or dropped connection, an auth

--- a/docs/ENRICH.md
+++ b/docs/ENRICH.md
@@ -62,6 +62,14 @@ key, model, or reachable URL, Enrich keeps that selection visible, explains
 that it is not configured, and will not start a run until you configure it or
 choose another provider.
 
+An OpenRouter model must have both **image input** and **structured outputs**
+on at least one currently available endpoint. Pictaria keeps strict structured
+output enabled. For `google/gemini-*` models it automatically projects the
+generation schema to Gemini's documented JSON Schema subset; Pictaria still
+applies the complete taxonomy, string-length, item-count, and numeric checks
+locally before accepting an answer. This provider-specific adaptation does not
+weaken the validation used for OpenAI or other OpenRouter models.
+
 For a dated, role-by-role starting point drawn from the Pictaria reference
 installation, see [Recommended AI models](RECOMMENDED-MODELS.md). It includes
 local and cloud choices and the extra multi-image requirement for the Curate
@@ -304,6 +312,15 @@ your approved tags on every request.
   converter, so set **Image source** to `original` in Settings → Enrich
   (`IMAGE_SOURCE=original`). Originals are typically JPEG; HEIC originals
   may still be rejected by LM Studio.
+- **OpenRouter says `404 No endpoints found`**: confirm that the exact current
+  model identifier accepts images and advertises structured outputs on an
+  available endpoint. OpenRouter model availability and endpoint capabilities
+  change independently; an old model slug or a model with no endpoint that
+  supports both requirements cannot run Enrich. Pictaria does not silently
+  fall back to unconstrained text output. If OpenRouter returns a successful
+  envelope with no answer, the failure message includes only bounded request,
+  provider, and finish metadata that can be shared for troubleshooting — never
+  prompts, images, reasoning text, or credentials.
 - **Rate limits, outages, and timeouts never cost a photo anything.**
   Failures are classified by *whose fault they are*. A provider error that
   is clearly environmental — a timeout or dropped connection, an auth

--- a/src/enrich/providers.mjs
+++ b/src/enrich/providers.mjs
@@ -861,9 +861,11 @@ function providerErrorDetail(text, providerName, apiKey) {
 
 // OpenRouter wraps the useful native-provider failure inside
 // error.metadata.raw. Never surface that field directly: it is untrusted and
-// could contain request data. Accept only a small JSON object, run it through
-// the same field allowlist as every other upstream diagnostic, and ignore
-// plaintext, arrays, debug objects, headers, prompts, and image data.
+// could contain request data. Accept only a small JSON object and read the
+// same fields allowed in every other upstream diagnostic; dedicated request,
+// prompt, image, header, and debug fields remain ignored. The allowed message
+// is still provider-controlled: bound it and redact credentials, but do not
+// describe it as automatically safe to publish.
 function openRouterErrorMetadataDiagnostic(body, options) {
   const metadata = body?.error?.metadata;
   if (!isPlainObject(metadata)) return '';

--- a/src/enrich/providers.mjs
+++ b/src/enrich/providers.mjs
@@ -726,7 +726,7 @@ async function postJson(provider, url, body, extraHeaders) {
   }
 
   if (!response.ok) {
-    const detail = await readErrorDetail(response, provider.apiKey);
+    const detail = await readErrorDetail(response, provider);
     throw new ProviderRequestError(providerStatusMessage(provider.providerName, response.status, detail), {
       status: response.status,
     });
@@ -761,16 +761,17 @@ async function postJson(provider, url, body, extraHeaders) {
 // bounded, and degrade to no detail rather than throw — the status-coded
 // error we are building is the failure that matters.
 const ERROR_DETAIL_MAX_BYTES = 64 * 1024;
-async function readErrorDetail(response, apiKey) {
+async function readErrorDetail(response, provider) {
   try {
     // Injected doubles without a body stream (tests) read whole.
     if (typeof response.body?.getReader === 'function') {
       return providerErrorDetail(
         (await readBodyBounded(response, ERROR_DETAIL_MAX_BYTES, 'Provider')).toString('utf8'),
-        apiKey,
+        provider.providerName,
+        provider.apiKey,
       );
     }
-    return providerErrorDetail(await response.text(), apiKey);
+    return providerErrorDetail(await response.text(), provider.providerName, provider.apiKey);
   } catch {
     return '';
   }
@@ -810,7 +811,7 @@ function nodePostJson(provider, url, headers, payload) {
         clearTimeout(deadline);
         const text = Buffer.concat(chunks).toString('utf8');
         if (response.statusCode < 200 || response.statusCode >= 300) {
-          const detail = providerErrorDetail(text, provider.apiKey);
+          const detail = providerErrorDetail(text, provider.providerName, provider.apiKey);
           reject(new ProviderRequestError(providerStatusMessage(provider.providerName, response.statusCode, detail), {
             status: response.statusCode,
           }));
@@ -836,9 +837,21 @@ function nodePostJson(provider, url, headers, payload) {
   });
 }
 
-function providerErrorDetail(text, apiKey) {
+const OPENROUTER_RAW_ERROR_MAX_BYTES = 16 * 1024;
+
+function providerErrorDetail(text, providerName, apiKey) {
   try {
-    return structuredUpstreamDiagnostic(JSON.parse(text), { secrets: [apiKey] });
+    const body = JSON.parse(text);
+    const options = { secrets: [apiKey] };
+    if (providerName !== 'openrouter') {
+      return structuredUpstreamDiagnostic(body, options);
+    }
+    const primary = structuredUpstreamDiagnostic(body, { ...options, maxBytes: 256 });
+    const metadata = openRouterErrorMetadataDiagnostic(body, options);
+    return sanitizeDiagnostic([primary, metadata].filter(Boolean).join('; '), {
+      ...options,
+      maxBytes: 512,
+    });
   } catch {
     // Arbitrary HTML/plaintext bodies are not diagnostics. The status and
     // provider identity still explain the failure without retaining a dump.
@@ -846,8 +859,48 @@ function providerErrorDetail(text, apiKey) {
   }
 }
 
+// OpenRouter wraps the useful native-provider failure inside
+// error.metadata.raw. Never surface that field directly: it is untrusted and
+// could contain request data. Accept only a small JSON object, run it through
+// the same field allowlist as every other upstream diagnostic, and ignore
+// plaintext, arrays, debug objects, headers, prompts, and image data.
+function openRouterErrorMetadataDiagnostic(body, options) {
+  const metadata = body?.error?.metadata;
+  if (!isPlainObject(metadata)) return '';
+
+  const fields = [];
+  if (typeof metadata.provider_name === 'string' || typeof metadata.provider_name === 'number') {
+    const providerName = sanitizeDiagnostic(metadata.provider_name, { ...options, maxBytes: 96 });
+    if (providerName) fields.push(`provider: ${providerName}`);
+  }
+
+  if (typeof metadata.raw === 'string'
+    && Buffer.byteLength(metadata.raw, 'utf8') <= OPENROUTER_RAW_ERROR_MAX_BYTES) {
+    try {
+      const nativeError = JSON.parse(metadata.raw);
+      if (isPlainObject(nativeError)) {
+        const status = nativeError.status ?? nativeError.error?.status ?? nativeError.detail?.status;
+        if (typeof status === 'string' || typeof status === 'number') {
+          const safeStatus = sanitizeDiagnostic(status, { ...options, maxBytes: 96 });
+          if (safeStatus) fields.push(`upstream status: ${safeStatus}`);
+        }
+        const detail = structuredUpstreamDiagnostic(nativeError, { ...options, maxBytes: 256 });
+        if (detail) fields.push(`upstream: ${detail}`);
+      }
+    } catch {
+      // Raw plaintext or malformed JSON is intentionally not diagnostic data.
+    }
+  }
+
+  return sanitizeDiagnostic(fields.join('; '), { ...options, maxBytes: 384 });
+}
+
 function providerStatusMessage(providerName, status, detail) {
   return `${providerName} request failed with status ${status}${detail ? `: ${detail}` : ''}`;
+}
+
+function isPlainObject(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function toDataUrl(image) {

--- a/src/enrich/providers.mjs
+++ b/src/enrich/providers.mjs
@@ -35,6 +35,34 @@ const OPENAI_MAX_OUTPUT_TOKENS = 8192;
 // can become a large transient allocation.
 const MAX_PROVIDER_RESPONSE_BYTES = 2 * 1024 * 1024;
 
+// Gemini accepts JSON Schema through OpenRouter, but its native structured-
+// output API supports only a documented subset of JSON Schema. Keep strict
+// generation while projecting out unsupported generation hints; the complete
+// Pictaria schema is still enforced by validateAiOutput after the response.
+const GEMINI_JSON_SCHEMA_KEYWORDS = new Set([
+  '$id',
+  '$defs',
+  '$ref',
+  '$anchor',
+  'type',
+  'format',
+  'title',
+  'description',
+  'enum',
+  'items',
+  'prefixItems',
+  'minItems',
+  'maxItems',
+  'minimum',
+  'maximum',
+  'anyOf',
+  'oneOf',
+  'properties',
+  'additionalProperties',
+  'required',
+  'propertyOrdering',
+]);
+
 // Transport-level provider failure. `infrastructure` separates "the provider
 // or network is unhealthy" (timeouts, refused connections, auth, rate limits,
 // 5xx) from "the provider judged this request's content" — the runner only
@@ -289,6 +317,7 @@ export class OpenRouterProvider {
   }
 
   async analyzeImages(images, { systemPrompt, userPrompt, jsonSchema, schemaName = 'pictaria_photo_enrichment' }) {
+    const providerJsonSchema = openRouterJsonSchema(this.modelName, jsonSchema);
     const body = {
       model: this.modelName,
       messages: [
@@ -306,7 +335,7 @@ export class OpenRouterProvider {
         json_schema: {
           name: schemaName,
           strict: true,
-          schema: jsonSchema,
+          schema: providerJsonSchema,
         },
       },
       temperature: 0,
@@ -319,7 +348,8 @@ export class OpenRouterProvider {
     });
     const outputText = extractChoiceMessageContent(rawOutput);
     if (!outputText) {
-      throw new Error('OpenRouter response did not include message content');
+      const detail = openRouterEmptyContentDiagnostic(rawOutput, this.apiKey);
+      throw new Error(`OpenRouter response did not include message content${detail ? `: ${detail}` : ''}`);
     }
     return { rawOutput, normalizedOutput: JSON.parse(outputText) };
   }
@@ -339,6 +369,53 @@ export class OpenRouterProvider {
     });
     return { rawOutput, text: extractChoiceMessageContent(rawOutput) };
   }
+}
+
+function openRouterJsonSchema(modelName, jsonSchema) {
+  if (!String(modelName ?? '').toLowerCase().startsWith('google/gemini-')) {
+    return jsonSchema;
+  }
+  return projectGeminiJsonSchema(jsonSchema);
+}
+
+function projectGeminiJsonSchema(value, context = 'schema') {
+  if (Array.isArray(value)) {
+    return value.map((item) => projectGeminiJsonSchema(item, context));
+  }
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+  if (context === 'properties' || context === '$defs') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, schema]) => [key, projectGeminiJsonSchema(schema)]),
+    );
+  }
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([key]) => GEMINI_JSON_SCHEMA_KEYWORDS.has(key))
+      .map(([key, child]) => [key, projectGeminiJsonSchema(child, key)]),
+  );
+}
+
+function openRouterEmptyContentDiagnostic(response, apiKey) {
+  const choice = response?.choices?.[0];
+  const fields = [];
+  for (const [label, value] of [
+    ['request id', response?.id],
+    ['provider', response?.provider],
+    ['finish reason', choice?.finish_reason],
+    ['native finish reason', choice?.native_finish_reason],
+  ]) {
+    if (typeof value === 'string' || typeof value === 'number') {
+      const text = String(value).trim();
+      if (text) fields.push(`${label}: ${text}`);
+    }
+  }
+  for (const error of [response?.error, choice?.error]) {
+    const detail = structuredUpstreamDiagnostic(error, { secrets: [apiKey], maxBytes: 256 });
+    if (detail) fields.push(`error: ${detail}`);
+  }
+  return sanitizeDiagnostic(fields.join('; '), { secrets: [apiKey], maxBytes: 512 });
 }
 
 export class VeniceProvider {

--- a/test/enrich/providers.test.mjs
+++ b/test/enrich/providers.test.mjs
@@ -33,6 +33,7 @@ function fakeFetch(responseBody, { status = 200, capture = {} } = {}) {
 
 const image = { data: Buffer.from('image-bytes'), mimeType: 'image/jpeg', assetId: 'asset-1' };
 const prompts = { systemPrompt: 'system', userPrompt: 'user', jsonSchema: { type: 'object' } };
+const OPENROUTER_OVERSIZED_TEST_BYTES = 17 * 1024;
 
 test('json parser accepts plain json, fences, and surrounding prose', () => {
   assert.deepEqual(parseJsonContent('{"caption": "Lake"}'), { caption: 'Lake' });
@@ -435,6 +436,94 @@ test('http errors surface provider name, status, and response detail', async () 
     () => provider.analyzeImage(image, prompts),
     /openrouter request failed with status 429.*rate limited/,
   );
+});
+
+test('openrouter HTTP errors safely expose structured native-provider metadata', async () => {
+  const secret = 'provider:test/+ key';
+  const provider = new OpenRouterProvider({
+    apiKey: secret,
+    modelName: 'google/gemini-2.5-flash',
+    fetchImpl: fakeFetch({
+      error: {
+        code: 400,
+        message: 'Provider returned error',
+        metadata: {
+          provider_name: 'Google AI Studio',
+          raw: JSON.stringify({
+            error: {
+              code: 400,
+              status: 'INVALID_ARGUMENT',
+              message: `Unable to process input image; Authorization: Bearer ${secret}`,
+              debug: 'private native debug data',
+            },
+            request: { prompt: 'private prompt', image: 'private image bytes' },
+          }),
+          debug: 'private router metadata',
+        },
+      },
+      debug: 'private router response',
+    }, { status: 400 }),
+  });
+
+  await assert.rejects(provider.analyzeImage(image, prompts), (error) => {
+    assert.equal(error.status, 400);
+    assert.match(error.message, /code: 400; Provider returned error/);
+    assert.match(error.message, /provider: Google AI Studio/);
+    assert.match(error.message, /upstream status: INVALID_ARGUMENT/);
+    assert.match(error.message, /upstream: code: 400; Unable to process input image/);
+    assert.doesNotMatch(error.message, /provider:test|private/i);
+    assert.match(error.message, /Authorization: \[redacted\]/);
+    assert.ok(Buffer.byteLength(error.message, 'utf8') <= 600);
+    return true;
+  });
+});
+
+test('openrouter HTTP errors ignore unstructured or oversized raw metadata', async () => {
+  for (const raw of [
+    'private prompt and image bytes',
+    JSON.stringify({ error: { message: 'private ' + 'x'.repeat(OPENROUTER_OVERSIZED_TEST_BYTES) } }),
+  ]) {
+    const provider = new OpenRouterProvider({
+      apiKey: 'key',
+      modelName: 'google/gemini-2.5-flash',
+      fetchImpl: fakeFetch({
+        error: {
+          code: 400,
+          message: 'Provider returned error',
+          metadata: { provider_name: 'Google AI Studio', raw },
+        },
+      }, { status: 400 }),
+    });
+
+    await assert.rejects(provider.analyzeImage(image, prompts), (error) => {
+      assert.match(error.message, /provider: Google AI Studio/);
+      assert.doesNotMatch(error.message, /private prompt|private x/i);
+      return true;
+    });
+  }
+});
+
+test('non-OpenRouter providers do not expose OpenRouter metadata envelopes', async () => {
+  const provider = new VeniceProvider({
+    apiKey: 'key',
+    modelName: 'qwen3-vl-235b-a22b',
+    fetchImpl: fakeFetch({
+      error: {
+        code: 400,
+        message: 'Provider returned error',
+        metadata: {
+          provider_name: 'must-not-survive',
+          raw: JSON.stringify({ error: { message: 'must-not-survive' } }),
+        },
+      },
+    }, { status: 400 }),
+  });
+
+  await assert.rejects(provider.analyzeImage(image, prompts), (error) => {
+    assert.match(error.message, /code: 400; Provider returned error/);
+    assert.doesNotMatch(error.message, /must-not-survive/);
+    return true;
+  });
 });
 
 test('provider errors redact exact, encoded, and echoed-header API credentials', async () => {

--- a/test/enrich/providers.test.mjs
+++ b/test/enrich/providers.test.mjs
@@ -203,6 +203,101 @@ test('openrouter posts identity headers and parses strict json content', async (
   assert.equal(capture.body.response_format.json_schema.strict, true);
 });
 
+test('openrouter projects Gemini schemas to its supported JSON Schema subset', async () => {
+  const capture = {};
+  const jsonSchema = {
+    type: 'object',
+    additionalProperties: false,
+    required: ['caption', 'tags'],
+    properties: {
+      caption: { type: 'string', description: 'What is shown.', maxLength: 4096 },
+      tags: {
+        type: 'array',
+        maxItems: 50,
+        items: {
+          type: 'object',
+          additionalProperties: false,
+          required: ['confidence'],
+          properties: {
+            confidence: { type: 'number', minimum: 0, maximum: 1 },
+          },
+        },
+      },
+      maxLength: { type: 'string', maxLength: 12 },
+    },
+  };
+  const originalSchema = structuredClone(jsonSchema);
+  const provider = new OpenRouterProvider({
+    apiKey: 'key',
+    modelName: 'google/gemini-2.5-flash',
+    fetchImpl: fakeFetch({ choices: [{ message: { content: '{"caption":"Lake","tags":[]}' } }] }, { capture }),
+  });
+
+  await provider.analyzeImage(image, { ...prompts, jsonSchema });
+
+  const sent = capture.body.response_format.json_schema.schema;
+  assert.equal(capture.body.response_format.json_schema.strict, true);
+  assert.equal(sent.properties.caption.maxLength, undefined);
+  assert.equal(sent.properties.caption.description, 'What is shown.');
+  assert.equal(sent.properties.tags.maxItems, 50);
+  assert.equal(sent.properties.tags.items.additionalProperties, false);
+  assert.equal(sent.properties.tags.items.properties.confidence.minimum, 0);
+  assert.equal(sent.properties.tags.items.properties.confidence.maximum, 1);
+  assert.deepEqual(sent.properties.maxLength, { type: 'string' });
+  assert.deepEqual(jsonSchema, originalSchema, 'provider projection must not mutate the validation schema');
+});
+
+test('openrouter leaves non-Gemini strict schemas unchanged', async () => {
+  const capture = {};
+  const jsonSchema = {
+    type: 'object',
+    properties: { caption: { type: 'string', maxLength: 4096 } },
+  };
+  const provider = new OpenRouterProvider({
+    apiKey: 'key',
+    modelName: 'qwen/qwen3-vl-32b-instruct',
+    fetchImpl: fakeFetch({ choices: [{ message: { content: '{"caption":"Lake"}' } }] }, { capture }),
+  });
+
+  await provider.analyzeImage(image, { ...prompts, jsonSchema });
+
+  assert.deepEqual(capture.body.response_format.json_schema.schema, jsonSchema);
+});
+
+test('openrouter empty content reports only bounded safe provider metadata', async () => {
+  const secret = 'provider:test/+ key';
+  const provider = new OpenRouterProvider({
+    apiKey: secret,
+    modelName: 'google/gemini-2.5-flash',
+    fetchImpl: fakeFetch({
+      id: 'gen-safe-id',
+      provider: 'Google AI Studio',
+      choices: [{
+        finish_reason: 'error',
+        native_finish_reason: 'INVALID_ARGUMENT',
+        message: { content: '', reasoning: 'private chain of thought' },
+        error: {
+          code: 400,
+          message: `Unable to process input; Authorization: Bearer ${secret}`,
+          debug: 'private provider payload',
+        },
+      }],
+      debug: 'private top-level payload',
+    }),
+  });
+
+  await assert.rejects(provider.analyzeImage(image, prompts), (error) => {
+    assert.match(error.message, /request id: gen-safe-id/);
+    assert.match(error.message, /provider: Google AI Studio/);
+    assert.match(error.message, /finish reason: error/);
+    assert.match(error.message, /native finish reason: INVALID_ARGUMENT/);
+    assert.match(error.message, /code: 400; Unable to process input/);
+    assert.doesNotMatch(error.message, /provider:test|private chain|private provider|private top-level/i);
+    assert.ok(Buffer.byteLength(error.message, 'utf8') <= 600);
+    return true;
+  });
+});
+
 test('ollama embeds the schema in the prompt and tolerates fenced output', async () => {
   const capture = {};
   const provider = new OllamaCloudProvider({


### PR DESCRIPTION
## Outcome

OpenRouter keeps strict structured output, while Google Gemini requests now receive only the JSON Schema keywords Gemini documents as supported. Pictaria continues to enforce the complete schema locally.

## Material changes

- Project Google Gemini schemas at the OpenRouter boundary without mutating the validation schema.
- Leave Qwen, OpenAI, and other OpenRouter model schemas unchanged.
- Include bounded, credential-redacted request/provider/finish metadata when OpenRouter returns no message content.
- For OpenRouter HTTP errors, expose only the backend name and allowlisted code/status/message from a small structured native-provider error; ignore plaintext, oversized, request, prompt, image, header-value, and debug metadata.
- Document model and endpoint requirements plus 404 troubleshooting. The upstream message remains provider-controlled and operators are told to review it before posting publicly.
- Add the user-visible fix to the Unreleased changelog.

## Validation

- npm test — 974 passed
- npm run check:publication — passed
- git diff --check — passed
- Request-shape tests cover Gemini projection, property-name preservation, non-Gemini behavior, schema immutability, diagnostic redaction, bounded native-error parsing, unstructured/oversized metadata rejection, and provider scoping.

## Risk and rollback

The schema adaptation is gated to model identifiers beginning with google/gemini-. OpenRouter native metadata is never emitted directly and is parsed only when it is a bounded JSON object. Dedicated sensitive fields are ignored and configured credentials are redacted, but any allowlisted upstream message remains provider-controlled and should be reviewed before public sharing. A rollback is a normal revert of this PR. The primary remaining uncertainty is live OpenRouter routing because no OpenRouter credential is stored in this checkout.

## Remaining work

Reporter validation against OpenRouter google/gemini-2.5-flash is still required before PIC-312 is complete and before the GitHub issue is closed.

Related to PIC-312

## Authorship and review

Implementation and tests by OpenAI Codex. Claude independently reviewed the initial implementation, verified its model scoping and local-validation preservation, identified the missing HTTP 400 metadata path addressed in the second commit, and approved that revision subject to the provider-controlled-message wording corrected in the third commit. The schema allow-list concern was checked against the current Google responseJsonSchema contract; the projection remains unchanged.