### PR TITLE
PIC-104: Complete Compose provider environment pass-through

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to Pictaria Server are documented here. This project follows
 
 ### Fixed
 
+- Docker Compose now forwards every documented non-path enrichment, AI,
+  Curate-referee, voice, and geocoding variable, including LM Studio's token
+  cap and temperature. Empty Compose values preserve the same runtime defaults
+  as a native installation; custom taxonomy and prompt paths still require a
+  matching container mount.
 - Insights keeps legitimate crowd photos in the library sweep when Immich
   reports more than 100 people. People relationships remain capped and excess
   entries are counted and surfaced instead of aborting the complete snapshot.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,21 +28,47 @@ services:
       BACKUP_ENABLED: ${BACKUP_ENABLED-true}
       BACKUP_INTERVAL_HOURS: ${BACKUP_INTERVAL_HOURS:-24}
       BACKUP_KEEP: ${BACKUP_KEEP:-7}
-      # Optional providers (see .env.example for the full list). Connections
-      # and models can also be set under Settings → AI Providers; the active
-      # enrichment provider is selected and remembered on the Enrich page.
+      # Enrichment and optional providers (see .env.example for the full
+      # list). Connections and models can also be set under Settings → AI
+      # Providers; the active provider is remembered on the Enrich page.
+      ENRICH_ENABLED: ${ENRICH_ENABLED:-false}
+      CAPTION_WRITEBACK: ${CAPTION_WRITEBACK:-false}
+      IMAGE_SOURCE: ${IMAGE_SOURCE:-preview}
+      MAX_FAILURES_PER_ASSET: ${MAX_FAILURES_PER_ASSET:-2}
+      PROMPT_VERSION: ${PROMPT_VERSION:-v2}
+      # Unlike ${VAR:-default}, ${VAR-default} preserves an explicitly blank
+      # value. Blank means false here, matching the native configuration path.
+      CURATE_BURST_GROUPING: ${CURATE_BURST_GROUPING-true}
+      REFEREE_GROUP_BUDGET_MB: ${REFEREE_GROUP_BUDGET_MB:-96}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       DEFAULT_PROVIDER: ${DEFAULT_PROVIDER:-cloud_openai}
+      CURATE_REFEREE_ENABLED: ${CURATE_REFEREE_ENABLED:-}
+      CURATE_REFEREE_PROVIDER: ${CURATE_REFEREE_PROVIDER:-}
+      CURATE_REFEREE_MODEL: ${CURATE_REFEREE_MODEL:-}
       TTS_PROVIDER: ${TTS_PROVIDER:-}
       STT_PROVIDER: ${STT_PROVIDER:-}
+      OPENAI_TTS_MODEL: ${OPENAI_TTS_MODEL:-}
+      OPENAI_TTS_VOICE: ${OPENAI_TTS_VOICE:-}
+      OPENAI_TTS_SPEED: ${OPENAI_TTS_SPEED:-}
+      OPENAI_TTS_FORMAT: ${OPENAI_TTS_FORMAT:-}
+      OPENAI_TTS_INSTRUCTIONS: ${OPENAI_TTS_INSTRUCTIONS:-}
       ELEVENLABS_API_KEY: ${ELEVENLABS_API_KEY:-}
       ELEVENLABS_VOICE_ID: ${ELEVENLABS_VOICE_ID:-}
+      ELEVENLABS_TTS_MODEL: ${ELEVENLABS_TTS_MODEL:-}
+      ELEVENLABS_OUTPUT_FORMAT: ${ELEVENLABS_OUTPUT_FORMAT:-}
+      ELEVENLABS_REQUEST_TIMEOUT_MS: ${ELEVENLABS_REQUEST_TIMEOUT_MS:-}
       # Spoken voice answers: provider, per-command models, and the interactive
       # deadline. Settings → Voice can set these too.
       VOICE_PROSE_PROVIDER: ${VOICE_PROSE_PROVIDER:-}
       VOICE_INTERESTING_MODEL: ${VOICE_INTERESTING_MODEL:-}
       VOICE_ASK_MODEL: ${VOICE_ASK_MODEL:-}
       VOICE_PROSE_TIMEOUT_MS: ${VOICE_PROSE_TIMEOUT_MS:-}
+      OPENAI_INTERESTING_MODEL: ${OPENAI_INTERESTING_MODEL:-}
+      OPENAI_INTERESTING_IMAGE_DETAIL: ${OPENAI_INTERESTING_IMAGE_DETAIL:-}
+      OPENAI_INTERESTING_MAX_OUTPUT_TOKENS: ${OPENAI_INTERESTING_MAX_OUTPUT_TOKENS:-}
+      OPENAI_ASK_MODEL: ${OPENAI_ASK_MODEL:-}
+      OPENAI_ASK_MAX_OUTPUT_TOKENS: ${OPENAI_ASK_MAX_OUTPUT_TOKENS:-}
+      OPENAI_REQUEST_TIMEOUT_MS: ${OPENAI_REQUEST_TIMEOUT_MS:-}
       # AI provider connections, used by Enrich, the Curate referee and the
       # spoken voice answers alike. Without these a .env-only install can
       # select a provider it then has no way to reach.
@@ -64,8 +90,12 @@ services:
       LMSTUDIO_MODEL: ${LMSTUDIO_MODEL:-}
       LMSTUDIO_BASE_URL: ${LMSTUDIO_BASE_URL:-}
       LMSTUDIO_API_KEY: ${LMSTUDIO_API_KEY:-}
+      LMSTUDIO_MAX_TOKENS: ${LMSTUDIO_MAX_TOKENS:-}
+      LMSTUDIO_TEMPERATURE: ${LMSTUDIO_TEMPERATURE:-}
       GEOCODING_PROVIDER: ${GEOCODING_PROVIDER:-}
       GEOAPIFY_API_KEY: ${GEOAPIFY_API_KEY:-}
+      GEOCODING_TIMEOUT_MS: ${GEOCODING_TIMEOUT_MS:-}
+      GEOCODING_COORDINATE_PRECISION: ${GEOCODING_COORDINATE_PRECISION:-}
     # Using LM Studio on the Docker host for local enrichment? Inside the
     # container 127.0.0.1 is the container itself — set the LM Studio base
     # URL (Settings → AI Providers) to http://host.docker.internal:1234/v1.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -130,6 +130,12 @@ Enrich page; that choice is saved immediately and applies to new runs across
 future visits and server restarts. `DEFAULT_PROVIDER` only seeds the choice
 when no saved UI selection exists, which makes it useful for initial setup and
 infrastructure-as-code deployments rather than as a second day-to-day control.
+The stock Docker Compose file forwards every non-path environment variable in
+this section; values saved in Settings continue to override their environment
+defaults. `TAXONOMY_PATH` and `PROMPTS_DIR` are intentional exceptions: a
+custom container path is meaningless without a matching bind mount, so add
+both the mount and the environment override to Compose when using custom
+files.
 
 | Variable | Default | Notes |
 | --- | --- | --- |
@@ -150,8 +156,8 @@ infrastructure-as-code deployments rather than as a second day-to-day control.
 | `VENICE_API_KEY` / `VENICE_MODEL` / `VENICE_BASE_URL` | — / *(empty — no default)* / `https://api.venice.ai/api/v1` | Key and model live under Settings → AI Providers. **UI**. The model must support vision and structured output; the AI referee additionally needs multi-image input (e.g. `qwen3-vl-235b-a22b`). |
 | `IMAGE_SOURCE` | `preview` | Which Immich rendition is sent to the model (`preview`, `thumbnail`, or `original`). Immich previews are WebP, which LM Studio cannot ingest — on macOS Pictaria converts them automatically; in Docker set this to `original`. **UI** |
 | `MAX_FAILURES_PER_ASSET` | `2` | Give up on an asset after this many failed attempts (per provider + model + prompt + taxonomy setup). `0` disables the limit; raising it above an asset's recorded failures re-attempts it on the next run. Stuck photos can also be retried one run at a time from the Enrich page's **Stuck photos** strip. |
-| `TAXONOMY_PATH` | `taxonomy/v1.json` | The shipped tag taxonomy and review-bucket policy. Editable at runtime in Settings → Enrich (the override lives in the settings store and must bump the taxonomy version). |
-| `PROMPTS_DIR` / `PROMPT_VERSION` | `prompts` / `v2` | Prompt templates for enrichment. The prompt text itself can be overridden in Settings → Enrich (no env var); runs with an override record prompt version `v2-custom`. |
+| `TAXONOMY_PATH` | `taxonomy/v1.json` | The shipped tag taxonomy and review-bucket policy. Editable at runtime in Settings → Enrich (the override lives in the settings store and must bump the taxonomy version). A custom container path requires a matching bind mount and Compose override. |
+| `PROMPTS_DIR` / `PROMPT_VERSION` | `prompts` / `v2` | Prompt templates for enrichment. `PROMPT_VERSION` is forwarded by stock Compose; a custom `PROMPTS_DIR` requires a matching bind mount and Compose override. The prompt text itself can be overridden in Settings → Enrich (no env var); runs with an override record prompt version `v2-custom`. |
 | `CURATE_BURST_GROUPING` | `true` | Collapse same-moment photos (bursts, re-shoots, duplicates) into stacked cards in the Curate queue. Off = flat photo-by-photo queue. **UI** |
 | `CURATE_REFEREE_ENABLED` | `false` | The gold star: an AI model compares each same-moment group side by side and picks the keeper, with a why-line per photo. Runs whenever enrichment is idle; needs `ENRICH_ENABLED`. **UI** |
 | `CURATE_REFEREE_PROVIDER` | *(empty)* | Referee provider; empty = follow the provider currently selected on Enrich. Lives under Settings → Curate. **UI** |

--- a/scripts/check-publication.mjs
+++ b/scripts/check-publication.mjs
@@ -243,6 +243,49 @@ const composeDefault = compose.match(/PICTARIA_IMAGE_TAG:-([^}\s]+)/)?.[1];
 if (!composeDefault || !/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(composeDefault)) {
   throw new Error('docker-compose.yml must default PICTARIA_IMAGE_TAG to an explicit release version.');
 }
+const composeEnvironmentKeys = new Set(
+  [...compose.matchAll(/^\s{6}([A-Z][A-Z0-9_]+):/gm)].map((match) => match[1]),
+);
+const serverConfigSource = readFileSync(resolve(root, 'src/config.mjs'), 'utf8');
+const serverEnvironmentKeys = new Set(
+  [...serverConfigSource.matchAll(/\benv\.([A-Z][A-Z0-9_]*)\b/g)].map((match) => match[1]),
+);
+const providerEnvironmentPrefixes = [
+  // Add a provider's prefix here when its first env-backed configuration is
+  // introduced; prefix-based discovery keeps later knobs self-maintaining.
+  'CURATE_',
+  'ELEVENLABS_',
+  'ENRICH_',
+  'GEOCODING_',
+  'LMSTUDIO_',
+  'OLLAMA_',
+  'OPENAI_',
+  'OPENROUTER_',
+  'VENICE_',
+  'VOICE_',
+];
+const providerEnvironmentNames = new Set([
+  'CAPTION_WRITEBACK',
+  'DEFAULT_PROVIDER',
+  'GEOAPIFY_API_KEY',
+  'IMAGE_SOURCE',
+  'MAX_FAILURES_PER_ASSET',
+  'PROMPT_VERSION',
+  'REFEREE_GROUP_BUDGET_MB',
+  'STT_PROVIDER',
+  'TTS_PROVIDER',
+]);
+const providerEnvironmentKeys = [...serverEnvironmentKeys]
+  .filter((key) => providerEnvironmentNames.has(key)
+    || providerEnvironmentPrefixes.some((prefix) => key.startsWith(prefix)))
+  .sort();
+const missingProviderEnvironmentKeys = providerEnvironmentKeys
+  .filter((key) => !composeEnvironmentKeys.has(key));
+if (missingProviderEnvironmentKeys.length > 0) {
+  throw new Error(
+    `docker-compose.yml must forward every supported AI and enrichment environment variable; missing: ${missingProviderEnvironmentKeys.join(', ')}.`,
+  );
+}
 const configuration = publicGuidance.get('docs/CONFIGURATION.md');
 if (!configuration.includes(`| \`PICTARIA_IMAGE_TAG\` | \`${composeDefault}\` |`)) {
   throw new Error(

--- a/src/config.mjs
+++ b/src/config.mjs
@@ -192,7 +192,7 @@ export function loadConfig(env = process.env) {
         modelName: env.OPENAI_MODEL || 'gpt-5.5',
       },
       local_lmstudio: {
-        apiKey: env.LMSTUDIO_API_KEY ?? 'lm-studio',
+        apiKey: env.LMSTUDIO_API_KEY || 'lm-studio',
         modelName: env.LMSTUDIO_MODEL || '',
         baseUrl: normalizeHttpUrl(env.LMSTUDIO_BASE_URL || 'http://127.0.0.1:1234/v1'),
         // 2400 gives long tag-lists + captions headroom: the 1600 cap was

--- a/test/config.test.mjs
+++ b/test/config.test.mjs
@@ -52,6 +52,29 @@ test('every environment-configurable service base URL rejects query components',
   }
 });
 
+test('empty Compose values preserve native LM Studio defaults', () => {
+  const native = loadConfig({}).providers.local_lmstudio;
+  const composeEmpty = loadConfig({
+    LMSTUDIO_API_KEY: '',
+    LMSTUDIO_MAX_TOKENS: '',
+    LMSTUDIO_TEMPERATURE: '',
+  }).providers.local_lmstudio;
+
+  assert.equal(native.apiKey, 'lm-studio');
+  assert.equal(composeEmpty.apiKey, native.apiKey);
+  assert.equal(composeEmpty.maxTokens, native.maxTokens);
+  assert.equal(composeEmpty.temperature, native.temperature);
+
+  const configured = loadConfig({
+    LMSTUDIO_API_KEY: 'proxy-token',
+    LMSTUDIO_MAX_TOKENS: '4096',
+    LMSTUDIO_TEMPERATURE: '0.7',
+  }).providers.local_lmstudio;
+  assert.equal(configured.apiKey, 'proxy-token');
+  assert.equal(configured.maxTokens, 4096);
+  assert.equal(configured.temperature, 0.7);
+});
+
 test('server auth configuration fails closed unless open mode is explicit', () => {
   for (const env of [{}, { APP_PASSWORD: '' }, { APP_PASSWORD: '', ALLOW_INSECURE_OPEN: 'false' }]) {
     assert.throws(


### PR DESCRIPTION
## Outcome

Stock Docker Compose now honors every documented non-path enrichment, AI-provider, Curate-referee, voice, and geocoding environment variable read by the server. Docker and native installs also keep identical LM Studio defaults when Compose forwards an empty optional value.

## Material changes

- Forward all 19 previously omitted provider-related variables plus all seven safe non-path Enrich controls.
- Keep TAXONOMY_PATH and PROMPTS_DIR as explicit exceptions because custom container paths require matching mounts; document that requirement.
- Derive the protected inventory mechanically from src/config.mjs, including future VOICE_ additions, so matching additions fail publication checks unless Compose forwards them.
- Document that a newly introduced provider must register its prefix with the publication guard.
- Treat an empty LMSTUDIO_API_KEY like an absent value, preserving the native lm-studio default.
- Add regression coverage for empty and explicitly configured LM Studio values.

## Validation

- Full test suite: 975 passed.
- Focused configuration suite: 6 passed.
- Publication hygiene: passed for 238 tracked files.
- All seven non-path Enrich controls mechanically confirmed as both server-read and Compose-forwarded.
- Git diff hygiene: passed.
- Docker is not installed on this laptop; GitHub CI performs the container build and boot smoke test.

## Risk and rollback

Low configuration risk. Defaults preserve existing behavior, and values saved in Settings still override environment defaults. CURATE_BURST_GROUPING deliberately uses Compose default syntax that distinguishes an absent value from an explicitly blank false value, matching native behavior. There is no data migration. Reverting this commit restores the previous Compose behavior.

## Remaining work

None for PIC-104.

Fixes PIC-104

## Authorship and review

Implemented by Codex for the repository owner. Revised in response to independent Linear review.