### PR TITLE
PIC-128: reject caption template leakage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to Pictaria Server are documented here. This project follows
 - Curate now offers the same synchronized **Load more** control below the
   photo grid, so long review sessions do not require scrolling back to the
   toolbar for another page.
+- Enrich rejects caption prompt labels and placeholder text from small vision
+  models instead of storing them as captions, and explicitly tells models to
+  return caption text only.
 - Docker Compose now forwards every documented non-path enrichment, AI,
   Curate-referee, voice, and geocoding variable, including LM Studio's token
   cap and temperature. Empty Compose values preserve the same runtime defaults

--- a/docs/ENRICH.md
+++ b/docs/ENRICH.md
@@ -267,6 +267,12 @@ The schema's fields (also listed with their uses on the Enrich page):
 | `exclusion_reasons` (tag + confidence + reason) | exclusions that keep a photo off the frame |
 | `needs_review` | flags the photo for human review |
 
+Caption values must contain the caption itself, without prompt labels such as
+`Full caption:` or `Short caption:` and without placeholder text such as
+`Full caption here`. Pictaria rejects those small-model template leaks as an
+invalid response, so the normal retry and per-photo failure handling apply
+instead of storing the label as photo metadata.
+
 **What is editable and what is not.** The taxonomy (which tags the model may
 use, thresholds, exclusions) and both prompts are editable in Settings →
 Enrich. The schema's *field list* is fixed: Curate's buckets, the star

--- a/prompts/v2_system.txt
+++ b/prompts/v2_system.txt
@@ -4,7 +4,7 @@ Your job is not to describe every possible detail. Your job is to decide:
 1. Is this image safe and pleasant to show passively on a home photo frame?
 2. Which approved semantic tags apply?
 3. Which exclusion tags apply?
-4. Write the captions. The full caption is two to three sentences, concrete and specific: who is in the photo, where it is, what is happening, and any readable text or signage. It feeds search, so include details someone might later search for. The short caption is a few words for the photo's card label.
+4. Write the captions. The full caption is two to three sentences, concrete and specific: who is in the photo, where it is, what is happening, and any readable text or signage. It feeds search, so include details someone might later search for. The short caption is a few words for the photo's card label. Put only caption text in the JSON fields: never prefix a value with "Full caption:" or "Short caption:", and never return placeholder text such as "Full caption here".
 
 Use only the approved taxonomy provided by the application.
 Return valid JSON only.

--- a/src/enrich/runner.mjs
+++ b/src/enrich/runner.mjs
@@ -66,7 +66,8 @@ const LOCAL_RETRY_SUFFIX =
   '\n\nLocal retry instructions: return only the strongest, clearly visible tags. ' +
   'Use no more than 20 candidate_tags and no more than 6 exclusion_reasons. ' +
   'Do not include weak, speculative, duplicate, or near-duplicate tags. ' +
-  'Keep each reason short.';
+  'Keep each reason short. Return only caption text in caption and short_caption: ' +
+  'do not prefix either value with "Full caption:" or "Short caption:", and do not use caption placeholder text.';
 
 export async function analyzeWithValidationRetry(provider, image, { systemPrompt, userPrompt, jsonSchema, taxonomy, log = () => {} }) {
   const prompts = [userPrompt];

--- a/src/enrich/schema.mjs
+++ b/src/enrich/schema.mjs
@@ -13,6 +13,7 @@ const MAX_SHORT_CAPTION_BYTES = 512;
 const MAX_TEXT_BYTES = 512;
 const MAX_REASON_BYTES = 1024;
 const MAX_LIST_ITEMS = 50;
+const CAPTION_TEMPLATE_LEAK = /^\s*(?:full|short)[ _-]+caption(?:[ _-]+here)?(?:\s*:|\s*[.!]?\s*$)/i;
 
 const REQUIRED_TOP_LEVEL_FIELDS = [
   'caption',
@@ -59,6 +60,8 @@ export function validateAiOutput(output, taxonomy) {
 
   validateString(normalized.caption, 'caption', MAX_CAPTION_BYTES);
   validateString(normalized.short_caption, 'short_caption', MAX_SHORT_CAPTION_BYTES);
+  validateCaptionText(normalized.caption, 'caption');
+  validateCaptionText(normalized.short_caption, 'short_caption');
   validateString(normalized.people_count, 'people_count', MAX_TEXT_BYTES);
 
   for (const field of [
@@ -149,12 +152,13 @@ export function enrichmentJsonSchema(taxonomy) {
         description:
           'Two to three sentences, concrete and specific: who is in the photo, where it is, ' +
           'what is happening, and any readable text or signage. Feeds caption search and photo ' +
-          'descriptions, so include details someone might later search for.',
+          'descriptions, so include details someone might later search for. Return caption text ' +
+          'only, without a Full caption or Short caption label.',
       },
       short_caption: {
         type: 'string',
         maxLength: MAX_SHORT_CAPTION_BYTES,
-        description: 'A few words used as the photo card label.',
+        description: 'A few words used as the photo card label. Return only the label text, without a caption-field prefix.',
       },
       is_photo: { type: 'boolean' },
       is_screenshot: { type: 'boolean' },
@@ -311,6 +315,12 @@ function validateString(value, field, maxBytes) {
   }
   if (Buffer.byteLength(value, 'utf8') > maxBytes) {
     throw new OutputValidationError(`${field} exceeds the ${maxBytes}-byte limit`);
+  }
+}
+
+function validateCaptionText(value, field) {
+  if (CAPTION_TEMPLATE_LEAK.test(value)) {
+    throw new OutputValidationError(`${field} repeats a caption prompt label or placeholder`);
   }
 }
 

--- a/test/enrich/runner.test.mjs
+++ b/test/enrich/runner.test.mjs
@@ -137,6 +137,7 @@ test('lm studio validation failures retry once with the stricter prompt', async 
   assert.equal(retryCount, 1);
   assert.equal(provider.calls.length, 2);
   assert.ok(provider.calls[1].userPrompt.includes('Local retry instructions'));
+  assert.ok(provider.calls[1].userPrompt.includes('do not prefix either value with "Full caption:" or "Short caption:"'));
   assert.equal(normalized.caption, sampleOutput().caption);
 });
 

--- a/test/enrich/schema.test.mjs
+++ b/test/enrich/schema.test.mjs
@@ -12,6 +12,26 @@ test('valid output passes', () => {
   assert.deepEqual(validateAiOutput(output, taxonomy), output);
 });
 
+test('caption prompt labels and placeholders are rejected without blocking ordinary prose', () => {
+  for (const [field, value] of [
+    ['caption', 'Full caption: A mountain lake under a bright sky.'],
+    ['caption', 'Full caption here'],
+    ['short_caption', 'Short caption: Mountain lake'],
+    ['short_caption', 'short_caption_here.'],
+  ]) {
+    const output = sampleOutput();
+    output[field] = value;
+    assert.throws(
+      () => validateAiOutput(output, taxonomy),
+      new RegExp(`${field} repeats a caption prompt label or placeholder`),
+    );
+  }
+
+  const ordinary = sampleOutput();
+  ordinary.caption = 'A printed sign explains where the full caption belongs in the exhibit.';
+  assert.deepEqual(validateAiOutput(ordinary, taxonomy), ordinary);
+});
+
 test('unknown tag fails', () => {
   const output = sampleOutput();
   output.candidate_tags.push({ tag: 'mountains', confidence: 0.9, reason: 'Bad free-form tag.' });


### PR DESCRIPTION
## Outcome

Prevents small vision models from storing caption prompt labels or literal placeholders as photo captions.

## Material changes

- Rejects caption values beginning with variants of `Full caption` or `Short caption`, including the observed `Full caption here` placeholder.
- Applies the check to both full and short caption fields after their existing type and size checks.
- Explicitly tells models in the shipped v2 prompt and structured-output descriptions to return caption text only.
- Keeps the match anchored and narrow so ordinary prose mentioning a “full caption” remains valid.
- Documents the validation and normal retry behavior and records the fix in the Unreleased changelog.
- Adds regressions for the observed label, placeholder, separator variants, and a legitimate non-prefix phrase.

## Validation

- `npm test` — 978 passed, 0 failed.
- Focused schema suite — 9 passed, 0 failed.
- `npm run check:publication`
- `git diff --check`

## Risk and rollback

Low and bounded. A model response matching the narrow prefix is retried through the existing invalid-output path rather than persisted. Reverting this commit restores the former permissive behavior.

## Remaining work

Previously written bad captions can self-heal when those photos are re-enriched; this change does not rewrite historical descriptions automatically.

Fixes PIC-128

## Authorship and review

Authored with Codex under the repository's DCO requirements. Ready for independent review in Linear and GitHub CI.
