### PR TITLE
PIC-221: add bottom Curate pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to Pictaria Server are documented here. This project follows
 
 ### Fixed
 
+- Curate now offers the same synchronized **Load more** control below the
+  photo grid, so long review sessions do not require scrolling back to the
+  toolbar for another page.
 - Docker Compose now forwards every documented non-path enrichment, AI,
   Curate-referee, voice, and geocoding variable, including LM Studio's token
   cap and temperature. Empty Compose values preserve the same runtime defaults

--- a/public/curate.html
+++ b/public/curate.html
@@ -182,7 +182,7 @@
       <span id="meta" class="p-muted"></span>
       <span id="metaEnrich" style="color: var(--p-danger); font-size: 12px; margin-left: 6px" hidden>Note: Enrich is running — Stacks may change as photos are added.</span>
       <div class="p-grow"></div>
-      <button id="loadMore" class="p-btn">Load more</button>
+      <button id="loadMore" class="p-btn" data-load-more>Load more</button>
     </div>
 
     <div id="refActPop" class="ref-act-pop" hidden>
@@ -195,6 +195,9 @@
       </div>
     </div>
     <section id="grid" class="grid"></section>
+    <div id="loadMoreBottomRow" class="p-row" style="justify-content: center; margin-top: 18px" hidden>
+      <button id="loadMoreBottom" class="p-btn" data-load-more>Load more</button>
+    </div>
   </main>
 
   <div id="bulkbar" class="bulkbar" hidden>

--- a/public/curate.js
+++ b/public/curate.js
@@ -483,6 +483,7 @@ function removeDecided(assetIds) {
   // Keep the queue flowing: when decisions run the loaded list low and the
   // server has more, append the next page before the user reaches the end.
   if (state.assets.length < LOAD_AHEAD && state.offset < state.total) loadAssets(true);
+  updateLoadMoreControls();
 }
 
 function updateBulkbar() {

--- a/public/curate.js
+++ b/public/curate.js
@@ -58,12 +58,12 @@ async function api(path, options = {}) {
 function loadAssets(append = false) {
   if (state.loading) return state.loadingPromise ?? Promise.resolve();
   state.loading = true;
+  updateLoadMoreControls();
   state.loadingPromise = doLoadAssets(append);
   return state.loadingPromise;
 }
 
 async function doLoadAssets(append) {
-  el('loadMore').disabled = true;
   try {
     const params = new URLSearchParams({ view: state.view, q: state.q, offset: String(state.offset), limit: String(state.limit) });
     if (state.group !== 'all' && state.view !== 'decided') params.set('group', state.group);
@@ -106,8 +106,16 @@ async function doLoadAssets(append) {
     toast(error.message, true);
   } finally {
     state.loading = false;
-    el('loadMore').disabled = state.offset >= state.total;
+    updateLoadMoreControls();
   }
+}
+
+function updateLoadMoreControls() {
+  const hasMore = state.offset < state.total;
+  document.querySelectorAll('[data-load-more]').forEach((button) => {
+    button.disabled = state.loading || !hasMore;
+  });
+  el('loadMoreBottomRow').hidden = state.assets.length === 0 || !hasMore;
 }
 
 function renderTabs(payload) {
@@ -1015,7 +1023,9 @@ el('search').addEventListener('input', () => {
   clearTimeout(el('search')._timer);
   el('search')._timer = setTimeout(loadAssetsFresh, 200);
 });
-el('loadMore').addEventListener('click', () => loadAssets(true));
+document.querySelectorAll('[data-load-more]').forEach((button) => {
+  button.addEventListener('click', () => loadAssets(true));
+});
 document.querySelectorAll('#groupFilter .p-tab').forEach((button) => {
   button.addEventListener('click', () => {
     if (state.group === button.dataset.group) return;

--- a/test/browser/smoke.test.mjs
+++ b/test/browser/smoke.test.mjs
@@ -933,6 +933,8 @@ test('admin UI smoke: gate, Insights lens, Curate, Smart Albums', { timeout: 120
       { label: 'empty state renders' },
     );
     assert.match(emptyText, /Queue is empty/);
+    assert.equal(await page.evaluate('document.getElementById("loadMore").disabled'), true);
+    assert.equal(await page.evaluate('document.getElementById("loadMoreBottomRow").hidden'), true);
   });
 
   await t.test('Smart Albums: multi-country album round-trips through the form', async () => {

--- a/test/browser/smoke.test.mjs
+++ b/test/browser/smoke.test.mjs
@@ -856,6 +856,39 @@ test('admin UI smoke: gate, Insights lens, Curate, Smart Albums', { timeout: 120
     );
   });
 
+  await t.test('Curate keeps top and bottom Load more controls synchronized', async () => {
+    await page.navigate(`${server.base}/curate.html?limit=3`);
+    await page.waitFor(
+      'document.querySelectorAll("#grid img").length === 3 && !document.querySelector(".gate-backdrop")',
+      { label: 'first Curate page renders' },
+    );
+
+    const firstPage = await page.evaluate(`(() => ({
+      topDisabled: document.getElementById('loadMore').disabled,
+      bottomDisabled: document.getElementById('loadMoreBottom').disabled,
+      bottomHidden: document.getElementById('loadMoreBottomRow').hidden,
+    }))()`);
+    assert.deepEqual(firstPage, { topDisabled: false, bottomDisabled: false, bottomHidden: false });
+
+    await page.evaluate('document.getElementById("loadMoreBottom").click()');
+    await page.waitFor(
+      'document.querySelectorAll("#grid img").length === 6 && !document.getElementById("loadMore").disabled',
+      { label: 'bottom control appends the second page' },
+    );
+    await page.evaluate('document.getElementById("loadMore").click()');
+    await page.waitFor(
+      'document.querySelectorAll("#grid img").length === 9 && document.getElementById("loadMore").disabled',
+      { label: 'top control appends the final page' },
+    );
+
+    const finalPage = await page.evaluate(`(() => ({
+      topDisabled: document.getElementById('loadMore').disabled,
+      bottomDisabled: document.getElementById('loadMoreBottom').disabled,
+      bottomHidden: document.getElementById('loadMoreBottomRow').hidden,
+    }))()`);
+    assert.deepEqual(finalPage, { topDisabled: true, bottomDisabled: true, bottomHidden: true });
+  });
+
   await t.test('Curate flows across page boundaries: auto-append + lightbox continuity', async () => {
     // A 3-photo page against the 9-photo queue: deciding must auto-append the
     // next page and keep the lightbox open across the boundary. A false "all


### PR DESCRIPTION
## Outcome

Adds a second **Load more** control below the Curate photo grid so long review sessions do not require scrolling back to the toolbar.

## Material changes

- Adds the bottom control after the grid.
- Routes both controls through the same loading action and shared state updater.
- Keeps both disabled while a request is active or when all results are loaded.
- Hides the bottom row when the result is empty or fully loaded.
- Adds browser coverage for first-page, intermediate, and fully-loaded states.
- Records the user-facing fix in the Unreleased changelog.

## Validation

- `npm test` — 978 passed, 0 failed.
- `npm run check:publication`
- `git diff --check`

## Risk and rollback

Low UI risk. Existing pagination behavior and the top control remain intact; the new control shares their code path. Reverting this commit restores the prior single-control presentation.

## Remaining work

None for this issue.

Fixes PIC-221

## Authorship and review

Authored with Codex under the repository's DCO requirements. Ready for independent review in Linear and GitHub CI.
