### PR TITLE
PIC-215: Re-run failed photos from Enrich history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to Pictaria Server are documented here. This project follows
 - Curate decision confirmations now offer a five-second **Undo (Z)** action
   for individual photos and whole Stacks, returning the most recently decided
   photos to the queue without interrupting the review flow.
+- Enrich Recent Runs cards now offer **Re-run N failed photos** for content
+  and infrastructure failures that still need work. The server recalculates
+  the set at click time, so later successes, deleted photos, and deliberately
+  discarded photos are never reprocessed from a stale card.
 
 ### Changed
 

--- a/docs/ENRICH.md
+++ b/docs/ENRICH.md
@@ -440,6 +440,17 @@ a batch of tags. The failed counter includes infrastructure failures
 (rate limits, timeouts, outages), which don't count against the photos and
 retry on the next run — see "When things go wrong" above for the split.
 
+A card with failures that still need work offers **Re-run N failed photos**.
+This starts a normal targeted run through the original provider (using that
+provider's current connection and model settings), including both content and
+infrastructure failures. The server recalculates the set when you click: a
+photo that has since succeeded under any setup, disappeared from Immich, or
+been deliberately discarded is left out. The content-failure cap is disabled
+for this deliberate retry only, so photos already at the limit get another
+chance; the run remains capped at 10,000 photos and records its own history
+card. If the original provider is no longer configured, its retry button stays
+disabled until its connection details are restored in Settings.
+
 Pictaria retains the newest 100 run summaries and bounded diagnostic logs.
 For each photo it keeps the newest normalized enrichment result needed by
 Curate and caption search; older run metadata remains, but raw provider
@@ -714,6 +725,13 @@ and expect the queue to breathe a little while enrichment is running.
 
 - `GET /api/enrich/status` — runner state, live counters, log tail, provider
   availability, library stats, `enabled`.
+- `GET /api/enrich/runs` — the newest run summaries, including a live
+  `retryableFailures` count for each history card.
+- `POST /api/enrich/runs/:id/retry` — re-evaluate and start a targeted retry
+  of that run's content and infrastructure failures that still need work,
+  using the original provider's current configuration; accepts optional
+  `{ sendToCurate }` (403 when enrichment is off, 404 when history expired,
+  409 while another run or queue resolution is active).
 - `POST /api/enrich/run` — start a library sweep, or a targeted run with
   `assetIds`; `retryFailureLimited: true` (targeted only) turns the
   per-photo failure cap off for that run (403 when enrichment is off;

--- a/public/enrich.html
+++ b/public/enrich.html
@@ -59,6 +59,7 @@
     .qitem .t { flex: 1 1 auto; font-weight: 700; min-width: 40px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .qitem .m { flex: 0 1 auto; min-width: 0; color: var(--p-muted); font-size: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
     .qitem .p-btn { height: 26px; font-size: 12px; flex-shrink: 0; }
+    .qitem .run-actions { justify-content: flex-end; }
     .qitem .opts { gap: 16px; }
     .qitem .opts label { color: var(--p-muted); font-size: 12px; display: inline-flex; align-items: center; gap: 5px; cursor: pointer; }
     .qitem .detail { color: var(--p-muted); font-size: 12px; min-width: 0; overflow-wrap: anywhere; }
@@ -391,6 +392,13 @@
       el('retryFailedBtn').disabled = off || busy || providerUnavailable;
       for (const button of document.querySelectorAll('#queueList .p-btn.accent')) {
         button.disabled = off || busy || providerUnavailable;
+      }
+      for (const button of document.querySelectorAll('#runsList .run-retry')) {
+        const retryProviderReady = state.providerConfigured.get(button.dataset.provider) === true;
+        button.disabled = off || busy || !retryProviderReady;
+        button.title = retryProviderReady
+          ? 'Start a new run for the failures from this run that still need enrichment.'
+          : 'This run’s provider is no longer configured. Add its connection details in AI Providers to retry.';
       }
       const activeId = busy ? status.options?.queueItemId : null;
       for (const button of document.querySelectorAll('#queueList .p-btn.quiet[data-qid]')) {
@@ -1023,6 +1031,16 @@
         const mins = run.startedAt && run.finishedAt ? Math.max(1, Math.round((new Date(run.finishedAt) - new Date(run.startedAt)) / 60000)) : null;
         when.textContent = `${fmtWhen(run.startedAt)}${mins ? ` · ${mins}m` : ''}`;
         top.append(title, when);
+        let retryBtn = null;
+        if ((run.retryableFailures ?? 0) > 0) {
+          retryBtn = document.createElement('button');
+          retryBtn.className = 'p-btn accent run-retry';
+          retryBtn.dataset.provider = run.provider;
+          retryBtn.dataset.runId = String(run.id);
+          retryBtn.disabled = true; // enabled below once provider state is known
+          retryBtn.textContent = `Re-run ${run.retryableFailures.toLocaleString()} failed photo${run.retryableFailures === 1 ? '' : 's'}`;
+          retryBtn.addEventListener('click', () => void retryRunFailures(run, retryBtn));
+        }
         if (run.hasLog) {
           const logBtn = document.createElement('button');
           logBtn.className = 'p-btn quiet';
@@ -1053,7 +1071,40 @@
         if (run.status === 'failed') detail.classList.add('bad');
 
         card.append(top, detail);
+        if (retryBtn) {
+          const actions = document.createElement('div');
+          actions.className = 'qline run-actions';
+          actions.append(retryBtn);
+          card.append(actions);
+        }
         box.append(card);
+      }
+      syncRunButtons(state.lastStatus);
+    }
+
+    async function retryRunFailures(run, button) {
+      button.disabled = true;
+      try {
+        const body = await api(`/api/enrich/runs/${run.id}/retry`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ sendToCurate: el('enrichCurate').checked }),
+        });
+        if (body.started === false) {
+          toast('Those photos no longer need enrichment.');
+          await loadRuns();
+          return;
+        }
+        const targeted = body.retryTargeted ?? 0;
+        const total = body.retryableFailures ?? targeted;
+        toast(body.retryTruncated
+          ? `Re-running ${targeted.toLocaleString()} of ${total.toLocaleString()} failed photos`
+          : `Re-running ${targeted.toLocaleString()} failed photo${targeted === 1 ? '' : 's'}`);
+        await refresh();
+      } catch (error) {
+        toast(error.message, true);
+      } finally {
+        syncRunButtons(state.lastStatus);
       }
     }
 

--- a/src/enrich/jobRunner.mjs
+++ b/src/enrich/jobRunner.mjs
@@ -292,6 +292,9 @@ export class EnrichJobRunner {
       ),
       options: {
         retryFailureLimited,
+        retrySourceRunId: Number.isSafeInteger(Number(options.retrySourceRunId)) && Number(options.retrySourceRunId) > 0
+          ? Number(options.retrySourceRunId)
+          : null,
         limit: clampInt(options.limit, 1, 100000, 100),
         offset: clampInt(options.offset, 0, 10000000, 0),
         skipAnySuccessful: options.skipAnySuccessful !== false,
@@ -313,9 +316,10 @@ export class EnrichJobRunner {
       this.#log(`targeted run: ${assetIds.length} assets from a slice${options.sliceTruncated ? ' (capped — send again for the rest)' : ''}`);
     }
     if (retryFailureLimited) {
-      this.#log(
-        `retrying photos at the failure limit: the ${this.config.maxFailuresPerAsset}-failure cap is off for this run; failures still count toward each photo's history`,
-      );
+      const source = this.state.options.retrySourceRunId;
+      this.#log(source
+        ? `retrying failures from run #${source}: the content-failure cap is off for this run; failures still count toward each photo's history`
+        : `retrying photos at the failure limit: the ${this.config.maxFailuresPerAsset}-failure cap is off for this run; failures still count toward each photo's history`);
     }
     if (options.reopenDecided) {
       this.#log('when this run finishes, earlier Curate decisions for these photos will be cleared for re-review');
@@ -393,12 +397,13 @@ export class EnrichJobRunner {
       if (this.state.options.sendToCurate && this.state.counters) {
         const failed = this.state.counters.failed ?? 0;
         // Honest about the failure limit: a normal run's failures re-enter
-        // only until they hit the cap, and a retry run's failures are by
-        // definition already there — "next run" would be a false promise.
+        // only until they hit the cap. A deliberate retry can also include
+        // first-time or infrastructure failures from a history card, so
+        // describe their retry path without claiming they are all capped.
         const failedNote = failed === 0
           ? ''
           : this.state.options.retryFailureLimited
-            ? `; ${failed} failed photo(s) stay out — still at the failure limit; Retry again to re-attempt them`
+            ? `; ${failed} failed photo(s) stay out — re-run them again from Recent runs if needed`
             : `; ${failed} failed photo(s) stay out and retry on the next run (until they hit the failure limit)`;
         this.#log(`sent to Curate: ${listed} photo(s) newly listed for review${failedNote}`);
       }

--- a/src/enrich/repository.mjs
+++ b/src/enrich/repository.mjs
@@ -1940,7 +1940,9 @@ export class Repository {
       taxonomyVersion: run.taxonomy_version,
       count,
       assetIds,
-      truncated: count > assetIds.length,
+      // A zero-id query is the cheap count-only mode used by history cards,
+      // not a page callers can meaningfully describe as truncated.
+      truncated: boundedLimit === 0 ? false : count > assetIds.length,
     };
   }
 
@@ -1953,6 +1955,13 @@ export class Repository {
       FROM job_runs ORDER BY id DESC LIMIT ?
     `).all(limit).map((row) => {
       const id = Number(row.id);
+      const counters = row.counters_json ? JSON.parse(row.counters_json) : null;
+      // Modern completed runs record failed=0 authoritatively. Avoid a
+      // historical-window query for those overwhelmingly common clean cards;
+      // legacy/interrupted rows with absent counters still get reconstructed.
+      const retryableFailures = Number.isFinite(counters?.failed) && counters.failed === 0
+        ? 0
+        : this.jobRunRetryFailures(id, { limit: 0 })?.count ?? 0;
       return {
         id,
         title: row.title,
@@ -1963,11 +1972,11 @@ export class Repository {
         targeted: row.targeted === null ? null : Number(row.targeted),
         status: row.status,
         error: row.error,
-        counters: row.counters_json ? JSON.parse(row.counters_json) : null,
+        counters,
         hasLog: Boolean(row.has_log),
         startedAt: row.started_at,
         finishedAt: row.finished_at,
-        retryableFailures: this.jobRunRetryFailures(id, { limit: 0 })?.count ?? 0,
+        retryableFailures,
       };
     });
   }

--- a/src/enrich/repository.mjs
+++ b/src/enrich/repository.mjs
@@ -1878,6 +1878,72 @@ export class Repository {
     `).run(MAX_JOB_RUNS);
   }
 
+  // Reconstruct the per-photo failures that belong to one historical job.
+  // Runs are single-flight, so the exact provider/model/prompt/taxonomy key
+  // plus the job's time window identifies its processing rows without adding
+  // a job id to the durable processing history. The set is evaluated live:
+  // any success (under any setup), a confirmed Immich deletion, or a human
+  // discard removes the photo before a retry can start.
+  jobRunRetryFailures(id, { limit = 10000 } = {}) {
+    const runId = Number(id);
+    if (!Number.isSafeInteger(runId) || runId < 1) return null;
+    const run = this.db.prepare(`
+      SELECT id, title, provider, model, prompt_version, taxonomy_version,
+             started_at, finished_at
+      FROM job_runs WHERE id = ?
+    `).get(runId);
+    if (!run) return null;
+
+    const boundedLimit = Number.isSafeInteger(limit)
+      ? Math.max(0, Math.min(limit, 10000))
+      : 10000;
+    const rows = this.db.prepare(`
+      WITH candidates AS (
+        SELECT f.asset_id, MIN(f.id) AS first_failure_id
+        FROM processing_runs f
+        WHERE f.status IN ('failed', 'failed_infra')
+          AND f.provider IS ? AND f.model IS ?
+          AND f.prompt_version IS ? AND f.taxonomy_version IS ?
+          AND f.started_at >= ? AND f.started_at <= ?
+          AND NOT EXISTS (
+            SELECT 1 FROM processing_runs s
+            WHERE s.asset_id = f.asset_id AND s.status = 'succeeded'
+          )
+          AND NOT EXISTS (
+            SELECT 1 FROM assets a
+            WHERE a.asset_id = f.asset_id
+              AND (a.missing_since IS NOT NULL OR a.enrich_discarded_at IS NOT NULL)
+          )
+        GROUP BY f.asset_id
+      )
+      SELECT asset_id, COUNT(*) OVER() AS total
+      FROM candidates
+      ORDER BY first_failure_id ASC
+      LIMIT ?
+    `).all(
+      run.provider,
+      run.model,
+      run.prompt_version,
+      run.taxonomy_version,
+      run.started_at,
+      run.finished_at,
+      boundedLimit + 1,
+    );
+    const assetIds = rows.slice(0, boundedLimit).map((row) => row.asset_id);
+    const count = Number(rows[0]?.total ?? 0);
+    return {
+      runId: Number(run.id),
+      title: run.title,
+      provider: run.provider,
+      model: run.model,
+      promptVersion: run.prompt_version,
+      taxonomyVersion: run.taxonomy_version,
+      count,
+      assetIds,
+      truncated: count > assetIds.length,
+    };
+  }
+
   listJobRuns(limit = 20) {
     // The log stays out of the list payload (it can be hundreds of KB);
     // fetch it per run via getJobRunLog.
@@ -1885,21 +1951,25 @@ export class Repository {
       SELECT id, title, provider, model, prompt_version, taxonomy_version, targeted,
              status, error, counters_json, log_json IS NOT NULL AS has_log, started_at, finished_at
       FROM job_runs ORDER BY id DESC LIMIT ?
-    `).all(limit).map((row) => ({
-      id: Number(row.id),
-      title: row.title,
-      provider: row.provider,
-      model: row.model,
-      promptVersion: row.prompt_version,
-      taxonomyVersion: row.taxonomy_version,
-      targeted: row.targeted === null ? null : Number(row.targeted),
-      status: row.status,
-      error: row.error,
-      counters: row.counters_json ? JSON.parse(row.counters_json) : null,
-      hasLog: Boolean(row.has_log),
-      startedAt: row.started_at,
-      finishedAt: row.finished_at,
-    }));
+    `).all(limit).map((row) => {
+      const id = Number(row.id);
+      return {
+        id,
+        title: row.title,
+        provider: row.provider,
+        model: row.model,
+        promptVersion: row.prompt_version,
+        taxonomyVersion: row.taxonomy_version,
+        targeted: row.targeted === null ? null : Number(row.targeted),
+        status: row.status,
+        error: row.error,
+        counters: row.counters_json ? JSON.parse(row.counters_json) : null,
+        hasLog: Boolean(row.has_log),
+        startedAt: row.started_at,
+        finishedAt: row.finished_at,
+        retryableFailures: this.jobRunRetryFailures(id, { limit: 0 })?.count ?? 0,
+      };
+    });
   }
 
   getJobRunLog(id) {

--- a/src/routes/enrich.mjs
+++ b/src/routes/enrich.mjs
@@ -808,6 +808,53 @@ export function createEnrichRoutes({ review, enrichRunner, taxonomy, repo, requi
       return true;
     }
 
+    const runRetryMatch = url.pathname.match(/^\/api\/enrich\/runs\/(\d+)\/retry$/);
+    if (request.method === 'POST' && runRetryMatch) {
+      if (!requireImmich(response)) {
+        return true;
+      }
+      if (!config.enrichEnabled) {
+        sendError(response, 403, 'enrichment_disabled', 'Enrichment is turned off — enable it in Settings → Enrich.');
+        return true;
+      }
+      const body = await readJsonBody(request);
+      if (queueBusy()) {
+        sendError(response, 409, 'enrich_run_conflict', 'An enrichment run or queued-job resolution is already in progress.');
+        return true;
+      }
+      const failures = repo.jobRunRetryFailures(Number(runRetryMatch[1]));
+      if (!failures) {
+        sendError(response, 404, 'run_not_found', 'That run is no longer in the history.');
+        return true;
+      }
+      // Re-evaluated at click time: a stale history card cannot re-run a
+      // photo that has since succeeded, disappeared, or been discarded.
+      if (failures.count === 0) {
+        sendJson(response, 200, { started: false, retryableFailures: 0 });
+        return true;
+      }
+      try {
+        const status = enrichRunner.start({
+          provider: failures.provider,
+          assetIds: failures.assetIds,
+          skipAnySuccessful: true,
+          retryFailureLimited: true,
+          retrySourceRunId: failures.runId,
+          title: `Retry failures · ${failures.title}`,
+          sendToCurate: body?.sendToCurate !== false,
+        });
+        sendJson(response, 202, {
+          ...status,
+          retryableFailures: failures.count,
+          retryTargeted: failures.assetIds.length,
+          retryTruncated: failures.truncated,
+        });
+      } catch (error) {
+        sendError(response, 409, 'enrich_run_conflict', diagnostic(error));
+      }
+      return true;
+    }
+
     const runLogMatch = url.pathname.match(/^\/api\/enrich\/runs\/(\d+)\/log$/);
     if (request.method === 'GET' && runLogMatch) {
       const entry = repo.getJobRunLog(Number(runLogMatch[1]));

--- a/test/browser/smoke.test.mjs
+++ b/test/browser/smoke.test.mjs
@@ -230,6 +230,36 @@ function seedEnrichment(dbPath) {
       });
       repo.reviewListAdd([assetId], 'seed');
     }
+
+    // Recent-runs failure retry: one infrastructure failure tied to a
+    // completed run. Its configured provider lets the browser affordance be
+    // exercised without contacting the provider itself.
+    repo.upsertAsset({ id: 'vienna-1', originalPath: '/photos/vienna-1.jpg' });
+    const failedRunId = repo.recordProcessingRun({
+      assetId: 'vienna-1',
+      provider: 'local_lmstudio',
+      model: 'smoke-vision-model',
+      promptVersion: 'v1',
+      taxonomyVersion: 'v1',
+      status: 'failed_infra',
+      error: 'provider unavailable during seed run',
+    });
+    repo.db.prepare('UPDATE processing_runs SET started_at = ?, finished_at = ? WHERE id = ?')
+      .run('2026-07-15T12:01:00.000Z', '2026-07-15T12:01:00.000Z', failedRunId);
+    repo.recordJobRun({
+      title: 'Seeded failed run',
+      provider: 'local_lmstudio',
+      model: 'smoke-vision-model',
+      promptVersion: 'v1',
+      taxonomyVersion: 'v1',
+      targeted: 1,
+      status: 'finished',
+      error: null,
+      counters: { analyzed: 1, succeeded: 0, failed: 1 },
+      log: ['12:01:00 provider unavailable during seed run'],
+      startedAt: '2026-07-15T12:00:00.000Z',
+      finishedAt: '2026-07-15T12:02:00.000Z',
+    });
   } finally {
     repo.close();
   }
@@ -282,6 +312,7 @@ test('admin UI smoke: gate, Insights lens, Curate, Smart Albums', { timeout: 120
     env: {
       IMMICH_BASE_URL: immich.base,
       IMMICH_API_KEY: 'fake-key',
+      ENRICH_ENABLED: 'true',
       DEFAULT_PROVIDER: 'local_lmstudio',
       LMSTUDIO_MODEL: 'smoke-vision-model',
     },
@@ -510,6 +541,35 @@ test('admin UI smoke: gate, Insights lens, Curate, Smart Albums', { timeout: 120
       '!document.getElementById("connStatus")?.hidden && !document.querySelector(".gate-backdrop")',
       { label: 'enrich page authenticated by session cookie' },
     );
+    await page.waitFor(
+      'document.querySelector("#runsList .run-retry:not([disabled])")?.textContent === "Re-run 1 failed photo"',
+      { label: 'historical failure retry action' },
+    );
+    await page.evaluate(`
+      window.__historyRetry = null;
+      const realFetch = window.fetch.bind(window);
+      window.fetch = async (input, init = {}) => {
+        if (/^\\/api\\/enrich\\/runs\\/\\d+\\/retry$/.test(String(input))) {
+          window.__historyRetry = { path: String(input), body: JSON.parse(init.body) };
+          return new Response(JSON.stringify({
+            running: true,
+            retryTargeted: 1,
+            retryableFailures: 1,
+            retryTruncated: false,
+          }), { status: 202, headers: { 'Content-Type': 'application/json' } });
+        }
+        return realFetch(input, init);
+      };
+      document.querySelector('#runsList .run-retry').click();
+    `);
+    await page.waitFor(
+      'document.getElementById("toast").textContent === "Re-running 1 failed photo"',
+      { label: 'historical failure retry confirmation' },
+    );
+    assert.deepEqual(await page.evaluate('window.__historyRetry'), {
+      path: '/api/enrich/runs/1/retry',
+      body: { sendToCurate: true },
+    });
 
     await page.navigate(`${server.base}/remote.html`);
     await page.waitFor(

--- a/test/enrich/repository.test.mjs
+++ b/test/enrich/repository.test.mjs
@@ -819,6 +819,65 @@ test('job run logs round-trip and stay out of the list payload', () => {
   });
 });
 
+test('job run retries reconstruct content and infrastructure failures that still need work', () => {
+  withRepo((repo) => {
+    const key = { provider: 'openrouter', model: 'vision-model', promptVersion: 'v2', taxonomyVersion: 'v1' };
+    const recordAt = (assetId, status, startedAt, overrides = {}) => {
+      repo.upsertAsset({ id: assetId });
+      const id = repo.recordProcessingRun({
+        assetId,
+        ...key,
+        ...overrides,
+        status,
+        ...(status === 'succeeded' ? { normalizedOutput: {} } : { error: `${status} test` }),
+      });
+      repo.db.prepare('UPDATE processing_runs SET started_at = ?, finished_at = ? WHERE id = ?')
+        .run(startedAt, startedAt, id);
+      return id;
+    };
+
+    recordAt('content-failure', 'failed', '2026-07-09T12:02:00.000Z');
+    recordAt('infra-failure', 'failed_infra', '2026-07-09T12:03:00.000Z');
+    recordAt('later-success', 'failed', '2026-07-09T12:04:00.000Z');
+    recordAt('later-success', 'succeeded', '2026-07-09T12:20:00.000Z', { provider: 'venice' });
+    recordAt('outside-window', 'failed', '2026-07-09T11:59:59.000Z');
+    recordAt('other-model', 'failed', '2026-07-09T12:05:00.000Z', { model: 'other-model' });
+    recordAt('missing', 'failed_infra', '2026-07-09T12:06:00.000Z');
+    repo.markAssetsMissing(['missing']);
+    recordAt('discarded', 'failed', '2026-07-09T12:07:00.000Z');
+    repo.discardAssets(['discarded']);
+
+    repo.recordJobRun({
+      title: 'Original sweep', ...key, targeted: 8, status: 'finished', error: null,
+      counters: { failed: 6 }, log: [],
+      startedAt: '2026-07-09T12:00:00.000Z', finishedAt: '2026-07-09T12:10:00.000Z',
+    });
+    const run = repo.listJobRuns(1)[0];
+    assert.equal(run.retryableFailures, 2);
+    assert.deepEqual(repo.jobRunRetryFailures(run.id), {
+      runId: run.id,
+      title: 'Original sweep',
+      provider: 'openrouter',
+      model: 'vision-model',
+      promptVersion: 'v2',
+      taxonomyVersion: 'v1',
+      count: 2,
+      assetIds: ['content-failure', 'infra-failure'],
+      truncated: false,
+    });
+    assert.deepEqual(repo.jobRunRetryFailures(run.id, { limit: 1 }).assetIds, ['content-failure']);
+    assert.equal(repo.jobRunRetryFailures(run.id, { limit: 1 }).count, 2);
+    assert.equal(repo.jobRunRetryFailures(run.id, { limit: 1 }).truncated, true);
+
+    // A success after the history card was rendered removes the photo from
+    // the live retry set and therefore updates the card count too.
+    recordAt('content-failure', 'succeeded', '2026-07-09T12:30:00.000Z', { provider: 'cloud_openai' });
+    assert.deepEqual(repo.jobRunRetryFailures(run.id).assetIds, ['infra-failure']);
+    assert.equal(repo.listJobRuns(1)[0].retryableFailures, 1);
+    assert.equal(repo.jobRunRetryFailures(9999), null);
+  });
+});
+
 test('job history has aggregate retention and bounded logs with a marker', () => {
   withRepo((repo) => {
     const largeLog = Array.from({ length: 700 }, (_, index) => `${index} ${'x'.repeat(1000)}`);

--- a/test/enrich/repository.test.mjs
+++ b/test/enrich/repository.test.mjs
@@ -868,6 +868,7 @@ test('job run retries reconstruct content and infrastructure failures that still
     assert.deepEqual(repo.jobRunRetryFailures(run.id, { limit: 1 }).assetIds, ['content-failure']);
     assert.equal(repo.jobRunRetryFailures(run.id, { limit: 1 }).count, 2);
     assert.equal(repo.jobRunRetryFailures(run.id, { limit: 1 }).truncated, true);
+    assert.equal(repo.jobRunRetryFailures(run.id, { limit: 0 }).truncated, false);
 
     // A success after the history card was rendered removes the photo from
     // the live retry set and therefore updates the card count too.
@@ -875,6 +876,22 @@ test('job run retries reconstruct content and infrastructure failures that still
     assert.deepEqual(repo.jobRunRetryFailures(run.id).assetIds, ['infra-failure']);
     assert.equal(repo.listJobRuns(1)[0].retryableFailures, 1);
     assert.equal(repo.jobRunRetryFailures(9999), null);
+
+    repo.recordJobRun({
+      title: 'Clean sweep', ...key, targeted: 1, status: 'finished', error: null,
+      counters: { analyzed: 1, succeeded: 1, failed: 0 }, log: [],
+      startedAt: '2026-07-09T13:00:00.000Z', finishedAt: '2026-07-09T13:01:00.000Z',
+    });
+    const originalRetryFailures = repo.jobRunRetryFailures.bind(repo);
+    const queriedRunIds = [];
+    repo.jobRunRetryFailures = (id, options) => {
+      queriedRunIds.push(id);
+      return originalRetryFailures(id, options);
+    };
+    const listed = repo.listJobRuns(2);
+    assert.equal(listed[0].retryableFailures, 0);
+    assert.equal(listed[1].retryableFailures, 1);
+    assert.deepEqual(queriedRunIds, [run.id]);
   });
 });
 

--- a/test/enrich/runHistoryRetry.test.mjs
+++ b/test/enrich/runHistoryRetry.test.mjs
@@ -1,0 +1,110 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Readable } from 'node:stream';
+
+import { createEnrichRoutes } from '../../src/routes/enrich.mjs';
+
+function jsonRequest(body = {}) {
+  const request = Readable.from([Buffer.from(JSON.stringify(body))]);
+  request.method = 'POST';
+  request.headers = { 'content-type': 'application/json' };
+  return request;
+}
+
+function fakeResponse() {
+  const out = { statusCode: null, body: null };
+  return {
+    out,
+    writeHead(statusCode) { out.statusCode = statusCode; },
+    end(payload) { out.body = payload ? JSON.parse(payload) : null; },
+  };
+}
+
+function makeHarness({ failures, running = false, startError = null } = {}) {
+  const state = { starts: [], requestedRunIds: [] };
+  const handler = createEnrichRoutes({
+    review: {},
+    taxonomy: {},
+    captionWriteback: {},
+    referee: null,
+    requireImmich: () => true,
+    config: { enrichEnabled: true },
+    immich: {},
+    activityLog: null,
+    repo: {
+      jobRunRetryFailures(id) {
+        state.requestedRunIds.push(id);
+        return failures === undefined ? null : failures;
+      },
+    },
+    enrichRunner: {
+      isRunning: () => running,
+      start(options) {
+        if (startError) throw startError;
+        state.starts.push(options);
+        return { running: true, options: { targeted: options.assetIds.length } };
+      },
+    },
+  });
+  return { handler, state };
+}
+
+test('history retry resolves targets server-side and starts a bounded failure-cap bypass', async () => {
+  const failures = {
+    runId: 17,
+    title: 'Summer sweep',
+    provider: 'openrouter',
+    count: 2,
+    assetIds: ['content-failure', 'infra-failure'],
+    truncated: false,
+  };
+  const { handler, state } = makeHarness({ failures });
+  const response = fakeResponse();
+  await handler(
+    jsonRequest({ assetIds: ['client-chosen-id'], provider: 'venice', sendToCurate: false }),
+    response,
+    new URL('http://x/api/enrich/runs/17/retry'),
+  );
+
+  assert.equal(response.out.statusCode, 202);
+  assert.deepEqual(state.requestedRunIds, [17]);
+  assert.deepEqual(state.starts, [{
+    provider: 'openrouter',
+    assetIds: ['content-failure', 'infra-failure'],
+    skipAnySuccessful: true,
+    retryFailureLimited: true,
+    retrySourceRunId: 17,
+    title: 'Retry failures · Summer sweep',
+    sendToCurate: false,
+  }]);
+  assert.equal(response.out.body.retryableFailures, 2);
+  assert.equal(response.out.body.retryTargeted, 2);
+  assert.equal(response.out.body.retryTruncated, false);
+});
+
+test('history retry reports a stale card cleanly when every failure is now covered', async () => {
+  const { handler, state } = makeHarness({
+    failures: { runId: 17, title: 'Old run', provider: 'openrouter', count: 0, assetIds: [], truncated: false },
+  });
+  const response = fakeResponse();
+  await handler(jsonRequest(), response, new URL('http://x/api/enrich/runs/17/retry'));
+
+  assert.equal(response.out.statusCode, 200);
+  assert.deepEqual(response.out.body, { started: false, retryableFailures: 0 });
+  assert.deepEqual(state.starts, []);
+});
+
+test('history retry refuses a missing run and a competing active run', async () => {
+  const missing = makeHarness();
+  const missingResponse = fakeResponse();
+  await missing.handler(jsonRequest(), missingResponse, new URL('http://x/api/enrich/runs/404/retry'));
+  assert.equal(missingResponse.out.statusCode, 404);
+  assert.equal(missingResponse.out.body.error.code, 'run_not_found');
+
+  const busy = makeHarness({ running: true, failures: { count: 1, assetIds: ['a1'] } });
+  const busyResponse = fakeResponse();
+  await busy.handler(jsonRequest(), busyResponse, new URL('http://x/api/enrich/runs/17/retry'));
+  assert.equal(busyResponse.out.statusCode, 409);
+  assert.equal(busyResponse.out.body.error.code, 'enrich_run_conflict');
+  assert.deepEqual(busy.state.requestedRunIds, []);
+});

--- a/test/enrich/runnerRetry.test.mjs
+++ b/test/enrich/runnerRetry.test.mjs
@@ -111,6 +111,18 @@ test('retry mode still aborts when the failures are infrastructure — the provi
   );
 });
 
+test('infrastructure failures increment the folded failed counter used by run history', async () => {
+  const repo = makeRepo();
+  const { counters } = await runBatch(batchOptions({
+    repo,
+    provider: infraFailingProvider(),
+    assetIds: IDS_9.slice(0, 2),
+    retryFailureLimited: true,
+  }));
+  assert.equal(counters.failed, 2);
+  assert.equal(repo.processing.filter((row) => row.status === 'failed_infra').length, 2);
+});
+
 test('run persistence and logs redact reflected active integration secrets', async () => {
   const secret = 'runner:test/+ key';
   const repo = makeRepo();


### PR DESCRIPTION
## Outcome

Enrich Recent Runs cards now offer **Re-run N failed photos** whenever that historical run still has content or infrastructure failures needing work.

## What changed

- Reconstructs a run's failed photo set from the existing run key and serialized job time window, avoiding a persisted-state migration.
- Re-evaluates eligibility on the server at click time and excludes photos that later succeeded, disappeared from Immich, or were deliberately discarded.
- Starts a normal bounded targeted run through the original provider, with the content-failure cap bypassed only for that deliberate retry.
- Disables the card action while Enrich is busy/off or while the original provider is unavailable.
- Updates the Enrich guide and Unreleased changelog.

## Validation

- `npm test` — 999 passed
- `npm run check:publication` — passed
- Browser smoke coverage verifies the rendered action and request flow.
- Repository and route tests cover content failures, infrastructure failures, later success, stale cards, missing history, and run exclusivity.

## Risk and rollback

No schema, migration, or persisted-state contract changes. The reconstruction relies on Enrich's existing single-flight run serialization and exact run metadata/time windows. Reverting this commit removes the endpoint and UI without changing stored data.

## Agent assistance

Implementation and tests were prepared with OpenAI Codex and validated with the repository's complete automated suite.

Fixes PIC-215
