### PR TITLE
PIC-45: prepare Pictaria Server 1.0.1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,8 +33,8 @@ ALLOW_INSECURE_OPEN=false
 # ---- Server ----
 # Container image selected by docker-compose.yml. Tagged release files default
 # to their matching versioned image tag; image tags omit the `v` used by Git
-# release refs (`1.0.0` versus `v1.0.0`). Set this only for deliberate testing.
-#PICTARIA_IMAGE_TAG=1.0.0
+# release refs (`1.0.1` versus `v1.0.1`). Set this only for deliberate testing.
+#PICTARIA_IMAGE_TAG=1.0.1
 #HOST=0.0.0.0
 #PORT=4080
 #REQUEST_TIMEOUT_MS=60000

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
     attributes:
       label: Pictaria Server version
       description: Find this in Settings or the authenticated health response.
-      placeholder: "1.0.0"
+      placeholder: "1.0.1"
     validations:
       required: true
   - type: input

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@ All notable changes to Pictaria Server are documented here. This project follows
 
 ## 1.0.1 - 2026-09-01
 
-### Fixed
+### Changed
 
 - Curate now offers the same synchronized **Load more** control below the
   photo grid, so long review sessions do not require scrolling back to the
   toolbar for another page.
+
+### Fixed
+
 - Enrich rejects caption prompt labels and placeholder text from small vision
   models instead of storing them as captions, and explicitly tells models to
   return caption text only.
@@ -52,6 +55,10 @@ All notable changes to Pictaria Server are documented here. This project follows
 - Persisted-state contracts, the Frame protocol, Node requirements, and the
   Immich 2.0+ compatibility floor are unchanged from 1.0.0. This is a
   code-only update with no startup migration.
+- Docker Compose installations should review their `.env` before upgrading.
+  Documented non-path settings that earlier Compose files did not forward now
+  take effect when configured, including enrichment limits, AI model and
+  timeout overrides, and geocoding timeouts.
 
 ## 1.0.0 - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to Pictaria Server are documented here. This project follows
 
 ## Unreleased
 
+## 1.0.1 - 2026-09-01
+
 ### Fixed
 
 - Curate now offers the same synchronized **Load more** control below the
@@ -44,6 +46,12 @@ All notable changes to Pictaria Server are documented here. This project follows
 - LM Studio-compatible local requests use a fresh HTTP connection for each
   generation, avoiding `socket hang up` failures when llama.cpp closes a
   completed connection before Pictaria's stricter validation retry.
+
+### Compatibility
+
+- Persisted-state contracts, the Frame protocol, Node requirements, and the
+  Immich 2.0+ compatibility floor are unchanged from 1.0.0. This is a
+  code-only update with no startup migration.
 
 ## 1.0.0 - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Pictaria Server are documented here. This project follows
 
 ## Unreleased
 
-## 1.0.1 - 2026-09-01
+## 1.0.1 - 2026-09-02
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Production installs should select an explicit reviewed release. The source
 tag and matching versioned GHCR image keep the deployment inputs aligned.
 
 ```sh
-PICTARIA_RELEASE=v1.0.0 # replace with the release you are installing
+PICTARIA_RELEASE=v1.0.1 # replace with the release you are installing
 mkdir pictaria-server && cd pictaria-server
 curl -fsSLO \
   "https://raw.githubusercontent.com/pictaria-ai/pictaria-server/${PICTARIA_RELEASE}/docker-compose.yml"
@@ -80,7 +80,7 @@ and its online-backup API; earlier builds fail at boot — `engines` says
 newer supported versions work as well.
 
 ```sh
-PICTARIA_RELEASE=v1.0.0 # replace with the release you are installing
+PICTARIA_RELEASE=v1.0.1 # replace with the release you are installing
 git clone --branch "$PICTARIA_RELEASE" --depth 1 \
   https://github.com/pictaria-ai/pictaria-server.git
 cd pictaria-server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     # Release files default to their matching versioned image tag. A tag is a
     # release name, not a cryptographic digest. Set PICTARIA_IMAGE_TAG only
     # when deliberately testing another published tag.
-    image: ghcr.io/pictaria-ai/pictaria-server:${PICTARIA_IMAGE_TAG:-1.0.0}
+    image: ghcr.io/pictaria-ai/pictaria-server:${PICTARIA_IMAGE_TAG:-1.0.1}
     build: .
     container_name: pictaria
     restart: unless-stopped

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -36,7 +36,7 @@ deliberately testing another published tag.
 
 | Variable | Default | Notes |
 | --- | --- | --- |
-| `PICTARIA_IMAGE_TAG` | `1.0.0` | Published container image tag selected by `docker-compose.yml`. Image tags omit the `v` used by Git release refs (`1.0.0` versus `v1.0.0`). |
+| `PICTARIA_IMAGE_TAG` | `1.0.1` | Published container image tag selected by `docker-compose.yml`. Image tags omit the `v` used by Git release refs (`1.0.1` versus `v1.0.1`). |
 
 ## Required
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -24,7 +24,7 @@ upgrade.
 ## Upgrade — Docker
 
 ```sh
-PICTARIA_RELEASE=v1.0.0 # replace with the release you are installing
+PICTARIA_RELEASE=v1.0.1 # replace with the release you are installing
 curl -fsSL -o docker-compose.release.yml \
   "https://raw.githubusercontent.com/pictaria-ai/pictaria-server/${PICTARIA_RELEASE}/docker-compose.yml"
 diff -u docker-compose.yml docker-compose.release.yml
@@ -45,7 +45,7 @@ docker compose -f docker-compose.release.yml config --images
 ```
 
 The printed image must end in the numeric image version corresponding to the
-source release you selected (`v1.0.0` uses image tag `1.0.0`). Next, make a
+source release you selected (`v1.0.1` uses image tag `1.0.1`). Next, make a
 rollback definition from the currently running Compose file. It should already
 resolve to the version you noted under Settings → Server; verify it before
 replacing the active definition:
@@ -72,7 +72,7 @@ test -z "$(git status --porcelain)" || {
   echo "Stop: preserve or reconcile local changes before upgrading."
   exit 1
 }
-PICTARIA_RELEASE=v1.0.0 # replace with the release you are installing
+PICTARIA_RELEASE=v1.0.1 # replace with the release you are installing
 git fetch --tags --prune
 git switch --detach "$PICTARIA_RELEASE"
 docker compose up -d --build
@@ -97,7 +97,7 @@ test -z "$(git status --porcelain)" || {
   echo "Stop: preserve or reconcile local changes before upgrading."
   exit 1
 }
-PICTARIA_RELEASE=v1.0.0 # replace with the release you are installing
+PICTARIA_RELEASE=v1.0.1 # replace with the release you are installing
 git fetch --tags --prune
 git switch --detach "$PICTARIA_RELEASE"
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pictaria-server",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",


### PR DESCRIPTION
## Outcome

Prepares the reviewed Pictaria Server 1.0.1 release candidate without publishing or tagging it.

## Material changes

- Bumps the server package and default Compose image from 1.0.0 to 1.0.1.
- Finalizes the accumulated Unreleased fixes under `1.0.1 - 2026-09-02`.
- Records that 1.0.1 has no persisted-state migration and does not change the Frame protocol, Node requirement, or Immich compatibility floor.
- Aligns the Docker and bare-Node quick starts, `.env.example`, configuration reference, and upgrade examples with `v1.0.1` / image tag `1.0.1`.

## Included fixes

- Oversized unused Immich EXIF fields no longer stop Insights.
- Crowd photos above the relationship cap remain usable in Insights.
- Immich tag-repair failures carry actionable diagnostics.
- Curate verifies both sides of tag decisions.
- OpenRouter Gemini schema compatibility and safer diagnostics.
- LM Studio reasoning-channel schema recovery.
- LM Studio-compatible local requests avoid stale keep-alive socket resets.
- Complete Compose forwarding for documented AI/enrichment variables.
- Bottom-of-grid Curate pagination.
- Caption-template leakage prevention and targeted local retry guidance.

Repository-hygiene changes are already live on `main` but do not affect the container payload.

## Validation

- `npm test` — 980 passed, 0 failed.
- `npm run check:publication` — passed for 242 tracked files.
- `git diff --check` — passed.
- Required GitHub CI passed on the rehearsed runtime candidate and is rerunning after the release-date-only commit.
- Only the historical wake-word availability note retains a non-test `1.0.0` reference.

## Upgrade and rollback rehearsal

Candidate `1b6885c` was built on Ubuntu x86-64 and exercised against an established v1.0.0 installation with a named data volume and complete off-volume backup. The full v1.0.0 → v1.0.1 candidate → v1.0.0 rollback → v1.0.1 candidate sequence passed. Health, authenticated version reporting, Immich connectivity and permissions, settings checksum, Insights counts, enrichment history, Curate state, and browser checks remained correct. No pre-migration snapshot appeared and no restore was required.

The final source candidate `0ea78c2` differs only by correcting the changelog release date from September 1 to September 2; no runtime rehearsal repetition is warranted.

A first build attempt failed before application startup because the guarded rehearsal wrapper cloned source files under mode 0600. No application state was touched; correcting the test harness file modes and rerunning the complete sequence succeeded.

## Risk and rollback

This is a code-only patch release with no startup migration. The documented version-pinned rollback procedure was exercised successfully and remains the recovery path.

## Remaining work

- Final review and approval of this release-preparation PR.
- Merge, create `v1.0.1`, let the tag workflow publish the multi-platform image, create the GitHub Release with the recorded digest, and smoke-test the public artifact.

Refs PIC-45
Refs PIC-302
Refs PIC-318

## Authorship and review

Authored with Codex under the repository DCO requirements. Independently reviewed in Linear; final release approval remains with the owner.