### PR TITLE
PIC-326: Paginate Enrich Recent Runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ All notable changes to Pictaria Server are documented here. This project follows
   photos, with the provider, model, and an optional operator-authored inference
   host label for comparing setups without adding prompts or provider responses
   to run history.
+- Enrich Recent Runs now starts with the newest 20 summaries and offers
+  **Load more** until every retained run is visible, including its log and any
+  still-retryable failed photos.
 
 ### Changed
 

--- a/docs/ENRICH.md
+++ b/docs/ENRICH.md
@@ -242,6 +242,11 @@ latest successful run per photo is what Curate and the caption data use.
   (30–60 s on large local models). Cancel doubles as pause — a queued job
   stays in the queue unless its run finishes cleanly, and running it again
   continues where it left off (already-enriched photos are skipped).
+- **Recent runs** starts with the newest 20 summaries. **Load more** walks
+  through all 100 retained summaries without loading their potentially large
+  logs; each log is fetched only when you open it. Retry actions remain
+  available on older loaded runs and always recalculate which failed photos
+  still need work before starting.
 
 ### Enrich and Curate are composable
 
@@ -743,8 +748,10 @@ and expect the queue to breathe a little while enrichment is running.
 
 - `GET /api/enrich/status` — runner state, live counters, log tail, provider
   availability, library stats, `enabled`.
-- `GET /api/enrich/runs` — the newest run summaries, including a live
-  `retryableFailures` count for each history card.
+- `GET /api/enrich/runs` — newest-first, stable cursor pages of retained run
+  summaries, including a live `retryableFailures` count for each returned
+  history card. Accepts `cursor` and `limit` (default 20, maximum 50) and
+  returns `{ runs, nextCursor, total }`.
 - `POST /api/enrich/runs/:id/retry` — re-evaluate and start a targeted retry
   of that run's content and infrastructure failures that still need work,
   using the original provider's current configuration; accepts optional
@@ -818,7 +825,8 @@ and expect the queue to breathe a little while enrichment is running.
 - `POST /api/enrich/captions/writeback/backfill` — queue every enriched
   photo with a caption for description writeback (409 when the setting is
   off).
-- `GET /api/enrich/runs` — run history (latest 20).
+- `GET /api/enrich/runs` — paged retained run history (newest first; default
+  20, maximum 50 per request).
 - `GET /api/enrich/runs/:id/log` — one run's full log.
 - `GET /api/enrich/caption?assetId=…` — one photo's full stored caption
   (the Curate lightbox uses it).

--- a/public/enrich.html
+++ b/public/enrich.html
@@ -232,6 +232,11 @@
       <summary><span class="chev">&#9654;</span> Recent runs <span class="sub">— what ran, with which model and versions, and each run's log</span></summary>
       <div class="provider-note" style="margin-top: 10px">End-to-end throughput uses successful photos only and covers Pictaria’s whole photo path: Immich download, image preparation, network, model response, and any retries. Skips do not count. It is useful for comparing your setups, but it is not pure model or token speed.</div>
       <div id="runsList" class="qlist queue" style="margin-top: 12px"></div>
+      <div class="qline" style="margin-top: 10px">
+        <span id="runsCount" class="m"></span>
+        <div class="p-grow"></div>
+        <button id="runsMoreBtn" class="p-btn quiet" hidden>Load more</button>
+      </div>
     </details>
   </main>
 
@@ -279,6 +284,11 @@
       lastStatus: null,
       liveLog: false,
       lastRunStartedAt: null,
+      runs: [],
+      runsNextCursor: null,
+      runsTotal: 0,
+      runsLoading: false,
+      runsRefreshPending: false,
     };
     const el = (id) => document.getElementById(id);
 
@@ -1012,9 +1022,19 @@
           : value.toFixed(2);
     }
 
-    async function loadRuns() {
-      let runs = [];
-      try { runs = (await api('/api/enrich/runs')).runs ?? []; } catch { return; }
+    function syncRunsPaging() {
+      const count = el('runsCount');
+      const button = el('runsMoreBtn');
+      count.textContent = state.runsTotal > 0
+        ? `Showing ${state.runs.length.toLocaleString()} of ${state.runsTotal.toLocaleString()} retained run${state.runsTotal === 1 ? '' : 's'}`
+        : '';
+      button.hidden = !state.runsNextCursor;
+      button.disabled = state.runsLoading;
+      button.textContent = state.runsLoading ? 'Loading…' : 'Load more';
+    }
+
+    function renderRuns() {
+      const runs = state.runs;
       const box = el('runsList');
       box.replaceChildren();
       if (!runs.length) {
@@ -1106,6 +1126,49 @@
       }
       syncRunButtons(state.lastStatus);
     }
+
+    async function loadRuns({ more = false } = {}) {
+      if (state.runsLoading) {
+        if (!more) state.runsRefreshPending = true;
+        return;
+      }
+      if (more && !state.runsNextCursor) return;
+      state.runsLoading = true;
+      syncRunsPaging();
+      try {
+        let cursor = more ? state.runsNextCursor : null;
+        const target = more ? state.runs.length + 20 : Math.max(20, state.runs.length);
+        let runs = more ? [...state.runs] : [];
+        let total = state.runsTotal;
+        do {
+          const remaining = more ? 20 : Math.max(1, target - runs.length);
+          const params = new URLSearchParams({ limit: String(Math.min(20, remaining)) });
+          if (cursor) params.set('cursor', cursor);
+          const page = await api(`/api/enrich/runs?${params}`);
+          total = Number.isSafeInteger(page.total) ? page.total : runs.length + (page.runs?.length ?? 0);
+          const byId = new Map(runs.map((run) => [run.id, run]));
+          for (const run of page.runs ?? []) byId.set(run.id, run);
+          runs = [...byId.values()].sort((a, b) => b.id - a.id);
+          cursor = page.nextCursor ?? null;
+          if (more) break;
+        } while (cursor && runs.length < Math.min(target, total));
+        state.runs = runs;
+        state.runsNextCursor = cursor;
+        state.runsTotal = total;
+        renderRuns();
+      } catch (error) {
+        if (more) toast(`Could not load older runs: ${error.message}`, true);
+      } finally {
+        state.runsLoading = false;
+        syncRunsPaging();
+        if (state.runsRefreshPending) {
+          state.runsRefreshPending = false;
+          void loadRuns();
+        }
+      }
+    }
+
+    el('runsMoreBtn').addEventListener('click', () => void loadRuns({ more: true }));
 
     async function retryRunFailures(run, button) {
       button.disabled = true;

--- a/public/enrich.html
+++ b/public/enrich.html
@@ -1136,24 +1136,24 @@
       state.runsLoading = true;
       syncRunsPaging();
       try {
-        let cursor = more ? state.runsNextCursor : null;
-        const target = more ? state.runs.length + 20 : Math.max(20, state.runs.length);
-        let runs = more ? [...state.runs] : [];
-        let total = state.runsTotal;
-        do {
-          const remaining = more ? 20 : Math.max(1, target - runs.length);
-          const params = new URLSearchParams({ limit: String(Math.min(20, remaining)) });
-          if (cursor) params.set('cursor', cursor);
-          const page = await api(`/api/enrich/runs?${params}`);
-          total = Number.isSafeInteger(page.total) ? page.total : runs.length + (page.runs?.length ?? 0);
-          const byId = new Map(runs.map((run) => [run.id, run]));
-          for (const run of page.runs ?? []) byId.set(run.id, run);
-          runs = [...byId.values()].sort((a, b) => b.id - a.id);
-          cursor = page.nextCursor ?? null;
-          if (more) break;
-        } while (cursor && runs.length < Math.min(target, total));
+        const previousCursor = state.runsNextCursor;
+        const params = new URLSearchParams({ limit: '20' });
+        if (more) params.set('cursor', previousCursor);
+        const page = await api(`/api/enrich/runs?${params}`);
+        const total = Number.isSafeInteger(page.total)
+          ? page.total
+          : state.runs.length + (page.runs?.length ?? 0);
+        // A newest-page refresh replaces matching cards with fresh counters
+        // while keeping older pages the operator explicitly loaded. New job
+        // ids sort ahead of them; retention can only evict the oldest tail.
+        const byId = new Map(state.runs.map((run) => [run.id, run]));
+        for (const run of page.runs ?? []) byId.set(run.id, run);
+        let runs = [...byId.values()].sort((a, b) => b.id - a.id);
+        if (runs.length > total) runs = runs.slice(0, total);
         state.runs = runs;
-        state.runsNextCursor = cursor;
+        state.runsNextCursor = runs.length >= total
+          ? null
+          : more ? page.nextCursor ?? null : previousCursor ?? page.nextCursor ?? null;
         state.runsTotal = total;
         renderRuns();
       } catch (error) {

--- a/src/enrich/repository.mjs
+++ b/src/enrich/repository.mjs
@@ -32,6 +32,8 @@ export const ENRICH_QUEUE_MAX_ITEM_BYTES = 64 * 1024;
 export const ENRICH_QUEUE_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
 export const ENRICH_QUEUE_DEFAULT_PAGE_SIZE = 50;
 export const ENRICH_QUEUE_MAX_PAGE_SIZE = 100;
+export const ENRICH_RUN_DEFAULT_PAGE_SIZE = 20;
+export const ENRICH_RUN_MAX_PAGE_SIZE = 50;
 
 // Local source of truth for enrichment runs, tags, and review decisions.
 // Uses the same SQLite schema as the Python reference implementation, so an
@@ -1976,14 +1978,26 @@ export class Repository {
     };
   }
 
-  listJobRuns(limit = 20) {
+  jobRunsPage({ beforeId = null, limit = ENRICH_RUN_DEFAULT_PAGE_SIZE } = {}) {
     // The log stays out of the list payload (it can be hundreds of KB);
     // fetch it per run via getJobRunLog.
-    return this.db.prepare(`
+    const boundedLimit = Math.max(
+      1,
+      Math.min(ENRICH_RUN_MAX_PAGE_SIZE, Math.floor(Number(limit) || ENRICH_RUN_DEFAULT_PAGE_SIZE)),
+    );
+    const cursor = Number(beforeId);
+    const hasCursor = Number.isSafeInteger(cursor) && cursor > 0;
+    const rows = (hasCursor ? this.db.prepare(`
+      SELECT id, title, provider, model, prompt_version, taxonomy_version, inference_host_label, targeted,
+             status, error, counters_json, log_json IS NOT NULL AS has_log, started_at, finished_at
+      FROM job_runs WHERE id < ? ORDER BY id DESC LIMIT ?
+    `).all(cursor, boundedLimit + 1) : this.db.prepare(`
       SELECT id, title, provider, model, prompt_version, taxonomy_version, inference_host_label, targeted,
              status, error, counters_json, log_json IS NOT NULL AS has_log, started_at, finished_at
       FROM job_runs ORDER BY id DESC LIMIT ?
-    `).all(limit).map((row) => {
+    `).all(boundedLimit + 1));
+    const hasMore = rows.length > boundedLimit;
+    const runs = rows.slice(0, boundedLimit).map((row) => {
       const id = Number(row.id);
       const counters = row.counters_json ? JSON.parse(row.counters_json) : null;
       // Modern completed runs record failed=0 authoritatively. Avoid a
@@ -2011,6 +2025,15 @@ export class Repository {
         retryableFailures,
       };
     });
+    return {
+      runs,
+      nextBeforeId: hasMore ? runs.at(-1)?.id ?? null : null,
+      total: Number(this.db.prepare('SELECT COUNT(*) AS count FROM job_runs').get()?.count ?? 0),
+    };
+  }
+
+  listJobRuns(limit = ENRICH_RUN_DEFAULT_PAGE_SIZE) {
+    return this.jobRunsPage({ limit }).runs;
   }
 
   getJobRunLog(id) {

--- a/src/routes/enrich.mjs
+++ b/src/routes/enrich.mjs
@@ -8,6 +8,8 @@ import {
   ENRICH_QUEUE_DEFAULT_PAGE_SIZE,
   ENRICH_QUEUE_MAX_PAGE_SIZE,
   ENRICH_QUEUE_MAX_ITEMS_GLOBAL,
+  ENRICH_RUN_DEFAULT_PAGE_SIZE,
+  ENRICH_RUN_MAX_PAGE_SIZE,
 } from '../enrich/repository.mjs';
 
 import { configuredSecrets, sanitizeDiagnostic } from '../diagnostics.mjs';
@@ -43,6 +45,42 @@ function queuePageLimit(value) {
       `Enrichment queue pages must contain 1-${ENRICH_QUEUE_MAX_PAGE_SIZE} items.`,
       400,
       'invalid_queue_limit',
+    );
+  }
+  return limit;
+}
+
+function encodeRunCursor(id) {
+  return Buffer.from(String(id), 'utf8').toString('base64url');
+}
+
+function decodeRunCursor(value) {
+  if (value === null || value === undefined || value === '') return null;
+  if (!/^[A-Za-z0-9_-]+$/.test(value)) {
+    throw new HttpBodyError('Invalid enrichment run cursor.', 400, 'invalid_run_cursor');
+  }
+  const decoded = Buffer.from(value, 'base64url').toString('utf8');
+  if (!/^[1-9]\d*$/.test(decoded)) {
+    throw new HttpBodyError('Invalid enrichment run cursor.', 400, 'invalid_run_cursor');
+  }
+  const id = Number(decoded);
+  if (!Number.isSafeInteger(id)) {
+    throw new HttpBodyError('Invalid enrichment run cursor.', 400, 'invalid_run_cursor');
+  }
+  return id;
+}
+
+function runPageLimit(value) {
+  if (value === null || value === undefined || value === '') return ENRICH_RUN_DEFAULT_PAGE_SIZE;
+  if (!/^\d+$/.test(value)) {
+    throw new HttpBodyError('Invalid enrichment run page limit.', 400, 'invalid_run_limit');
+  }
+  const limit = Number(value);
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > ENRICH_RUN_MAX_PAGE_SIZE) {
+    throw new HttpBodyError(
+      `Enrichment run pages must contain 1-${ENRICH_RUN_MAX_PAGE_SIZE} items.`,
+      400,
+      'invalid_run_limit',
     );
   }
   return limit;
@@ -805,7 +843,15 @@ export function createEnrichRoutes({ review, enrichRunner, taxonomy, repo, requi
     }
 
     if (request.method === 'GET' && url.pathname === '/api/enrich/runs') {
-      sendJson(response, 200, { runs: repo.listJobRuns(20) });
+      const page = repo.jobRunsPage({
+        beforeId: decodeRunCursor(url.searchParams.get('cursor')),
+        limit: runPageLimit(url.searchParams.get('limit')),
+      });
+      sendJson(response, 200, {
+        runs: page.runs,
+        nextCursor: page.nextBeforeId === null ? null : encodeRunCursor(page.nextBeforeId),
+        total: page.total,
+      });
       return true;
     }
 

--- a/test/browser/smoke.test.mjs
+++ b/test/browser/smoke.test.mjs
@@ -260,6 +260,24 @@ function seedEnrichment(dbPath) {
       startedAt: '2026-07-15T12:00:00.000Z',
       finishedAt: '2026-07-15T12:02:00.000Z',
     });
+    // Keep the failed run beyond the initial 20-card page so the browser
+    // smoke exercises pagination plus retry/log actions on loaded history.
+    for (let index = 1; index <= 20; index += 1) {
+      repo.recordJobRun({
+        title: `Seeded historical run ${index}`,
+        provider: 'local_lmstudio',
+        model: 'smoke-vision-model',
+        promptVersion: 'v1',
+        taxonomyVersion: 'v1',
+        targeted: 1,
+        status: 'finished',
+        error: null,
+        counters: { analyzed: 1, succeeded: 1, failed: 0 },
+        log: [],
+        startedAt: '2026-07-15T12:02:00.000Z',
+        finishedAt: '2026-07-15T12:02:01.000Z',
+      });
+    }
     repo.recordJobRun({
       title: 'Seeded successful run',
       provider: 'local_lmstudio',
@@ -571,8 +589,24 @@ test('admin UI smoke: gate, Insights lens, Curate, Smart Albums', { timeout: 120
       { label: 'enrich page authenticated by session cookie' },
     );
     await page.waitFor(
+      'document.getElementById("runsCount")?.textContent === "Showing 20 of 23 retained runs" && !document.getElementById("runsMoreBtn")?.hidden',
+      { label: 'initial bounded run-history page' },
+    );
+    assert.equal(
+      await page.evaluate('[...document.querySelectorAll("#runsList .qitem")].some((item) => item.textContent.includes("Seeded failed run"))'),
+      false,
+    );
+    await page.evaluate('document.getElementById("runsMoreBtn").click()');
+    await page.waitFor(
+      'document.getElementById("runsCount")?.textContent === "Showing 23 of 23 retained runs" && document.getElementById("runsMoreBtn")?.hidden',
+      { label: 'all retained run history loaded' },
+    );
+    await page.evaluate('window.__runsRefreshDone = false; loadRuns().then(() => { window.__runsRefreshDone = true; })');
+    await page.waitFor('window.__runsRefreshDone === true', { label: 'loaded-depth history refresh' });
+    assert.equal(await page.evaluate('document.querySelectorAll("#runsList .qitem").length'), 23);
+    await page.waitFor(
       'document.querySelector("#runsList .run-retry:not([disabled])")?.textContent === "Re-run 1 failed photo"',
-      { label: 'historical failure retry action' },
+      { label: 'historical failure retry action on an older page' },
     );
     const runComparison = await page.evaluate(`(() => {
       const card = [...document.querySelectorAll('#runsList .qitem')]
@@ -587,6 +621,16 @@ test('admin UI smoke: gate, Insights lens, Curate, Smart Albums', { timeout: 120
       return card?.textContent ?? '';
     })()`);
     assert.match(onePhotoComparison, /End-to-end: 150 photos\/min · 0\.40 sec\/photo · over 1 photo/);
+    await page.evaluate(`(() => {
+      const card = [...document.querySelectorAll('#runsList .qitem')]
+        .find((item) => item.textContent.includes('Seeded failed run'));
+      [...card.querySelectorAll('button')].find((button) => button.textContent === 'Log').click();
+    })()`);
+    await page.waitFor(
+      'document.getElementById("logPopupTitle")?.textContent === "Seeded failed run" && !document.getElementById("logPopup")?.hidden',
+      { label: 'older run log opens after pagination' },
+    );
+    await page.evaluate('document.getElementById("logPopupClose").click()');
     await page.evaluate(`
       window.__historyRetry = null;
       const realFetch = window.fetch.bind(window);

--- a/test/browser/smoke.test.mjs
+++ b/test/browser/smoke.test.mjs
@@ -601,9 +601,19 @@ test('admin UI smoke: gate, Insights lens, Curate, Smart Albums', { timeout: 120
       'document.getElementById("runsCount")?.textContent === "Showing 23 of 23 retained runs" && document.getElementById("runsMoreBtn")?.hidden',
       { label: 'all retained run history loaded' },
     );
-    await page.evaluate('window.__runsRefreshDone = false; loadRuns().then(() => { window.__runsRefreshDone = true; })');
+    await page.evaluate(`
+      window.__runListFetches = 0;
+      const runListFetch = window.fetch.bind(window);
+      window.fetch = async (input, init = {}) => {
+        if (String(input).startsWith('/api/enrich/runs?')) window.__runListFetches += 1;
+        return runListFetch(input, init);
+      };
+      window.__runsRefreshDone = false;
+      loadRuns().then(() => { window.__runsRefreshDone = true; });
+    `);
     await page.waitFor('window.__runsRefreshDone === true', { label: 'loaded-depth history refresh' });
     assert.equal(await page.evaluate('document.querySelectorAll("#runsList .qitem").length'), 23);
+    assert.equal(await page.evaluate('window.__runListFetches'), 1);
     await page.waitFor(
       'document.querySelector("#runsList .run-retry:not([disabled])")?.textContent === "Re-run 1 failed photo"',
       { label: 'historical failure retry action on an older page' },

--- a/test/enrich/repository.test.mjs
+++ b/test/enrich/repository.test.mjs
@@ -819,6 +819,41 @@ test('job run logs round-trip and stay out of the list payload', () => {
   });
 });
 
+test('job run history uses stable newest-first keyset pages', () => {
+  withRepo((repo) => {
+    for (let index = 1; index <= 45; index += 1) {
+      repo.recordJobRun({
+        title: `Run ${index}`, provider: 'p', model: 'm', promptVersion: 'v1', taxonomyVersion: 'v1',
+        targeted: 1, status: 'finished', error: null, counters: { succeeded: 1, failed: 0 }, log: [],
+        startedAt: '2026-07-09T12:00:00.000Z', finishedAt: '2026-07-09T12:00:01.000Z',
+      });
+    }
+
+    const first = repo.jobRunsPage({ limit: 20 });
+    assert.deepEqual(first.runs.map((run) => run.id), Array.from({ length: 20 }, (_, index) => 45 - index));
+    assert.equal(first.nextBeforeId, 26);
+    assert.equal(first.total, 45);
+
+    // A new run between requests does not shift or duplicate older pages.
+    repo.recordJobRun({
+      title: 'New after first page', provider: 'p', model: 'm', promptVersion: 'v1', taxonomyVersion: 'v1',
+      targeted: 1, status: 'finished', error: null, counters: { succeeded: 1, failed: 0 }, log: [],
+      startedAt: '2026-07-09T12:01:00.000Z', finishedAt: '2026-07-09T12:01:01.000Z',
+    });
+    const second = repo.jobRunsPage({ beforeId: first.nextBeforeId, limit: 20 });
+    const third = repo.jobRunsPage({ beforeId: second.nextBeforeId, limit: 20 });
+    assert.deepEqual(second.runs.map((run) => run.id), Array.from({ length: 20 }, (_, index) => 25 - index));
+    assert.deepEqual(third.runs.map((run) => run.id), [5, 4, 3, 2, 1]);
+    assert.equal(second.nextBeforeId, 6);
+    assert.equal(third.nextBeforeId, null);
+    assert.equal(second.total, 46);
+    assert.deepEqual(
+      [...first.runs, ...second.runs, ...third.runs].map((run) => run.id),
+      Array.from({ length: 45 }, (_, index) => 45 - index),
+    );
+  });
+});
+
 test('job run history derives honest end-to-end throughput and snapshots bounded host context', () => {
   withRepo((repo) => {
     repo.recordJobRun({

--- a/test/enrich/repository.test.mjs
+++ b/test/enrich/repository.test.mjs
@@ -821,7 +821,7 @@ test('job run logs round-trip and stay out of the list payload', () => {
 
 test('job run history uses stable newest-first keyset pages', () => {
   withRepo((repo) => {
-    for (let index = 1; index <= 45; index += 1) {
+    for (let index = 1; index <= 120; index += 1) {
       repo.recordJobRun({
         title: `Run ${index}`, provider: 'p', model: 'm', promptVersion: 'v1', taxonomyVersion: 'v1',
         targeted: 1, status: 'finished', error: null, counters: { succeeded: 1, failed: 0 }, log: [],
@@ -830,27 +830,38 @@ test('job run history uses stable newest-first keyset pages', () => {
     }
 
     const first = repo.jobRunsPage({ limit: 20 });
-    assert.deepEqual(first.runs.map((run) => run.id), Array.from({ length: 20 }, (_, index) => 45 - index));
-    assert.equal(first.nextBeforeId, 26);
-    assert.equal(first.total, 45);
+    assert.deepEqual(first.runs.map((run) => run.id), Array.from({ length: 20 }, (_, index) => 120 - index));
+    assert.equal(first.nextBeforeId, 101);
+    assert.equal(first.total, 100);
 
-    // A new run between requests does not shift or duplicate older pages.
+    const retainedIds = [...first.runs.map((run) => run.id)];
+    let cursor = first.nextBeforeId;
+    while (cursor !== null) {
+      const page = repo.jobRunsPage({ beforeId: cursor, limit: 20 });
+      retainedIds.push(...page.runs.map((run) => run.id));
+      cursor = page.nextBeforeId;
+    }
+    assert.deepEqual(retainedIds, Array.from({ length: 100 }, (_, index) => 120 - index));
+    assert.equal(new Set(retainedIds).size, 100);
+
+    // A new run prunes only the oldest retained row. A page walk that held
+    // the first cursor continues without offsets, duplicates, or skipped
+    // surviving ids; the newly inserted row belongs to a future fresh walk.
     repo.recordJobRun({
       title: 'New after first page', provider: 'p', model: 'm', promptVersion: 'v1', taxonomyVersion: 'v1',
       targeted: 1, status: 'finished', error: null, counters: { succeeded: 1, failed: 0 }, log: [],
       startedAt: '2026-07-09T12:01:00.000Z', finishedAt: '2026-07-09T12:01:01.000Z',
     });
-    const second = repo.jobRunsPage({ beforeId: first.nextBeforeId, limit: 20 });
-    const third = repo.jobRunsPage({ beforeId: second.nextBeforeId, limit: 20 });
-    assert.deepEqual(second.runs.map((run) => run.id), Array.from({ length: 20 }, (_, index) => 25 - index));
-    assert.deepEqual(third.runs.map((run) => run.id), [5, 4, 3, 2, 1]);
-    assert.equal(second.nextBeforeId, 6);
-    assert.equal(third.nextBeforeId, null);
-    assert.equal(second.total, 46);
-    assert.deepEqual(
-      [...first.runs, ...second.runs, ...third.runs].map((run) => run.id),
-      Array.from({ length: 45 }, (_, index) => 45 - index),
-    );
+    const continuedIds = [...first.runs.map((run) => run.id)];
+    cursor = first.nextBeforeId;
+    while (cursor !== null) {
+      const page = repo.jobRunsPage({ beforeId: cursor, limit: 20 });
+      assert.equal(page.total, 100);
+      continuedIds.push(...page.runs.map((run) => run.id));
+      cursor = page.nextBeforeId;
+    }
+    assert.deepEqual(continuedIds, Array.from({ length: 99 }, (_, index) => 120 - index));
+    assert.equal(new Set(continuedIds).size, 99);
   });
 });
 

--- a/test/enrich/runHistoryPage.test.mjs
+++ b/test/enrich/runHistoryPage.test.mjs
@@ -1,0 +1,82 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Readable } from 'node:stream';
+
+import { createEnrichRoutes } from '../../src/routes/enrich.mjs';
+
+function getRequest() {
+  const request = Readable.from([]);
+  request.method = 'GET';
+  request.headers = {};
+  return request;
+}
+
+function fakeResponse() {
+  const out = { statusCode: null, body: null };
+  return {
+    out,
+    writeHead(statusCode) { out.statusCode = statusCode; },
+    end(payload) { out.body = payload ? JSON.parse(payload) : null; },
+  };
+}
+
+function makeHarness() {
+  const calls = [];
+  const handler = createEnrichRoutes({
+    review: {},
+    enrichRunner: { isRunning: () => false },
+    taxonomy: {},
+    repo: {
+      jobRunsPage(options) {
+        calls.push(options);
+        const newest = options.beforeId === null;
+        return {
+          runs: newest
+            ? Array.from({ length: options.limit }, (_, index) => ({ id: 50 - index }))
+            : Array.from({ length: options.limit }, (_, index) => ({ id: options.beforeId - index - 1 })),
+          nextBeforeId: newest ? 31 : 26,
+          total: 50,
+        };
+      },
+    },
+    requireImmich: () => true,
+    config: { enrichEnabled: true },
+    immich: {},
+    captionWriteback: {},
+    referee: null,
+  });
+  return { handler, calls };
+}
+
+test('run history route returns bounded opaque cursor pages', async () => {
+  const { handler, calls } = makeHarness();
+  let response = fakeResponse();
+  await handler(getRequest(), response, new URL('http://x/api/enrich/runs'));
+
+  assert.equal(response.out.statusCode, 200);
+  assert.equal(response.out.body.runs.length, 20);
+  assert.equal(response.out.body.total, 50);
+  assert.ok(response.out.body.nextCursor);
+  assert.deepEqual(calls[0], { beforeId: null, limit: 20 });
+  const firstCursor = response.out.body.nextCursor;
+
+  response = fakeResponse();
+  await handler(getRequest(), response, new URL(`http://x/api/enrich/runs?limit=5&cursor=${firstCursor}`));
+  assert.equal(response.out.statusCode, 200);
+  assert.deepEqual(response.out.body.runs.map((run) => run.id), [30, 29, 28, 27, 26]);
+  assert.deepEqual(calls[1], { beforeId: 31, limit: 5 });
+  assert.ok(response.out.body.nextCursor);
+});
+
+test('run history route rejects malformed cursors and out-of-range limits', async () => {
+  const { handler, calls } = makeHarness();
+  await assert.rejects(
+    () => handler(getRequest(), fakeResponse(), new URL('http://x/api/enrich/runs?cursor=not-a-cursor')),
+    (error) => error.code === 'invalid_run_cursor' && error.status === 400,
+  );
+  await assert.rejects(
+    () => handler(getRequest(), fakeResponse(), new URL('http://x/api/enrich/runs?limit=51')),
+    (error) => error.code === 'invalid_run_limit' && error.status === 400,
+  );
+  assert.deepEqual(calls, []);
+});


### PR DESCRIPTION
## Outcome

Every retained Enrich run is now reachable from Recent Runs without making the initial page heavy. The page starts with 20 summaries and **Load more** walks through the remaining local history.

This branch was reviewed while stacked on #24, then rebased unchanged onto
`main` after #24 merged. GitHub automatically closed the stacked PR when its
temporary base branch was deleted, so this PR supersedes #25.

## Material changes

- add bounded newest-first keyset pagination to `GET /api/enrich/runs` (`cursor`, default page size 20, maximum 50)
- keep detailed logs out of list payloads and calculate live retry counts only for returned cards
- add a responsive **Load more** control with an honest `Showing N of M retained runs` count
- preserve the user's loaded history depth when run completion refreshes the newest page
- keep Log and **Re-run N failed photos** actions working on older loaded pages
- document the retained-history behavior and add it to the Unreleased changelog

## Validation

- `npm test` — 1,007/1,007 passed, including the real browser flow
- focused repository and route tests — 41/41 passed
- browser smoke — 24/24 passed; verifies initial 20-card page, Load more, retained-depth refresh, and older-page Log/retry actions
- `npm run check:publication` — passed for 246 tracked files
- `git diff --check` — clean

## Risk and rollback

The endpoint remains backward-compatible for clients that only consume `runs`; pagination adds `nextCursor` and `total`. There is no schema or persisted-state migration. Rollback is the normal code/image rollback and does not alter retained run data.

Implementation and validation were performed with Codex. Independent review remains pending.

Fixes PIC-326
