### PR TITLE
PIC-121: Add transient Curate undo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to Pictaria Server are documented here. This project follows
   chat-completions servers using a configurable base URL, model, and optional
   bearer key. It uses portable JSON-object output and keeps Pictaria's full
   local response validation.
+- Curate decision confirmations now offer a five-second **Undo (Z)** action
+  for individual photos and whole Stacks, returning the most recently decided
+  photos to the queue without interrupting the review flow.
 
 ### Changed
 

--- a/docs/ENRICH.md
+++ b/docs/ENRICH.md
@@ -564,6 +564,13 @@ Human decisions always win for display eligibility; buckets only organize the
 queue. Decisions are recorded locally first (source of truth), then pushed to
 Immich by the sync worker.
 
+After a single-photo or Stack decision, the confirmation at the bottom of
+Curate offers **Undo (Z)** for five seconds. The decision still applies and
+the queue advances immediately; selecting Undo, or pressing `Z`, clears that
+most recent decision and returns the affected photo or whole Stack to the
+queue. A newer decision replaces the pending Undo. The multi-select bulk bar
+keeps its existing deliberate recovery path through the Decided tab.
+
 ### Stacks and the AI referee
 
 Photos of the **same moment** are grouped by three signals: capture time

--- a/public/curate.html
+++ b/public/curate.html
@@ -259,7 +259,10 @@
     </div>
   </div>
 
-  <div id="toast" class="p-toast"></div>
+  <div id="toast" class="p-toast">
+    <span id="toastMessage" aria-live="polite"></span>
+    <button id="toastUndo" class="p-btn quiet toast-undo" type="button" hidden>Undo (Z)</button>
+  </div>
   <script src="/curate.js"></script>
 </body>
 </html>

--- a/public/curate.js
+++ b/public/curate.js
@@ -104,7 +104,9 @@ async function doLoadAssets(append) {
     // Stacks/singles passes don't apply to the decided list.
     el('groupFilter').hidden = state.view === 'decided';
   } catch (error) {
-    toast(error.message, true);
+    // A low-water append can fail after the decision itself succeeded. Keep
+    // that decision's short Undo window alive while reporting the load error.
+    toast(error.message, true, { preserveUndo: true });
   } finally {
     state.loading = false;
     updateLoadMoreControls();
@@ -523,10 +525,21 @@ function restoreUndecided(undo) {
   state.total = Math.max(state.assets.length, state.total + restored);
   state.offset = state.assets.length;
   const active = tabs.querySelector('.p-tab.active .count');
-  if (active) active.textContent = String(state.total);
+  // Tabs show the whole bucket while state.total follows the current search.
+  // Mirror removeDecided's relative adjustment instead of replacing the
+  // bucket count with a filtered result count.
+  if (active) active.textContent = String(Number(active.textContent) + restored);
   renderGrid();
   updateBulkbar();
   if (state.compareBurstId) renderBurstbox();
+  // A lightbox decision advances to the next row. Reinserting the undone
+  // photo before that row changes the meaning of lightboxIndex, so reopen the
+  // restored photo before another shortcut can act on the wrong asset.
+  if (state.lightboxIndex !== -1) {
+    const restoredId = undo.removed[0]?.asset.assetId;
+    const restoredIndex = state.assets.findIndex((asset) => asset.assetId === restoredId);
+    if (restoredIndex !== -1) openLightbox(restoredIndex);
+  }
   updateLoadMoreControls();
   return Promise.resolve();
 }
@@ -1201,6 +1214,7 @@ document.addEventListener('keydown', (event) => {
 let toastTimer = null;
 let toastGeneration = 0;
 let pendingUndo = null;
+let pendingUndoUntil = 0;
 
 function dismissToast() {
   toastGeneration += 1;
@@ -1210,34 +1224,44 @@ function dismissToast() {
   el('toastUndo').hidden = true;
   el('toastUndo').disabled = false;
   pendingUndo = null;
+  pendingUndoUntil = 0;
 }
 
 function showUndoingToast() {
   toastGeneration += 1;
   clearTimeout(toastTimer);
   pendingUndo = null;
+  pendingUndoUntil = 0;
   el('toastMessage').textContent = 'Undoing…';
   el('toastUndo').hidden = true;
   el('toast').className = 'p-toast visible';
 }
 
-function toast(message, isError = false, { undo = null, durationMs = 2400 } = {}) {
+function toast(message, isError = false, { undo = null, durationMs = 2400, preserveUndo = false } = {}) {
+  const now = Date.now();
+  const retainedUndo = preserveUndo && pendingUndoUntil > now ? pendingUndo : null;
+  const nextUndo = undo ?? retainedUndo;
+  const nextDurationMs = retainedUndo && !undo
+    ? Math.max(1, pendingUndoUntil - now)
+    : durationMs;
   const generation = ++toastGeneration;
   const node = el('toast');
   el('toastMessage').textContent = message;
   const undoButton = el('toastUndo');
-  undoButton.hidden = !undo;
+  undoButton.hidden = !nextUndo;
   undoButton.disabled = false;
-  pendingUndo = undo;
+  pendingUndo = nextUndo;
+  pendingUndoUntil = nextUndo ? now + nextDurationMs : 0;
   node.className = `p-toast visible ${isError ? 'error' : ''}`;
-  node.classList.toggle('undoable', Boolean(undo));
+  node.classList.toggle('undoable', Boolean(nextUndo));
   clearTimeout(toastTimer);
   toastTimer = setTimeout(() => {
     if (generation !== toastGeneration) return;
     node.classList.remove('visible', 'undoable');
     undoButton.hidden = true;
     pendingUndo = null;
-  }, durationMs);
+    pendingUndoUntil = 0;
+  }, nextDurationMs);
 }
 
 el('toastUndo').addEventListener('click', undoLastDecision);

--- a/public/curate.js
+++ b/public/curate.js
@@ -25,6 +25,7 @@ const state = {
 // runs below it and the server has more, the next page appends by itself —
 // no "Load more" click, no lightbox dead-end mid-queue.
 const LOAD_AHEAD = 25;
+const UNDO_WINDOW_MS = 5000;
 
 // Page-size override for tests and power users: /curate.html?limit=5.
 {
@@ -435,19 +436,57 @@ async function keepBest(asset) {
   const best = asset.burstBestAssetId;
   const rest = (asset.burstAssetIds ?? []).filter((id) => id !== best && live.has(id));
   if (!best || !live.has(best) || rest.length === 0) return;
+  const assetIds = [best, ...rest];
+  const decision = beginDecision(assetIds, true);
   try {
     await api('/api/review/decision', { method: 'POST', body: JSON.stringify({ action: 'approve', asset_ids: [best] }) });
     const payload = await api('/api/review/decision', { method: 'POST', body: JSON.stringify({ action: 'reviewed', asset_ids: rest }) });
-    removeDecided([best, ...rest]);
+    removeDecided(assetIds);
     renderSync(payload.sync);
-    toast(`kept ★, skipped ${rest.length}`);
+    showDecisionToast(`kept ★, skipped ${rest.length}`, decision);
   } catch (error) {
-    toast(error.message, true);
+    showDecisionError(error, decision);
   }
 }
 
 // ---------- Decisions ----------
-async function decide(action, assetIds) {
+let decisionGeneration = 0;
+
+function snapshotForUndo(assetIds) {
+  if (state.view === 'decided') return null;
+  const ids = [...new Set(assetIds)];
+  const wanted = new Set(ids);
+  const removed = state.assets.flatMap((asset, index) =>
+    wanted.has(asset.assetId) ? [{ asset, index }] : []);
+  if (removed.length !== ids.length) return null;
+  return {
+    assetIds: ids,
+    removed,
+    context: { view: state.view, q: state.q, group: state.group },
+  };
+}
+
+function beginDecision(assetIds, undoable) {
+  const generation = ++decisionGeneration;
+  dismissToast();
+  return {
+    generation,
+    undo: undoable ? snapshotForUndo(assetIds) : null,
+  };
+}
+
+function showDecisionToast(message, decision) {
+  if (decision.generation !== decisionGeneration) return;
+  toast(message, false, decision.undo ? { undo: decision.undo, durationMs: UNDO_WINDOW_MS } : undefined);
+}
+
+function showDecisionError(error, decision) {
+  if (decision.generation !== decisionGeneration) return;
+  toast(error?.message || String(error), true);
+}
+
+async function decide(action, assetIds, { undoable = true } = {}) {
+  const decision = beginDecision(assetIds, undoable);
   try {
     const payload = await api('/api/review/decision', { method: 'POST', body: JSON.stringify({ action, asset_ids: assetIds }) });
     if (state.view === 'decided') {
@@ -457,9 +496,60 @@ async function decide(action, assetIds) {
       removeDecided(assetIds);
     }
     renderSync(payload.sync);
-    toast(`${action}: ${assetIds.length} photo${assetIds.length === 1 ? '' : 's'}`);
+    showDecisionToast(`${action}: ${assetIds.length} photo${assetIds.length === 1 ? '' : 's'}`, decision);
   } catch (error) {
-    toast(error.message, true);
+    showDecisionError(error, decision);
+  }
+}
+
+function restoreUndecided(undo) {
+  for (const id of undo.assetIds) state.recentlyDecided.delete(id);
+  const sameContext = state.view === undo.context.view
+    && state.q === undo.context.q
+    && state.group === undo.context.group;
+  // If the user changed context or deliberately started another load while
+  // Undo was crossing the network, refresh from the authoritative list. The
+  // ordinary path below preserves the user's exact place in a long queue.
+  if (!sameContext || state.loading) return loadAssetsFresh();
+
+  const present = new Set(state.assets.map((asset) => asset.assetId));
+  let restored = 0;
+  for (const { asset, index } of undo.removed) {
+    if (present.has(asset.assetId)) continue;
+    state.assets.splice(Math.min(index, state.assets.length), 0, asset);
+    present.add(asset.assetId);
+    restored += 1;
+  }
+  state.total = Math.max(state.assets.length, state.total + restored);
+  state.offset = state.assets.length;
+  const active = tabs.querySelector('.p-tab.active .count');
+  if (active) active.textContent = String(state.total);
+  renderGrid();
+  updateBulkbar();
+  if (state.compareBurstId) renderBurstbox();
+  updateLoadMoreControls();
+  return Promise.resolve();
+}
+
+async function undoLastDecision() {
+  const undo = pendingUndo;
+  if (!undo) return;
+  const generation = ++decisionGeneration;
+  showUndoingToast();
+  try {
+    // removeDecided can start a low-water append. Let any request made while
+    // the decision was still applied settle before clearing it, so a stale
+    // count cannot overwrite the restored queue moments later.
+    while (state.loading) await state.loadingPromise;
+    const payload = await api('/api/review/decision', {
+      method: 'POST',
+      body: JSON.stringify({ action: 'clear', asset_ids: undo.assetIds }),
+    });
+    await restoreUndecided(undo);
+    renderSync(payload.sync);
+    if (generation === decisionGeneration) toast('Decision undone');
+  } catch (error) {
+    if (generation === decisionGeneration) toast(`Couldn’t undo: ${error?.message || String(error)}`, true);
   }
 }
 
@@ -1013,9 +1103,10 @@ function renderSync(sync) {
   }
 }
 
-function loadAssetsFresh() {
+async function loadAssetsFresh() {
+  while (state.loading) await state.loadingPromise;
   state.offset = 0;
-  loadAssets(false);
+  return loadAssets(false);
 }
 
 // ---------- Wiring ----------
@@ -1045,7 +1136,7 @@ el('selectVisible').addEventListener('change', () => {
   updateBulkbar();
 });
 document.querySelectorAll('[data-bulk]').forEach((button) => {
-  button.addEventListener('click', () => decide(button.dataset.bulk, [...state.selected]));
+  button.addEventListener('click', () => decide(button.dataset.bulk, [...state.selected], { undoable: false }));
 });
 function setConnected(connected) {
   el('connStatus').hidden = !connected;
@@ -1072,7 +1163,15 @@ el('burstbox').addEventListener('click', (event) => {
 });
 
 document.addEventListener('keydown', (event) => {
-  if (event.target.tagName === 'INPUT') return;
+  if (event.target.closest?.('input, textarea, select, [contenteditable="true"]')) return;
+  if (
+    event.key.toLowerCase() === 'z' && pendingUndo
+    && !event.metaKey && !event.ctrlKey && !event.altKey
+  ) {
+    event.preventDefault();
+    undoLastDecision();
+    return;
+  }
   if (event.key === 'Escape') {
     // Innermost layer first: lightbox above compare view above the grid.
     if (state.lightboxIndex !== -1) closeLightbox();
@@ -1100,13 +1199,48 @@ document.addEventListener('keydown', (event) => {
 });
 
 let toastTimer = null;
-function toast(message, isError = false) {
-  const node = el('toast');
-  node.textContent = message;
-  node.className = `p-toast visible ${isError ? 'error' : ''}`;
+let toastGeneration = 0;
+let pendingUndo = null;
+
+function dismissToast() {
+  toastGeneration += 1;
   clearTimeout(toastTimer);
-  toastTimer = setTimeout(() => node.classList.remove('visible'), 2400);
+  const node = el('toast');
+  node.classList.remove('visible', 'undoable', 'error');
+  el('toastUndo').hidden = true;
+  el('toastUndo').disabled = false;
+  pendingUndo = null;
 }
+
+function showUndoingToast() {
+  toastGeneration += 1;
+  clearTimeout(toastTimer);
+  pendingUndo = null;
+  el('toastMessage').textContent = 'Undoing…';
+  el('toastUndo').hidden = true;
+  el('toast').className = 'p-toast visible';
+}
+
+function toast(message, isError = false, { undo = null, durationMs = 2400 } = {}) {
+  const generation = ++toastGeneration;
+  const node = el('toast');
+  el('toastMessage').textContent = message;
+  const undoButton = el('toastUndo');
+  undoButton.hidden = !undo;
+  undoButton.disabled = false;
+  pendingUndo = undo;
+  node.className = `p-toast visible ${isError ? 'error' : ''}`;
+  node.classList.toggle('undoable', Boolean(undo));
+  clearTimeout(toastTimer);
+  toastTimer = setTimeout(() => {
+    if (generation !== toastGeneration) return;
+    node.classList.remove('visible', 'undoable');
+    undoButton.hidden = true;
+    pendingUndo = null;
+  }, durationMs);
+}
+
+el('toastUndo').addEventListener('click', undoLastDecision);
 
 function escapeHtml(value) {
   return String(value ?? '').replace(/[&<>"']/g, (ch) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[ch]));

--- a/public/curate.js
+++ b/public/curate.js
@@ -454,7 +454,7 @@ async function keepBest(asset) {
 // ---------- Decisions ----------
 let decisionGeneration = 0;
 
-function snapshotForUndo(assetIds) {
+function snapshotForUndo(assetIds, { returnToLightboxId = null } = {}) {
   if (state.view === 'decided') return null;
   const ids = [...new Set(assetIds)];
   const wanted = new Set(ids);
@@ -465,15 +465,16 @@ function snapshotForUndo(assetIds) {
     assetIds: ids,
     removed,
     context: { view: state.view, q: state.q, group: state.group },
+    returnToLightboxId,
   };
 }
 
-function beginDecision(assetIds, undoable) {
+function beginDecision(assetIds, undoable, options = {}) {
   const generation = ++decisionGeneration;
   dismissToast();
   return {
     generation,
-    undo: undoable ? snapshotForUndo(assetIds) : null,
+    undo: undoable ? snapshotForUndo(assetIds, options) : null,
   };
 }
 
@@ -487,8 +488,8 @@ function showDecisionError(error, decision) {
   toast(error?.message || String(error), true);
 }
 
-async function decide(action, assetIds, { undoable = true } = {}) {
-  const decision = beginDecision(assetIds, undoable);
+async function decide(action, assetIds, { undoable = true, returnToLightboxId = null } = {}) {
+  const decision = beginDecision(assetIds, undoable, { returnToLightboxId });
   try {
     const payload = await api('/api/review/decision', { method: 'POST', body: JSON.stringify({ action, asset_ids: assetIds }) });
     if (state.view === 'decided') {
@@ -531,12 +532,21 @@ function restoreUndecided(undo) {
   if (active) active.textContent = String(Number(active.textContent) + restored);
   renderGrid();
   updateBulkbar();
-  if (state.compareBurstId) renderBurstbox();
-  // A lightbox decision advances to the next row. Reinserting the undone
-  // photo before that row changes the meaning of lightboxIndex, so reopen the
-  // restored photo before another shortcut can act on the wrong asset.
-  if (state.lightboxIndex !== -1) {
-    const restoredId = undo.removed[0]?.asset.assetId;
+  // A standalone lightbox can advance directly into a Stack, which closes it
+  // and opens compare. Undo is a rewind: leave that auto-opened Stack and
+  // return to the exact photo where the decision began. Stack-wide decisions
+  // do not set this marker, so their Undo still restores the card in place.
+  if (undo.returnToLightboxId) {
+    if (state.compareBurstId) closeBurstbox();
+    const restoredIndex = state.assets.findIndex((asset) => asset.assetId === undo.returnToLightboxId);
+    if (restoredIndex !== -1) openLightbox(restoredIndex);
+  } else {
+    if (state.compareBurstId) renderBurstbox();
+    // A lightbox decision normally advances to the next row. Reinserting the
+    // undone photo before that row changes the meaning of lightboxIndex, so
+    // reopen the restored photo before another shortcut can act on the wrong
+    // asset.
+    const restoredId = state.lightboxIndex !== -1 ? undo.removed[0]?.asset.assetId : null;
     const restoredIndex = state.assets.findIndex((asset) => asset.assetId === restoredId);
     if (restoredIndex !== -1) openLightbox(restoredIndex);
   }
@@ -685,7 +695,11 @@ function lightboxDecide(action) {
   // lbBurst scoping note in openLightbox).
   const ids = el('lbBurstApply').checked && asset.burstAssetIds ? undecidedStackIds(asset) : [asset.assetId];
   const nextIndex = state.lightboxIndex; // list shrinks; same index = next photo
-  decide(action, ids).then(() => {
+  // Only a one-photo decision from the standalone lightbox rewinds here.
+  // Zoomed Stack members return to compare, while apply-to-all remains a
+  // Stack-wide action whose Undo restores the Stack card without reopening it.
+  const returnToLightboxId = !state.compareBurstId && ids.length === 1 ? asset.assetId : null;
+  decide(action, ids, { returnToLightboxId }).then(() => {
     if (state.view === 'decided') return;
     if (state.compareBurstId) closeLightbox(); // zoomed from compare: back to it
     else advanceLightbox(nextIndex);

--- a/public/pictaria.css
+++ b/public/pictaria.css
@@ -360,6 +360,19 @@ body {
 }
 .p-toast.visible { opacity: 1; transform: translate(-50%, 0); }
 .p-toast.error { border-color: var(--p-danger); }
+.p-toast.undoable {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  pointer-events: auto;
+}
+.p-toast .toast-undo {
+  height: 26px;
+  padding: 0 9px;
+  color: var(--p-accent);
+  border-color: var(--p-accent-deep);
+  flex: none;
+}
 
 /* ---- Product / license footer ---- */
 .p-legal-footer {

--- a/test/browser/smoke.test.mjs
+++ b/test/browser/smoke.test.mjs
@@ -818,6 +818,116 @@ test('admin UI smoke: gate, Insights lens, Curate, Smart Albums', { timeout: 120
     assert.equal(Number(await page.evaluate('document.querySelector(".p-tab.active .count").textContent')), baseline);
   });
 
+  await t.test('Curate Undo preserves bucket counts under search and restores lightbox identity', async () => {
+    await page.navigate(`${server.base}/curate.html`);
+    await page.waitFor(
+      `document.querySelector('[data-asset-id="${REVIEW_ASSET_IDS[2]}"]') && !document.querySelector(".gate-backdrop")`,
+      { label: 'curate ready for filtered undo' },
+    );
+    const baseline = Number(await page.evaluate('document.querySelector(".p-tab.active .count").textContent'));
+
+    // The tab is the complete bucket count even while the grid total follows
+    // a search. Undo must adjust that tab relatively, not replace it with 1.
+    await page.evaluate(`(() => {
+      const search = document.getElementById('search');
+      search.value = 'review-3.jpg';
+      search.dispatchEvent(new Event('input', { bubbles: true }));
+    })()`);
+    await page.waitFor(
+      `state.total === 1 && document.querySelector('[data-asset-id="${REVIEW_ASSET_IDS[2]}"]')`,
+      { label: 'search narrows Curate to one photo' },
+    );
+    assert.equal(Number(await page.evaluate('document.querySelector(".p-tab.active .count").textContent')), baseline);
+    await page.evaluate(`
+      [...document.querySelectorAll('[data-asset-id="${REVIEW_ASSET_IDS[2]}"] .card-actions button')]
+        .find((button) => button.textContent === 'Yes').click()
+    `);
+    await page.waitFor(
+      `!document.querySelector('[data-asset-id="${REVIEW_ASSET_IDS[2]}"]') && !document.getElementById('toastUndo').hidden`,
+      { label: 'filtered decision offers undo' },
+    );
+    assert.equal(Number(await page.evaluate('document.querySelector(".p-tab.active .count").textContent')), baseline - 1);
+    await page.evaluate('document.getElementById("toastUndo").click()');
+    await page.waitFor(
+      `document.querySelector('[data-asset-id="${REVIEW_ASSET_IDS[2]}"]') && document.getElementById('toastMessage').textContent === 'Decision undone'`,
+      { label: 'filtered photo restored' },
+    );
+    assert.equal(Number(await page.evaluate('document.querySelector(".p-tab.active .count").textContent')), baseline);
+
+    await page.evaluate(`(() => {
+      const search = document.getElementById('search');
+      search.value = '';
+      search.dispatchEvent(new Event('input', { bubbles: true }));
+    })()`);
+    await page.waitFor(
+      `state.total === ${baseline} && document.querySelector('[data-asset-id="${REVIEW_ASSET_IDS[3]}"]')`,
+      { label: 'full Curate bucket restored' },
+    );
+
+    // A lightbox decision advances immediately. Undo must reopen the restored
+    // photo so the image, index, and next keyboard decision all agree.
+    await page.evaluate(`document.querySelector('[data-asset-id="${REVIEW_ASSET_IDS[3]}"] img').click()`);
+    await page.waitFor(
+      `document.getElementById('lbImage').src.includes('${REVIEW_ASSET_IDS[3]}')`,
+      { label: 'undo target opens in lightbox' },
+    );
+    await page.evaluate('document.querySelector(\'[data-lb="approve"]\').click()');
+    await page.waitFor(
+      `!document.getElementById('lbImage').src.includes('${REVIEW_ASSET_IDS[3]}') && !document.getElementById('toastUndo').hidden`,
+      { label: 'lightbox advances after decision' },
+    );
+    await page.evaluate('document.getElementById("toastUndo").click()');
+    await page.waitFor(
+      `document.getElementById('lbImage').src.includes('${REVIEW_ASSET_IDS[3]}') && state.assets[state.lightboxIndex]?.assetId === '${REVIEW_ASSET_IDS[3]}'`,
+      { label: 'lightbox image and state return to undone photo' },
+    );
+    await page.evaluate('document.getElementById("lbClose").click()');
+  });
+
+  await t.test('Curate keeps a live Undo when its background append fails', async () => {
+    await page.navigate(`${server.base}/curate.html?limit=5`);
+    await page.waitFor(
+      'state.assets.length === 5 && !document.querySelector(".gate-backdrop")',
+      { label: 'short Curate page ready' },
+    );
+    const baseline = Number(await page.evaluate('document.querySelector(".p-tab.active .count").textContent'));
+    const targetId = await page.evaluate(`(() => {
+      const asset = state.assets.find((item) => document.querySelector('[data-asset-id="' + item.assetId + '"]'));
+      return asset.assetId;
+    })()`);
+
+    // The decision succeeds, but the low-water append it starts returns an
+    // ordinary load error. The error replaces the message, not the Undo.
+    await page.evaluate(`(() => {
+      const realFetch = window.fetch;
+      window.fetch = (input, init) => {
+        const url = new URL(typeof input === 'string' ? input : input.url, location.href);
+        if (url.pathname === '/api/review/assets' && Number(url.searchParams.get('offset')) > 0) {
+          window.fetch = realFetch;
+          return Promise.resolve(new Response(JSON.stringify({ error: { message: 'append blocked' } }), {
+            status: 500,
+            headers: { 'content-type': 'application/json' },
+          }));
+        }
+        return realFetch(input, init);
+      };
+    })()`);
+    await page.evaluate(`
+      [...document.querySelectorAll('[data-asset-id="${targetId}"] .card-actions button')]
+        .find((button) => button.textContent === 'Yes').click()
+    `);
+    await page.waitFor(
+      `document.getElementById('toastMessage').textContent === 'append blocked' && !document.getElementById('toastUndo').hidden`,
+      { label: 'append error retains undo action' },
+    );
+    await page.evaluate('document.getElementById("toastUndo").click()');
+    await page.waitFor(
+      `state.assets.some((asset) => asset.assetId === '${targetId}') && document.getElementById('toastMessage').textContent === 'Decision undone'`,
+      { label: 'undo survives append error' },
+    );
+    assert.equal(Number(await page.evaluate('document.querySelector(".p-tab.active .count").textContent')), baseline);
+  });
+
   await t.test('Curate lightbox contains long filenames and model names inside its sidebar', async () => {
     await page.navigate(`${server.base}/curate.html`);
     await page.waitFor(

--- a/test/browser/smoke.test.mjs
+++ b/test/browser/smoke.test.mjs
@@ -706,6 +706,118 @@ test('admin UI smoke: gate, Insights lens, Curate, Smart Albums', { timeout: 120
     assert.equal(await page.evaluate('document.getElementById("metaEnrich").hidden'), true);
   });
 
+  await t.test('Curate offers one transient Undo for single photos and whole Stacks', async () => {
+    await page.navigate(`${server.base}/curate.html`);
+    await page.waitFor(
+      `document.querySelector('[data-asset-id="${REVIEW_ASSET_IDS[0]}"]') && !document.querySelector(".gate-backdrop")`,
+      { label: 'curate ready for undo' },
+    );
+    const baseline = Number(await page.evaluate('document.querySelector(".p-tab.active .count").textContent'));
+    const yesButton = (assetId) =>
+      `[...document.querySelectorAll('[data-asset-id="${assetId}"] .card-actions button')].find((button) => button.textContent === "Yes")`;
+
+    // Hold the first request while the second finishes: even when rapid
+    // decisions complete out of order, the newest click owns the one Undo.
+    await page.evaluate(`(() => {
+      const realFetch = window.fetch;
+      window.__firstDecisionHeld = false;
+      window.fetch = (input, init) => {
+        const body = init?.body ? JSON.parse(init.body) : null;
+        if (
+          String(input).includes('/api/review/decision')
+          && body?.action === 'approve'
+          && body?.asset_ids?.[0] === ${JSON.stringify(REVIEW_ASSET_IDS[0])}
+        ) {
+          window.__firstDecisionHeld = true;
+          return new Promise((resolve, reject) => {
+            window.__releaseFirstDecision = () => {
+              window.fetch = realFetch;
+              realFetch(input, init).then(resolve, reject);
+            };
+          });
+        }
+        return realFetch(input, init);
+      };
+    })()`);
+    await page.evaluate(`${yesButton(REVIEW_ASSET_IDS[0])}.click()`);
+    await page.waitFor(
+      'window.__firstDecisionHeld',
+      { label: 'first decision held in flight' },
+    );
+    await page.evaluate(`${yesButton(REVIEW_ASSET_IDS[1])}.click()`);
+    await page.waitFor(
+      `!document.querySelector('[data-asset-id="${REVIEW_ASSET_IDS[1]}"]') && !document.getElementById("toastUndo").hidden`,
+      { label: 'second decision replaces pending undo' },
+    );
+    await page.evaluate('window.__releaseFirstDecision()');
+    await page.waitFor(
+      `!document.querySelector('[data-asset-id="${REVIEW_ASSET_IDS[0]}"]')`,
+      { label: 'older decision completes after newest' },
+    );
+    assert.equal(await page.evaluate('document.getElementById("toastUndo").textContent'), 'Undo (Z)');
+    const toastLayout = await page.evaluate(`(() => {
+      const message = document.getElementById('toastMessage').getBoundingClientRect();
+      const button = document.getElementById('toastUndo').getBoundingClientRect();
+      return {
+        centerDifference: Math.abs((message.top + message.height / 2) - (button.top + button.height / 2)),
+        pointerEvents: getComputedStyle(document.getElementById('toast')).pointerEvents,
+      };
+    })()`);
+    assert.ok(toastLayout.centerDifference < 1, 'Undo is vertically aligned with the confirmation');
+    assert.equal(toastLayout.pointerEvents, 'auto', 'Undo remains clickable');
+    await page.evaluate('document.dispatchEvent(new KeyboardEvent("keydown", { key: "z" }))');
+    await page.waitFor(
+      `document.querySelector('[data-asset-id="${REVIEW_ASSET_IDS[1]}"]') && document.getElementById("toastMessage").textContent === "Decision undone"`,
+      { label: 'Z restores newest photo' },
+    );
+    assert.equal(
+      await page.evaluate(`Boolean(document.querySelector('[data-asset-id="${REVIEW_ASSET_IDS[0]}"]'))`),
+      false,
+      'the superseded decision remains applied',
+    );
+    assert.equal(Number(await page.evaluate('document.querySelector(".p-tab.active .count").textContent')), baseline - 1);
+
+    // Restore the first photo directly so this subtest leaves the shared
+    // fixture unchanged for the remaining Curate flows.
+    await page.evaluate(`(async () => {
+      const response = await fetch('/api/review/decision', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ action: 'clear', asset_ids: [${JSON.stringify(REVIEW_ASSET_IDS[0])}] }),
+      });
+      if (!response.ok) throw new Error('test cleanup failed');
+      await loadAssetsFresh();
+    })()`);
+    await page.waitFor(
+      `document.querySelector('[data-asset-id="${REVIEW_ASSET_IDS[0]}"]') && document.querySelector(".p-tab.active .count").textContent === "${baseline}"`,
+      { label: 'single-photo test state restored' },
+    );
+
+    // Keep-best creates two different decisions under the hood (approve the
+    // star, review the rest); one Undo clears and restores the exact group.
+    const stack = await page.evaluate(`(() => {
+      const card = [...document.querySelectorAll('#grid .p-card.stack')]
+        .find((item) => [...item.querySelectorAll('button')].some((button) => button.textContent.startsWith('★ Keep')));
+      const ids = state.assets.filter((asset) => asset.burstId === card.dataset.burstId).map((asset) => asset.assetId);
+      return { burstId: card.dataset.burstId, ids };
+    })()`);
+    assert.equal(stack.ids.length, 2, 'seeded stack has two live photos');
+    await page.evaluate(`(() => {
+      const card = document.querySelector('[data-burst-id="${stack.burstId}"]');
+      [...card.querySelectorAll('button')].find((button) => button.textContent.startsWith('★ Keep')).click();
+    })()`);
+    await page.waitFor(
+      `${JSON.stringify(stack.ids)}.every((id) => !state.assets.some((asset) => asset.assetId === id)) && !document.getElementById("toastUndo").hidden`,
+      { label: 'stack decision offers one undo' },
+    );
+    await page.evaluate('document.getElementById("toastUndo").click()');
+    await page.waitFor(
+      `${JSON.stringify(stack.ids)}.every((id) => state.assets.some((asset) => asset.assetId === id)) && document.getElementById("toastMessage").textContent === "Decision undone"`,
+      { label: 'button restores whole stack' },
+    );
+    assert.equal(Number(await page.evaluate('document.querySelector(".p-tab.active .count").textContent')), baseline);
+  });
+
   await t.test('Curate lightbox contains long filenames and model names inside its sidebar', async () => {
     await page.navigate(`${server.base}/curate.html`);
     await page.waitFor(

--- a/test/browser/smoke.test.mjs
+++ b/test/browser/smoke.test.mjs
@@ -882,6 +882,34 @@ test('admin UI smoke: gate, Insights lens, Curate, Smart Albums', { timeout: 120
       { label: 'lightbox image and state return to undone photo' },
     );
     await page.evaluate('document.getElementById("lbClose").click()');
+
+    // The next queue item can be a Stack, which replaces the standalone
+    // lightbox with compare. Undo must still rewind to the original single
+    // photo rather than strand the user in the auto-opened Stack.
+    await page.evaluate(`(() => {
+      const targetId = ${JSON.stringify(REVIEW_ASSET_IDS[4])};
+      const stackIds = new Set(${JSON.stringify([ARROW_A_ID, ARROW_B_ID])});
+      const target = state.assets.find((asset) => asset.assetId === targetId);
+      const stack = state.assets.filter((asset) => stackIds.has(asset.assetId));
+      if (!target || stack.length !== 2) throw new Error('single-to-Stack fixture missing');
+      const moved = new Set([targetId, ...stackIds]);
+      state.assets = [target, ...stack, ...state.assets.filter((asset) => !moved.has(asset.assetId))];
+      state.offset = state.assets.length;
+      renderGrid();
+      openLightbox(0);
+    })()`);
+    await page.evaluate('document.querySelector(\'[data-lb="approve"]\').click()');
+    await page.waitFor(
+      `document.getElementById('burstbox').classList.contains('open') && !document.getElementById('lightbox').classList.contains('open') && !document.getElementById('toastUndo').hidden`,
+      { label: 'lightbox advances into the next Stack' },
+    );
+    await page.evaluate('document.getElementById("toastUndo").click()');
+    await page.waitFor(
+      `!document.getElementById('burstbox').classList.contains('open') && document.getElementById('lightbox').classList.contains('open') && state.assets[state.lightboxIndex]?.assetId === '${REVIEW_ASSET_IDS[4]}'`,
+      { label: 'Undo leaves Stack and rewinds to original single photo' },
+    );
+    await page.evaluate('document.getElementById("lbClose").click()');
+    assert.equal(Number(await page.evaluate('document.querySelector(".p-tab.active .count").textContent')), baseline);
   });
 
   await t.test('Curate keeps a live Undo when its background append fails', async () => {


### PR DESCRIPTION
## Outcome

Curate now offers a five-second **Undo (Z)** action in the existing bottom confirmation after individual-photo and whole-Stack decisions. The decision still applies immediately and the review flow advances without waiting.

Fixes PIC-121.

## Material changes

- Reuses the existing toast, with one compact Undo button and a plain `Z` shortcut.
- Clears the exact IDs from the newest photo or Stack decision through the existing durable `clear` action.
- Restores removed rows in place when the user remains in the same queue context; otherwise refreshes the current view.
- Preserves full bucket counts under filtered searches and rewinds a standalone lightbox to the restored photo, including when the next item auto-opens a Stack.
- Keeps a live Undo available when a background low-water page append reports an error.
- Keeps Undo single-level and deterministic when rapid requests complete out of order: the newest click owns it.
- Leaves multi-select bulk actions on their existing deliberate recovery path through the Decided tab.
- Documents the behavior in the Enrich/Curate reference and Unreleased changelog.

## Validation

- `npm test` — 995/995 pass.
- Browser coverage verifies click and `Z` Undo, exact whole-Stack restoration, single-level rapid decisions completing out of order, filtered bucket counts, ordinary lightbox identity, single-photo-to-Stack rewind, background-append failure handling, confirmation/button alignment, and clickable toast behavior.
- `npm run check:dco` — pass.
- `npm run check:publication` — pass for 243 tracked files.
- `git diff --check origin/main...HEAD` — pass.

## Risks and rollback

This is a client-only Curate workflow change that reuses the existing review-decision endpoint and persisted `clear` semantics. It adds no database migration or API contract. Reverting the PR restores the previous confirmation-only toast.

## Remaining work

None for the agreed scope. Bulk multi-select Undo remains intentionally outside PIC-121.

## Authorship and review

Implemented by Codex under the owner-approved scope. Review history is tracked in PIC-121.
