### PR TITLE
PIC-5: finish public repository hygiene

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,84 @@
+name: Bug report
+description: Report a reproducible problem with Pictaria Server
+title: "[Bug]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve Pictaria Server. Please remove API keys,
+        passwords, private URLs, photo contents, and other personal data from
+        logs before posting them publicly.
+  - type: input
+    id: pictaria-version
+    attributes:
+      label: Pictaria Server version
+      description: Find this in Settings or the authenticated health response.
+      placeholder: "1.0.0"
+    validations:
+      required: true
+  - type: input
+    id: immich-version
+    attributes:
+      label: Immich version
+      placeholder: "3.1.0"
+    validations:
+      required: true
+  - type: dropdown
+    id: installation
+    attributes:
+      label: Installation method
+      options:
+        - Docker Compose
+        - Docker without the supplied Compose file
+        - Bare Node.js
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: platform
+    attributes:
+      label: Host platform
+      description: Operating system, CPU architecture, and relevant NAS or container platform.
+      placeholder: "Ubuntu 24.04, x86_64, Docker 27"
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened?
+      description: Describe the behavior and its impact.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Open ...
+        2. Choose ...
+        3. See ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Relevant sanitized logs or diagnostics
+      description: Include only the smallest useful excerpt. Remove secrets, private URLs, filenames, names, locations, and photo-derived content.
+      render: shell
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues for the same problem.
+          required: true
+        - label: I removed credentials and personal data from everything above.
+          required: true
+        - label: This is not a security vulnerability; security reports follow SECURITY.md instead.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Report a security vulnerability privately
+    url: https://github.com/pictaria-ai/pictaria-server/security/policy
+    about: Follow the security policy instead of opening a public issue.
+  - name: Setup and troubleshooting documentation
+    url: https://github.com/pictaria-ai/pictaria-server/blob/main/docs/GETTING-STARTED.md
+    about: Check installation, permissions, and connection guidance before filing a bug.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Report a security vulnerability privately
     url: https://github.com/pictaria-ai/pictaria-server/security/policy

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,37 @@
+name: Feature request
+description: Suggest a focused improvement to Pictaria Server
+title: "[Feature]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        A concrete problem and desired outcome are more useful than a proposed
+        implementation. Please do not include private photo-library details.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+      description: Explain the workflow or limitation you encounter today.
+    validations:
+      required: true
+  - type: textarea
+    id: outcome
+    attributes:
+      label: What outcome would you like?
+      description: Describe what success looks like without prescribing internal design.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Current workaround or alternatives
+      description: Optional; tell us how you handle this today.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and did not find this request.
+          required: true
+        - label: I removed personal photo-library details and credentials.
+          required: true

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ say" }`. A successful response is the provider's audio payload; the
 - [docs/RUNNING.md](docs/RUNNING.md) — running as a service (launchd, systemd) and uptime monitoring.
 - [docs/UPGRADING.md](docs/UPGRADING.md) — moving an existing install to a newer release, and rolling back.
 - [SECURITY.md](SECURITY.md) — supported versions, security boundaries, and private vulnerability reporting.
+- [SUPPORT.md](SUPPORT.md) — where to ask for help and what diagnostic context is safe to share.
 - [CHANGELOG.md](CHANGELOG.md) — release history.
 
 ## Development

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,10 +2,11 @@
 
 ## Reporting a vulnerability
 
-Please report suspected vulnerabilities privately to
-[security@pictaria.ai](mailto:security@pictaria.ai). When GitHub private
-vulnerability reporting is available for this repository, the private
-reporting form under the Security tab is also a preferred channel.
+Please use this repository's
+[private vulnerability reporting form](https://github.com/pictaria-ai/pictaria-server/security/advisories/new)
+for suspected vulnerabilities. It keeps the report private and gives the
+project an auditable place to investigate and coordinate a fix. You may also
+email [security@pictaria.ai](mailto:security@pictaria.ai).
 
 We aim to acknowledge reports within three business days. Please allow us a
 reasonable opportunity to investigate, coordinate a fix, and agree on a

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,24 @@
+# Support
+
+Pictaria Server is a community-supported self-hosted project. GitHub Issues are
+the right place for reproducible bugs and focused feature requests; support is
+best effort rather than a guaranteed response-time service.
+
+Before filing a bug:
+
+1. Check the [getting-started guide](docs/GETTING-STARTED.md),
+   [running guide](docs/RUNNING.md), and
+   [Immich compatibility guide](docs/IMMICH-COMPATIBILITY.md).
+2. Confirm the problem still occurs on a currently supported Pictaria Server
+   release and include that exact version.
+3. Include the Immich version, installation method, host platform, minimal
+   reproduction steps, and only the smallest useful sanitized log excerpt.
+
+Never post API keys, passwords, private hostnames or URLs, personal filenames,
+photo contents, names, locations, or unredacted diagnostics. If a report may be
+a security vulnerability, do not open a public issue; follow
+[SECURITY.md](SECURITY.md) for private reporting.
+
+General Docker, operating-system, reverse-proxy, VPN, Immich, and model-server
+administration remains the operator's responsibility. Pictaria documentation
+can explain the integration points, but cannot provide platform-wide support.


### PR DESCRIPTION
## Outcome

Completes the remaining practical public-repository hygiene for Pictaria Server.

## Material changes

- Adds structured GitHub issue forms for bug reports and feature requests.
- Adds issue-form links to private security reporting and setup documentation.
- Adds a concise support policy covering best-effort support, useful diagnostic context, privacy, and operator responsibilities.
- Links the support policy from the README documentation index.
- Configures `main` branch protection separately in GitHub: pull requests are required, the four existing CI checks must pass on an up-to-date branch, conversations must be resolved, linear history is required, and force-pushes/deletion are disabled. Approval count remains zero because the project currently uses one GitHub identity; maintainers retain an explicit override path.

## Validation

- Parsed all issue-form YAML successfully.
- `npm run check:publication`
- `git diff --check`

## Risk and rollback

Low risk: the commit changes repository guidance and issue intake only. Revert this commit to remove the files. Branch protection can be adjusted independently in repository settings.

## Remaining work

Social preview artwork and GitHub Discussions remain optional presentation/community features, not release requirements.

Fixes PIC-5

## Authorship and review

Authored with Codex under the repository's DCO requirements. Ready for independent review in Linear and GitHub CI.
