### PR TITLE
PIC-318: prevent LM Studio-compatible socket hang ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ All notable changes to Pictaria Server are documented here. This project follows
   local validation. OpenRouter failures now expose bounded, credential-redacted
   provider and structured upstream error details; empty responses expose
   request and finish metadata instead of a context-free error.
+- LM Studio-compatible local requests use a fresh HTTP connection for each
+  generation, avoiding `socket hang up` failures when llama.cpp closes a
+  completed connection before Pictaria's stricter validation retry.
 
 ## 1.0.0 - 2026-08-28
 

--- a/src/enrich/providers.mjs
+++ b/src/enrich/providers.mjs
@@ -784,6 +784,15 @@ function nodePostJson(provider, url, headers, payload) {
   return new Promise((resolve, reject) => {
     const target = new URL(url);
     const makeRequest = target.protocol === 'https:' ? httpsRequest : httpRequest;
+    // LM Studio's OpenAI-compatible surface can also reach lightweight local
+    // servers such as llama.cpp, some of which close a completed keep-alive
+    // connection just as the stricter validation retry
+    // begins, so Node's global Agent can reuse a socket that is already being
+    // torn down and report ECONNRESET / "socket hang up". A model generation
+    // takes orders of magnitude longer than a TCP handshake; isolate these
+    // requests instead of retrying a POST that may already have consumed
+    // inference work upstream.
+    const isolateConnection = provider.providerName === 'local_lmstudio';
     const chunks = [];
     const fail = (reason, { timeout = false } = {}) => reject(
       new ProviderRequestError(
@@ -795,7 +804,11 @@ function nodePostJson(provider, url, headers, payload) {
     // 'error' event is reported as a timeout rather than a generic
     // transport failure.
     let timedOut = false;
-    const request = makeRequest(target, { method: 'POST', headers }, (response) => {
+    const request = makeRequest(target, {
+      method: 'POST',
+      headers,
+      ...(isolateConnection ? { agent: false } : {}),
+    }, (response) => {
       let received = 0;
       response.on('data', (chunk) => {
         received += chunk.length;

--- a/test/enrich/providers.test.mjs
+++ b/test/enrich/providers.test.mjs
@@ -590,6 +590,37 @@ test('missing message content raises a clear error', async () => {
   await assert.rejects(() => provider.analyzeImage(image, prompts), /did not include message content/);
 });
 
+test('lm studio node transport isolates consecutive requests from stale keep-alive sockets', async () => {
+  let connectionCount = 0;
+  const connectionHeaders = [];
+  const server = createServer((request, response) => {
+    request.resume();
+    connectionHeaders.push(request.headers.connection);
+    response.writeHead(200, { 'content-type': 'application/json' });
+    response.end(JSON.stringify({ choices: [{ message: { content: '{"caption":"Lake"}' } }] }));
+  });
+  server.on('connection', () => {
+    connectionCount += 1;
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+  const provider = new LmStudioProvider({
+    modelName: 'm',
+    baseUrl: `http://127.0.0.1:${server.address().port}/v1`,
+  });
+
+  try {
+    await provider.analyzeImage(image, prompts);
+    await provider.analyzeImage(image, prompts);
+
+    assert.equal(connectionCount, 2);
+    assert.deepEqual(connectionHeaders, ['close', 'close']);
+  } finally {
+    server.closeAllConnections?.();
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
 test('node transport caps a runaway provider response body', async () => {
   // Streams far past the 2MB cap; the client must abort mid-body instead of
   // accumulating chunks without bound.


### PR DESCRIPTION
## Outcome

Prevents consecutive LM Studio-compatible generations from failing with a socket hang up when a lightweight local server such as llama.cpp closes a completed keep-alive connection as Pictaria begins its stricter validation retry.

## Changes

- Give each LM Studio-compatible node HTTP request a fresh, isolated connection.
- Preserve the existing five-minute provider deadline and response-size cap.
- Leave OpenAI, OpenRouter, Venice, and Ollama transport behavior unchanged.
- Add regression coverage proving consecutive LM Studio-compatible requests use separate connections.
- Record the user-facing fix in the changelog.

## Validation

- Focused provider suite: 33 passed.
- Full server suite: 980 passed, 0 failed.
- Publication hygiene: passed for 242 tracked files.
- Git diff whitespace check: passed.

## Risk and rollback

The tradeoff is one additional local TCP handshake per LM Studio-compatible generation, negligible beside model inference time. The change avoids automatic POST retries that could duplicate expensive inference. Rollback is a normal revert of commit 5e301c5; no persisted state, migration, configuration, or protocol changes are involved.

## Remaining work

Merge after review, incorporate this commit into the 1.0.1 release candidate, and ask the reporter to verify with llama.cpp after the release is available.

Related to PIC-318
Related to #19

Implemented by Codex under owner direction; independent review is pending in Linear.