### PR TITLE
PIC-294: Verify Curate tag removals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to Pictaria Server are documented here. This project follows
   cap and temperature. Empty Compose values preserve the same runtime defaults
   as a native installation; custom taxonomy and prompt paths still require a
   matching container mount.
+- Curate verifies and repairs both sides of every Immich tag decision, so a
+  rejected or reviewed photo cannot finish synchronization while retaining
+  `frame/eligible` or `frame/favorite`, and approving a photo likewise removes
+  contradictory rejection tags.
 - Insights keeps legitimate crowd photos in the library sweep when Immich
   reports more than 100 people. People relationships remain capped and excess
   entries are counted and surfaced instead of aborting the complete snapshot.

--- a/docs/ENRICH.md
+++ b/docs/ENRICH.md
@@ -32,9 +32,10 @@ For each photo, one *processing run*:
 
 Enrichment runs are always dry runs against Immich. Tags reach Immich only
 through Curate decisions, via a durable background sync worker that verifies
-and repairs Immich's tag state after writing. For that sync, enable **Tags**
-under **Immich Account Settings → Features** for the account whose API key
-Pictaria uses, and grant that key `tag.read`, `tag.create`, and `tag.asset`.
+and repairs both required additions and required removals after writing. For
+that sync, enable **Tags** under **Immich Account Settings → Features** for the
+account whose API key Pictaria uses, and grant that key `tag.read`,
+`tag.create`, and `tag.asset`.
 
 ## Providers
 

--- a/src/enrich/reviewService.mjs
+++ b/src/enrich/reviewService.mjs
@@ -439,10 +439,11 @@ export class ReviewService {
     await this.verifyAndRepairTags(job);
   }
 
-  // Immich can report a successful mutation before every requested tag is
-  // visible on the asset. Verify the final state after a short settle and
-  // re-push once; if tags are still missing, throw so the durable queue retries
-  // the whole (idempotent) job.
+  // Immich can report a successful mutation before every requested addition
+  // or removal is visible on the asset. Verify the complete final state after
+  // a short settle and repair once; if it is still inconsistent, throw so the
+  // durable queue retries the whole (idempotent) job. A never-show decision
+  // must not complete while the remote photo is still eligible.
   async verifyAndRepairTags(job) {
     const localTagsByAsset = this.repo.loadAssetTagsFor(job.assetIds, { prefix: 'ai/' });
     const expectedByAsset = new Map(
@@ -452,6 +453,8 @@ export class ReviewService {
     for (let attempt = 0; attempt < 2; attempt += 1) {
       await sleep(this.verifyDelayMs);
       const missingByAsset = new Map();
+      const retainedByAsset = new Map();
+      const retainedTagIdsByAsset = new Map();
       for (const assetId of job.assetIds) {
         const remoteAsset = await this.immich.getAsset(assetId);
         if (!Array.isArray(remoteAsset?.tags)) {
@@ -459,31 +462,62 @@ export class ReviewService {
             'Immich did not expose asset tags. Enable Tags under Account Settings → Features for the API-key account, confirm the key includes tag.read, tag.create, and tag.asset, then retry.',
           );
         }
+        const remoteTagIds = tagMap(remoteAsset.tags);
         const remoteTags = new Set(remoteAsset.tags.map((tag) => tagValue(tag)).filter(Boolean));
         const missing = (expectedByAsset.get(assetId) ?? []).filter((tag) => !remoteTags.has(tag));
         if (missing.length > 0) {
           missingByAsset.set(assetId, missing);
         }
+        const retained = job.remove.filter((tag) => remoteTags.has(tag));
+        if (retained.length > 0) {
+          retainedByAsset.set(assetId, retained);
+          retainedTagIdsByAsset.set(
+            assetId,
+            retained.map((tag) => remoteTagIds[tag]).filter(Boolean),
+          );
+        }
       }
-      if (missingByAsset.size === 0) {
+      if (missingByAsset.size === 0 && retainedByAsset.size === 0) {
         return;
       }
       if (attempt === 1) {
-        const summary = [...missingByAsset.entries()]
-          .map(([assetId, tags]) => `${assetId}: ${tags.join(', ')}`)
-          .join(' | ');
+        const problems = [];
+        if (missingByAsset.size > 0) {
+          problems.push(`Missing: ${[...missingByAsset.entries()]
+            .map(([assetId, tags]) => `${assetId}: ${tags.join(', ')}`)
+            .join(' | ')}`);
+        }
+        if (retainedByAsset.size > 0) {
+          problems.push(`Still present: ${[...retainedByAsset.entries()]
+            .map(([assetId, tags]) => `${assetId}: ${tags.join(', ')}`)
+            .join(' | ')}`);
+        }
         throw new Error(
-          `Immich did not retain all requested tags after a repair attempt. Confirm Tags is enabled for the API-key account and that the affected photos are owned by or writable to that account, then retry. Missing: ${summary}`,
+          `Immich did not retain all requested tags after a repair attempt. Confirm Tags is enabled for the API-key account and that the affected photos are owned by or writable to that account, then retry. ${problems.join(' | ')}`,
         );
       }
-      this.log(`immich is still missing tags on ${missingByAsset.size} asset(s); repairing`);
-      const allMissing = [...new Set([...missingByAsset.values()].flat())].sort();
-      const resolved = await ensureImmichTagIds(this.immich, allMissing);
-      for (const [assetId, missing] of missingByAsset) {
-        await this.immich.tagAssetsBulk({
-          assetIds: [assetId],
-          tagIds: missing.map((tag) => resolved[tag]).filter(Boolean),
-        });
+      const inconsistentAssets = new Set([...missingByAsset.keys(), ...retainedByAsset.keys()]);
+      this.log(`immich tag state is still inconsistent on ${inconsistentAssets.size} asset(s); repairing`);
+      if (retainedByAsset.size > 0) {
+        const assetsByTagId = new Map();
+        for (const [assetId, retainedTagIds] of retainedTagIdsByAsset) {
+          for (const retainedTagId of retainedTagIds) {
+            push(assetsByTagId, retainedTagId, assetId);
+          }
+        }
+        for (const [retainedTagId, assetIds] of assetsByTagId) {
+          await this.immich.untagAssets({ tagId: retainedTagId, assetIds });
+        }
+      }
+      if (missingByAsset.size > 0) {
+        const allMissing = [...new Set([...missingByAsset.values()].flat())].sort();
+        const resolved = await ensureImmichTagIds(this.immich, allMissing);
+        for (const [assetId, missing] of missingByAsset) {
+          await this.immich.tagAssetsBulk({
+            assetIds: [assetId],
+            tagIds: missing.map((tag) => resolved[tag]).filter(Boolean),
+          });
+        }
       }
     }
   }

--- a/test/enrich/reviewService.test.mjs
+++ b/test/enrich/reviewService.test.mjs
@@ -480,6 +480,70 @@ test('a temporarily missing tag is detected by verification and repaired', async
   });
 });
 
+test('a temporarily retained incompatible tag is detected and removed on repair', async () => {
+  await withService(async ({ repo, immich, service }) => {
+    seedAsset(repo, 'dropped-removal', { decisions: TWO_AI_TAGS });
+    immich.assetTags.set('dropped-removal', new Set(['frame/eligible', 'frame/favorite']));
+
+    // Simulate Immich acknowledging the first eligible removal without
+    // applying it. The verification repair must issue the removal again.
+    const originalUntag = immich.untagAssets.bind(immich);
+    let dropped = false;
+    immich.untagAssets = async (request) => {
+      if (!dropped && request.tagId === 'tag-frame/eligible') {
+        dropped = true;
+        immich.calls.push(['untag', request.tagId, request.assetIds]);
+        return [];
+      }
+      return originalUntag(request);
+    };
+
+    const job = {
+      id: 1,
+      action: 'reject',
+      assetIds: ['dropped-removal'],
+      add: ['frame/never-show', 'frame/reviewed'],
+      remove: ['frame/eligible', 'frame/favorite'],
+      attempts: 0,
+    };
+    await service.pushDecisionToImmich(job);
+
+    const finalTags = immich.assetTags.get('dropped-removal');
+    assert.ok(finalTags.has('frame/never-show'));
+    assert.ok(finalTags.has('frame/reviewed'));
+    assert.equal(finalTags.has('frame/eligible'), false);
+    assert.equal(finalTags.has('frame/favorite'), false);
+    assert.equal(
+      immich.calls.filter(([kind, tagId]) => kind === 'untag' && tagId === 'tag-frame/eligible').length,
+      2,
+    );
+  });
+});
+
+test('a persistent contradictory tag keeps the durable sync visible as failed', async () => {
+  await withService(async ({ repo, immich, service }) => {
+    seedAsset(repo, 'contradictory-photo', { decisions: TWO_AI_TAGS });
+    immich.assetTags.set('contradictory-photo', new Set(['frame/never-show', 'frame/reviewed']));
+    immich.untagAssets = async ({ tagId, assetIds }) => {
+      immich.calls.push(['untag', tagId, assetIds]);
+      return []; // acknowledge while retaining the tag
+    };
+
+    const job = {
+      id: 1,
+      action: 'approve',
+      assetIds: ['contradictory-photo'],
+      add: ['frame/eligible'],
+      remove: ['frame/never-show', 'frame/reviewed'],
+      attempts: 0,
+    };
+    await assert.rejects(
+      service.pushDecisionToImmich(job),
+      /did not retain all requested tags.*Still present: contradictory-photo: frame\/never-show, frame\/reviewed/,
+    );
+  });
+});
+
 test('missing Immich tag data reports the feature and API-key checks', async () => {
   await withService(async ({ repo, immich, service }) => {
     seedAsset(repo, 'no-tag-data', { decisions: TWO_AI_TAGS });


### PR DESCRIPTION
## Outcome

Curate now verifies the complete requested Immich tag state before a durable sync slice completes. A rejected or reviewed photo cannot remain frame/eligible or frame/favorite, and an approved photo cannot retain contradictory rejection tags.

## Material changes

- detect both missing required tags and forbidden tags that remain present;
- retry dropped removals once, grouped by Immich tag ID;
- keep a persistently contradictory job failed and retryable with an actionable diagnostic;
- document the two-sided verification and add the change to Unreleased;
- add regression coverage for a dropped removal, successful repair, and persistent failure.

## Validation

- focused Curate/ReviewService suite: 58/58 passed;
- full repository suite: 976/976 passed;
- publication hygiene passed for 238 tracked files;
- DCO sign-off and diff checks pass locally.

## Risk and rollback

The existing verification reads and durable retry limits are unchanged. Extra Immich mutations occur only when verification observes a forbidden tag still present. The change is code-only with no persisted-state migration; reverting this PR restores the former additions-only verification.

## Remaining work

None for this issue. Fixes PIC-294.

## Authorship and review

Implemented by Codex Desktop under David Rangel's direction. No independent agent review has been performed yet.