### PR TITLE
PIC-119: Retry temporary provider overloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ All notable changes to Pictaria Server are documented here. This project follows
   state contract to version 7. Existing installations take the standard
   automatic pre-migration recovery snapshot before adopting the additive
   provider and per-run benchmark-context settings.
+- Enrich now retries a photo twice when any configured provider reports a
+  temporary 429 or 503 response, honoring bounded `Retry-After` guidance and
+  keeping cancellation responsive during the wait. The Curate AI referee also
+  uses bounded provider retry guidance before its existing five-minute
+  fallback.
 
 ## 1.0.1 - 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,9 +35,10 @@ All notable changes to Pictaria Server are documented here. This project follows
   provider and per-run benchmark-context settings.
 - Enrich now retries a photo twice when any configured provider reports a
   temporary 429 or 503 response, honoring bounded `Retry-After` guidance and
-  keeping cancellation responsive during the wait. The Curate AI referee also
-  uses bounded provider retry guidance before its existing five-minute
-  fallback.
+  keeping cancellation responsive during the wait. Persistent overloads stop
+  multiplying those waits across a run until the provider responds again. The
+  Curate AI referee also uses bounded provider retry guidance before its
+  existing five-minute fallback.
 
 ## 1.0.1 - 2026-09-02
 

--- a/docs/ENRICH.md
+++ b/docs/ENRICH.md
@@ -380,9 +380,9 @@ your approved tags on every request.
   `Retry-After` request between one second and five minutes; without one it
   waits 15 seconds, then 30 seconds. The live run log shows each retry, and
   Cancel interrupts those waits promptly. If two photos exhaust both retries
-  without a successful provider response in between, Enrich stops adding
-  overload waits for the rest of that provider-down probe; one successful
-  response turns them back on.
+  without a successful provider response in between, Enrich skips further
+  overload waits until the provider responds successfully again. It still
+  makes one ordinary attempt per photo so it can detect that recovery.
   That keeps an exhausted quota from stretching the existing fast-failure
   check across more than 20 minutes of requested wait. If both attempts still
   fail — or for another clearly environmental error such as a timeout, dropped

--- a/docs/ENRICH.md
+++ b/docs/ENRICH.md
@@ -374,16 +374,18 @@ your approved tags on every request.
   upstream provider, so review it before posting it publicly in case that
   provider echoed request content in its message.
 - **Rate limits, outages, and timeouts never cost a photo anything.**
-  Failures are classified by *whose fault they are*. A provider error that
-  is clearly environmental — a timeout or dropped connection, an auth
-  error (401/403), a rate limit (429, e.g. "model currently overloaded"),
-  or any 5xx — records as an **infrastructure failure**: it shows up in
-  the run's failure count, but it is never counted against the photo, and
-  the next run over the same slice retries every affected photo
-  automatically. Nothing to reset, nothing lost — when a cloud model has
-  a bad day and bounces 15% of a run, one re-run later (with "Only
-  unenriched" on, the default) mops them all up. Immich-side network
-  errors and 5xx are treated the same way.
+  Failures are classified by *whose fault they are*. When a provider reports
+  a temporary rate limit (429) or unavailable service (503), Enrich retries
+  that same photo twice before moving on. It follows the provider's
+  `Retry-After` request up to five minutes; without one it waits 15 seconds,
+  then 30 seconds. The live run log shows each retry, and Cancel interrupts
+  those waits promptly. If both attempts still fail — or for another clearly
+  environmental error such as a timeout, dropped connection, auth error
+  (401/403), or other 5xx — the result records as an **infrastructure
+  failure**: it shows up in the run's failure count, but it is never counted
+  against the photo, and the next run over the same slice retries every
+  affected photo automatically. Nothing to reset, nothing lost. Immich-side
+  network errors and 5xx are treated the same way.
 - **A photo that keeps genuinely failing is dropped after two strikes.**
   Failures the provider pins on the request itself — most commonly a
   response the schema rejects (an unparseable answer, too many tags) —
@@ -678,8 +680,9 @@ pauses until the run ends and resumes by itself). Turning the toggle off
 in Settings stops it after the in-flight Stack; existing verdicts stay.
 Errors are handled the patient way: when a judgment fails — the model
 overloaded (429), unreachable, or returning garbage — the strip shows
-*"retrying after an error"* with the message, the referee waits five
-minutes before touching the provider again, and the stack is **not**
+*"retrying after an error"* with the message. The referee follows a provider's
+`Retry-After` guidance up to five minutes, or waits five minutes when no hint
+is supplied, before touching the provider again. The stack is **not**
 marked judged, so the exact same group is retried once the backoff ends.
 Nothing is skipped or lost to a flaky provider; a batch just takes longer.
 The activity popup keeps the recent errors if you want the history.

--- a/docs/ENRICH.md
+++ b/docs/ENRICH.md
@@ -377,15 +377,20 @@ your approved tags on every request.
   Failures are classified by *whose fault they are*. When a provider reports
   a temporary rate limit (429) or unavailable service (503), Enrich retries
   that same photo twice before moving on. It follows the provider's
-  `Retry-After` request up to five minutes; without one it waits 15 seconds,
-  then 30 seconds. The live run log shows each retry, and Cancel interrupts
-  those waits promptly. If both attempts still fail — or for another clearly
-  environmental error such as a timeout, dropped connection, auth error
-  (401/403), or other 5xx — the result records as an **infrastructure
-  failure**: it shows up in the run's failure count, but it is never counted
-  against the photo, and the next run over the same slice retries every
-  affected photo automatically. Nothing to reset, nothing lost. Immich-side
-  network errors and 5xx are treated the same way.
+  `Retry-After` request between one second and five minutes; without one it
+  waits 15 seconds, then 30 seconds. The live run log shows each retry, and
+  Cancel interrupts those waits promptly. If two photos exhaust both retries
+  without a successful provider response in between, Enrich stops adding
+  overload waits for the rest of that provider-down probe; one successful
+  response turns them back on.
+  That keeps an exhausted quota from stretching the existing fast-failure
+  check across more than 20 minutes of requested wait. If both attempts still
+  fail — or for another clearly environmental error such as a timeout, dropped
+  connection, auth error (401/403), or other 5xx — the result records as an
+  **infrastructure failure**: it shows up in the run's failure count, but it is
+  never counted against the photo, and the next run over the same slice retries
+  every affected photo automatically. Nothing to reset, nothing lost.
+  Immich-side network errors and 5xx are treated the same way.
 - **A photo that keeps genuinely failing is dropped after two strikes.**
   Failures the provider pins on the request itself — most commonly a
   response the schema rejects (an unparseable answer, too many tags) —

--- a/src/enrich/providers.mjs
+++ b/src/enrich/providers.mjs
@@ -68,10 +68,13 @@ const GEMINI_JSON_SCHEMA_KEYWORDS = new Set([
 // 5xx) from "the provider judged this request's content" — the runner only
 // charges an asset's permanent failure allowance for the latter.
 export class ProviderRequestError extends Error {
-  constructor(message, { status = null, timeout = false } = {}) {
+  constructor(message, { status = null, timeout = false, retryAfterMs = null } = {}) {
     super(message);
     this.name = 'ProviderRequestError';
     this.status = status;
+    // Keep the provider's retry hint as bounded numeric metadata, never as
+    // raw header text. Callers decide their own cap and fallback policy.
+    this.retryAfterMs = Number.isFinite(retryAfterMs) && retryAfterMs >= 0 ? retryAfterMs : null;
     // Callers that answer a person in real time (the voice commands) need
     // to tell a genuine deadline apart from a refused connection, a DNS
     // failure, or an unparseable body — all of which also arrive without
@@ -81,6 +84,20 @@ export class ProviderRequestError extends Error {
     this.infrastructure =
       status === null || status === 401 || status === 403 || status === 429 || status >= 500;
   }
+}
+
+// Retry-After permits either seconds or an HTTP date. A malformed or past
+// value is no hint; callers retain their normal fallback behavior.
+export function parseRetryAfterMs(value, now = Date.now()) {
+  const raw = Array.isArray(value) ? value[0] : value;
+  if (typeof raw !== 'string' || !raw.trim()) return null;
+  const seconds = Number(raw.trim());
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.round(seconds * 1000);
+  }
+  const at = Date.parse(raw);
+  if (!Number.isFinite(at) || at <= now) return null;
+  return at - now;
 }
 
 export function createProvider(name, options) {
@@ -830,6 +847,7 @@ async function postJson(provider, url, body, extraHeaders) {
     const detail = await readErrorDetail(response, provider);
     throw new ProviderRequestError(providerStatusMessage(provider.providerName, response.status, detail), {
       status: response.status,
+      retryAfterMs: parseRetryAfterMs(response.headers?.get?.('retry-after')),
     });
   }
   try {
@@ -927,6 +945,7 @@ function nodePostJson(provider, url, headers, payload) {
           const detail = providerErrorDetail(text, provider.providerName, provider.apiKey);
           reject(new ProviderRequestError(providerStatusMessage(provider.providerName, response.statusCode, detail), {
             status: response.statusCode,
+            retryAfterMs: parseRetryAfterMs(response.headers['retry-after']),
           }));
           return;
         }

--- a/src/enrich/refereeService.mjs
+++ b/src/enrich/refereeService.mjs
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto';
 
 import { awaitDrain } from '../lifecycle.mjs';
 import { MAX_STACK_MEMBERS } from './reviewService.mjs';
-import { fetchImage } from './runner.mjs';
+import { fetchImage, PROVIDER_RETRY_AFTER_CAP_MS } from './runner.mjs';
 import { createProvider } from './providers.mjs';
 import { configuredSecrets, sanitizeDiagnostic } from '../diagnostics.mjs';
 
@@ -143,6 +143,7 @@ export class RefereeService {
 
     this._lastError = null;
     this._lastErrorAt = 0;
+    this._errorBackoffMs = ERROR_BACKOFF_MS;
     this._current = null; // group key being refereed, for status
     this._currentSize = null;
     this._currentStartedAt = null;
@@ -292,7 +293,7 @@ export class RefereeService {
   async tick() {
     if (this._working || this._stopped || this._paused || !this.enabled()) return;
     if (this.enrichRunner.isRunning()) return; // the model belongs to enrichment
-    if (this._lastError && Date.now() - this._lastErrorAt < ERROR_BACKOFF_MS) return;
+    if (this._lastError && Date.now() - this._lastErrorAt < this._errorBackoffMs) return;
     this._working = true;
     try {
       // Contiguous block: keep going while there is work and the model is
@@ -317,9 +318,12 @@ export class RefereeService {
         secrets: configuredSecrets(this.config, this.immich),
       });
       this._lastErrorAt = Date.now();
+      this._errorBackoffMs = Number.isFinite(error?.retryAfterMs) && error.retryAfterMs >= 0
+        ? Math.min(error.retryAfterMs, PROVIDER_RETRY_AFTER_CAP_MS)
+        : ERROR_BACKOFF_MS;
       this._recentErrors.unshift({ at: new Date().toISOString(), message: this._lastError });
       this._recentErrors.length = Math.min(this._recentErrors.length, 50);
-      this.log(`referee: ${this._lastError} — backing off`);
+      this.log(`referee: ${this._lastError} — backing off for ${formatBackoff(this._errorBackoffMs)}`);
     } finally {
       this._working = false;
       this._current = null;
@@ -482,6 +486,7 @@ export class RefereeService {
       durationMs: Date.now() - started,
     });
     this._lastError = null;
+    this._errorBackoffMs = ERROR_BACKOFF_MS;
     const best = picks.find((pick) => pick.rank === 1);
     this.log(
       `referee: ranked ${group.members.length}-photo group in ${Math.round((Date.now() - started) / 1000)}s`
@@ -489,6 +494,11 @@ export class RefereeService {
     );
     return true;
   }
+}
+
+function formatBackoff(ms) {
+  if (ms >= 60000 && ms % 60000 === 0) return `${ms / 60000}m`;
+  return `${Math.max(0, Math.round(ms / 1000))}s`;
 }
 
 // Turn the model's photo-indexed answers into asset-keyed picks, defending

--- a/src/enrich/runner.mjs
+++ b/src/enrich/runner.mjs
@@ -41,6 +41,10 @@ export async function fetchImage(immich, assetId, imageSource, { maxBytes = null
 // pattern means the provider is down (e.g. LM Studio's server not started),
 // not that the photos are hard.
 const PROVIDER_DOWN_FAILURE_LIMIT = 8;
+export const PROVIDER_OVERLOAD_RETRY_LIMIT = 2;
+export const PROVIDER_RETRY_AFTER_CAP_MS = 5 * 60000;
+const PROVIDER_OVERLOAD_FALLBACK_MS = [15000, 30000];
+const RETRY_CANCEL_POLL_MS = 250;
 const MAX_ENRICH_TRAVERSAL_WINDOWS = 1_000;
 const MAX_ENRICH_TRAVERSAL_ITEMS = 100_000;
 const ENRICH_TRAVERSAL_TIMEOUT_MS = 10 * 60 * 1000;
@@ -69,7 +73,49 @@ const LOCAL_RETRY_SUFFIX =
   'Keep each reason short. Return only caption text in caption and short_caption: ' +
   'do not prefix either value with "Full caption:" or "Short caption:", and do not use caption placeholder text.';
 
-export async function analyzeWithValidationRetry(provider, image, { systemPrompt, userPrompt, jsonSchema, taxonomy, log = () => {} }) {
+class RetryWaitCancelledError extends Error {
+  constructor() {
+    super('cancellation requested during provider retry wait');
+    this.name = 'RetryWaitCancelledError';
+  }
+}
+
+function isRetryableProviderOverload(error) {
+  return error?.name === 'ProviderRequestError' && (error.status === 429 || error.status === 503);
+}
+
+function overloadRetryDelay(error, retryIndex) {
+  if (Number.isFinite(error?.retryAfterMs) && error.retryAfterMs >= 0) {
+    return Math.min(error.retryAfterMs, PROVIDER_RETRY_AFTER_CAP_MS);
+  }
+  return PROVIDER_OVERLOAD_FALLBACK_MS[Math.min(retryIndex, PROVIDER_OVERLOAD_FALLBACK_MS.length - 1)];
+}
+
+function formatRetryDelay(ms) {
+  if (ms >= 60000 && ms % 60000 === 0) return `${ms / 60000}m`;
+  return `${Math.max(0, Math.round(ms / 1000))}s`;
+}
+
+async function waitForRetry(ms, { shouldStop, sleep }) {
+  let remaining = ms;
+  while (remaining > 0) {
+    if (shouldStop()) return false;
+    const chunk = Math.min(remaining, RETRY_CANCEL_POLL_MS);
+    await sleep(chunk);
+    remaining -= chunk;
+  }
+  return !shouldStop();
+}
+
+export async function analyzeWithValidationRetry(provider, image, {
+  systemPrompt,
+  userPrompt,
+  jsonSchema,
+  taxonomy,
+  log = () => {},
+  shouldStop = () => false,
+  retrySleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+}) {
   const prompts = [userPrompt];
   // Every local provider (local_*), plus generic endpoints that explicitly
   // opt in, earns one retry with stricter instructions before a validation
@@ -80,23 +126,37 @@ export async function analyzeWithValidationRetry(provider, image, { systemPrompt
   }
 
   let lastError = null;
+  let overloadRetryCount = 0;
   for (let attemptIndex = 0; attemptIndex < prompts.length; attemptIndex += 1) {
-    try {
-      const result = await provider.analyzeImage(image, {
-        systemPrompt,
-        userPrompt: prompts[attemptIndex],
-        jsonSchema,
-      });
-      const normalized = validateAiOutput(result.normalizedOutput, taxonomy);
-      const decisions = mapOutputToTags(normalized, taxonomy);
-      return { result, normalized, decisions, retryCount: attemptIndex };
-    } catch (error) {
-      if (!(error instanceof OutputValidationError)) {
-        throw error;
-      }
-      lastError = error;
-      if (attemptIndex + 1 < prompts.length) {
-        log(`retrying with stricter local prompt after validation failure: ${error.message}`);
+    while (true) {
+      try {
+        const result = await provider.analyzeImage(image, {
+          systemPrompt,
+          userPrompt: prompts[attemptIndex],
+          jsonSchema,
+        });
+        const normalized = validateAiOutput(result.normalizedOutput, taxonomy);
+        const decisions = mapOutputToTags(normalized, taxonomy);
+        return { result, normalized, decisions, retryCount: attemptIndex + overloadRetryCount };
+      } catch (error) {
+        if (isRetryableProviderOverload(error) && overloadRetryCount < PROVIDER_OVERLOAD_RETRY_LIMIT) {
+          const retryIndex = overloadRetryCount;
+          overloadRetryCount += 1;
+          const delay = overloadRetryDelay(error, retryIndex);
+          log(`${error.status} — retrying in ${formatRetryDelay(delay)} (${overloadRetryCount}/${PROVIDER_OVERLOAD_RETRY_LIMIT})`);
+          if (!await waitForRetry(delay, { shouldStop, sleep: retrySleep })) {
+            throw new RetryWaitCancelledError();
+          }
+          continue;
+        }
+        if (!(error instanceof OutputValidationError)) {
+          throw error;
+        }
+        lastError = error;
+        if (attemptIndex + 1 < prompts.length) {
+          log(`retrying with stricter local prompt after validation failure: ${error.message}`);
+        }
+        break;
       }
     }
   }
@@ -128,6 +188,7 @@ export async function runBatch({
   shouldStop = () => false,
   log = () => {},
   now = Date.now,
+  retrySleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
 }) {
   const diagnosticSecrets = configuredSecrets(immich, provider);
   if (maxAnalyzed !== null && maxAnalyzed < 1) {
@@ -300,7 +361,7 @@ export async function runBatch({
         const { normalized, decisions, retryCount } = await analyzeWithValidationRetry(
           provider,
           { data: image.data, mimeType: image.contentType, assetId },
-          { systemPrompt, userPrompt, jsonSchema, taxonomy, log },
+          { systemPrompt, userPrompt, jsonSchema, taxonomy, log, shouldStop, retrySleep },
         );
         // One transaction: a run may never read as 'succeeded' without its
         // tags, caption index, review listing, and caption-writeback marker.
@@ -337,6 +398,11 @@ export async function runBatch({
         log(`  tags: ${decisions.map((decision) => decision.tag).join(', ') || '(none)'}`);
         log(`  caption: ${typeof normalized.caption === 'string' && normalized.caption ? normalized.caption : '(none)'}`);
       } catch (error) {
+        if (error instanceof RetryWaitCancelledError) {
+          log('stopping early: cancellation requested during provider retry wait');
+          stopped = true;
+          break;
+        }
         const infrastructure = isInfrastructureFailure(error);
         const diagnostic = sanitizeDiagnostic(error instanceof Error ? error.message : error, {
           secrets: diagnosticSecrets,

--- a/src/enrich/runner.mjs
+++ b/src/enrich/runner.mjs
@@ -43,6 +43,8 @@ export async function fetchImage(immich, assetId, imageSource, { maxBytes = null
 const PROVIDER_DOWN_FAILURE_LIMIT = 8;
 export const PROVIDER_OVERLOAD_RETRY_LIMIT = 2;
 export const PROVIDER_RETRY_AFTER_CAP_MS = 5 * 60000;
+const PROVIDER_RETRY_AFTER_MIN_MS = 1000;
+const PROVIDER_OVERLOAD_EXHAUSTION_LIMIT = 2;
 const PROVIDER_OVERLOAD_FALLBACK_MS = [15000, 30000];
 const RETRY_CANCEL_POLL_MS = 250;
 const MAX_ENRICH_TRAVERSAL_WINDOWS = 1_000;
@@ -86,7 +88,7 @@ function isRetryableProviderOverload(error) {
 
 function overloadRetryDelay(error, retryIndex) {
   if (Number.isFinite(error?.retryAfterMs) && error.retryAfterMs >= 0) {
-    return Math.min(error.retryAfterMs, PROVIDER_RETRY_AFTER_CAP_MS);
+    return Math.max(PROVIDER_RETRY_AFTER_MIN_MS, Math.min(error.retryAfterMs, PROVIDER_RETRY_AFTER_CAP_MS));
   }
   return PROVIDER_OVERLOAD_FALLBACK_MS[Math.min(retryIndex, PROVIDER_OVERLOAD_FALLBACK_MS.length - 1)];
 }
@@ -115,6 +117,8 @@ export async function analyzeWithValidationRetry(provider, image, {
   log = () => {},
   shouldStop = () => false,
   retrySleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  overloadRetryLimit = PROVIDER_OVERLOAD_RETRY_LIMIT,
+  onProviderResponse = () => {},
 }) {
   const prompts = [userPrompt];
   // Every local provider (local_*), plus generic endpoints that explicitly
@@ -135,15 +139,18 @@ export async function analyzeWithValidationRetry(provider, image, {
           userPrompt: prompts[attemptIndex],
           jsonSchema,
         });
+        // A completed provider response proves a persistent 429/503 wave has
+        // ended even if local schema validation later rejects its content.
+        onProviderResponse();
         const normalized = validateAiOutput(result.normalizedOutput, taxonomy);
         const decisions = mapOutputToTags(normalized, taxonomy);
         return { result, normalized, decisions, retryCount: attemptIndex + overloadRetryCount };
       } catch (error) {
-        if (isRetryableProviderOverload(error) && overloadRetryCount < PROVIDER_OVERLOAD_RETRY_LIMIT) {
+        if (isRetryableProviderOverload(error) && overloadRetryCount < overloadRetryLimit) {
           const retryIndex = overloadRetryCount;
           overloadRetryCount += 1;
           const delay = overloadRetryDelay(error, retryIndex);
-          log(`${error.status} — retrying in ${formatRetryDelay(delay)} (${overloadRetryCount}/${PROVIDER_OVERLOAD_RETRY_LIMIT})`);
+          log(`${error.status} — retrying in ${formatRetryDelay(delay)} (${overloadRetryCount}/${overloadRetryLimit})`);
           if (!await waitForRetry(delay, { shouldStop, sleep: retrySleep })) {
             throw new RetryWaitCancelledError();
           }
@@ -293,6 +300,20 @@ export async function runBatch({
   let stopped = false;
   let listedForReview = 0;
   let infraFailed = 0;
+  // A persistent quota/outage must not multiply the per-photo wait across
+  // the provider-down circuit breaker's first eight failures. After two
+  // photos exhaust both overload retries without any provider success, keep
+  // making one ordinary attempt per photo but skip further waits. The first
+  // success proves recovery and re-enables the polite retry policy.
+  let exhaustedOverloadPhotos = 0;
+  let overloadRetriesSuppressed = false;
+  const noteProviderResponse = () => {
+    if (overloadRetriesSuppressed) {
+      log('provider responded — overload retries re-enabled');
+    }
+    exhaustedOverloadPhotos = 0;
+    overloadRetriesSuppressed = false;
+  };
 
   while (true) {
     const scanTotal = scanned + assets.length;
@@ -343,6 +364,7 @@ export async function runBatch({
       analyzed += 1;
       counters.analyzed += 1;
       log(`${position} analyzing ${assetId}`);
+      const overloadRetryLimit = overloadRetriesSuppressed ? 0 : PROVIDER_OVERLOAD_RETRY_LIMIT;
       try {
         let image;
         try {
@@ -361,7 +383,17 @@ export async function runBatch({
         const { normalized, decisions, retryCount } = await analyzeWithValidationRetry(
           provider,
           { data: image.data, mimeType: image.contentType, assetId },
-          { systemPrompt, userPrompt, jsonSchema, taxonomy, log, shouldStop, retrySleep },
+          {
+            systemPrompt,
+            userPrompt,
+            jsonSchema,
+            taxonomy,
+            log,
+            shouldStop,
+            retrySleep,
+            overloadRetryLimit,
+            onProviderResponse: noteProviderResponse,
+          },
         );
         // One transaction: a run may never read as 'succeeded' without its
         // tags, caption index, review listing, and caption-writeback marker.
@@ -402,6 +434,16 @@ export async function runBatch({
           log('stopping early: cancellation requested during provider retry wait');
           stopped = true;
           break;
+        }
+        if (overloadRetryLimit > 0 && isRetryableProviderOverload(error)) {
+          exhaustedOverloadPhotos += 1;
+          if (exhaustedOverloadPhotos >= PROVIDER_OVERLOAD_EXHAUSTION_LIMIT) {
+            overloadRetriesSuppressed = true;
+            log(
+              `provider remained overloaded after retries on ${exhaustedOverloadPhotos} photos — `
+              + 'skipping further overload waits until a request succeeds',
+            );
+          }
         }
         const infrastructure = isInfrastructureFailure(error);
         const diagnostic = sanitizeDiagnostic(error instanceof Error ? error.message : error, {

--- a/test/enrich/providers.test.mjs
+++ b/test/enrich/providers.test.mjs
@@ -16,9 +16,10 @@ import {
   extractOpenAiOutputText,
   extractSchemaConstrainedChoiceContent,
   lmStudioSupportedImage,
+  parseRetryAfterMs,
 } from '../../src/enrich/providers.mjs';
 
-function fakeFetch(responseBody, { status = 200, capture = {} } = {}) {
+function fakeFetch(responseBody, { status = 200, headers = {}, capture = {} } = {}) {
   return async (url, options) => {
     capture.url = url;
     capture.options = options;
@@ -26,6 +27,7 @@ function fakeFetch(responseBody, { status = 200, capture = {} } = {}) {
     return {
       ok: status >= 200 && status < 300,
       status,
+      headers: { get: (name) => headers[String(name).toLowerCase()] ?? null },
       json: async () => responseBody,
       text: async () => JSON.stringify(responseBody),
     };
@@ -499,17 +501,29 @@ test('venice requires both an api key and an explicit model', () => {
   assert.throws(() => new VeniceProvider({ apiKey: 'k' }), /Venice model is required/);
 });
 
-test('http errors surface provider name, status, and response detail', async () => {
+test('http errors surface provider name, status, response detail, and Retry-After', async () => {
   const provider = new OpenRouterProvider({
     apiKey: 'key',
     modelName: 'm',
-    fetchImpl: fakeFetch({ error: 'rate limited' }, { status: 429 }),
+    fetchImpl: fakeFetch({ error: 'rate limited' }, { status: 429, headers: { 'retry-after': '30' } }),
   });
 
   await assert.rejects(
     () => provider.analyzeImage(image, prompts),
-    /openrouter request failed with status 429.*rate limited/,
+    (error) => {
+      assert.match(error.message, /openrouter request failed with status 429.*rate limited/);
+      assert.equal(error.retryAfterMs, 30000);
+      return true;
+    },
   );
+});
+
+test('Retry-After parsing accepts seconds and future HTTP dates, but rejects stale values', () => {
+  const now = Date.parse('2026-09-03T12:00:00.000Z');
+  assert.equal(parseRetryAfterMs('1.5', now), 1500);
+  assert.equal(parseRetryAfterMs('Thu, 03 Sep 2026 12:02:00 GMT', now), 120000);
+  assert.equal(parseRetryAfterMs('Thu, 03 Sep 2026 11:59:00 GMT', now), null);
+  assert.equal(parseRetryAfterMs('not-a-delay', now), null);
 });
 
 test('openrouter HTTP errors safely expose structured native-provider metadata', async () => {
@@ -662,6 +676,34 @@ test('missing message content raises a clear error', async () => {
   });
 
   await assert.rejects(() => provider.analyzeImage(image, prompts), /did not include message content/);
+});
+
+test('node transport carries Retry-After metadata from provider errors', async () => {
+  const server = createServer((request, response) => {
+    request.resume();
+    response.writeHead(429, { 'content-type': 'application/json', 'retry-after': '7' });
+    response.end(JSON.stringify({ error: 'busy' }));
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+  const provider = new LmStudioProvider({
+    modelName: 'm',
+    baseUrl: `http://127.0.0.1:${server.address().port}/v1`,
+  });
+
+  try {
+    await assert.rejects(
+      () => provider.analyzeImage(image, prompts),
+      (error) => {
+        assert.equal(error.status, 429);
+        assert.equal(error.retryAfterMs, 7000);
+        return true;
+      },
+    );
+  } finally {
+    server.closeAllConnections?.();
+    await new Promise((resolve) => server.close(resolve));
+  }
 });
 
 test('lm studio node transport isolates consecutive requests from stale keep-alive sockets', async () => {

--- a/test/enrich/refereeService.test.mjs
+++ b/test/enrich/refereeService.test.mjs
@@ -15,7 +15,7 @@ import {
 } from '../../src/enrich/refereeService.mjs';
 import { annotateBursts } from '../../src/enrich/reviewService.mjs';
 import { Repository } from '../../src/enrich/repository.mjs';
-import { LmStudioProvider, OpenAiCompatibleProvider } from '../../src/enrich/providers.mjs';
+import { LmStudioProvider, OpenAiCompatibleProvider, ProviderRequestError } from '../../src/enrich/providers.mjs';
 import { ResponseTooLargeError } from '../../src/fetchWithTimeout.mjs';
 
 test('refereeGroupKey is order-insensitive and membership-sensitive', () => {
@@ -325,6 +325,46 @@ test('batchDone counts judged stacks this run and resets when the queue drains',
     st = service.status();
     assert.equal(st.remaining, 0);
     assert.equal(st.batchDone, 0);
+  });
+});
+
+test('referee backoff honors a bounded Retry-After hint and otherwise keeps the five-minute fallback', async () => {
+  await withRepo(async (repo) => {
+    const scenarios = [
+      { retryAfterMs: 120000, expectedMs: 120000, expectedLog: 'backing off for 2m' },
+      { retryAfterMs: 60 * 60000, expectedMs: 5 * 60000, expectedLog: 'backing off for 5m' },
+      { retryAfterMs: null, expectedMs: 5 * 60000, expectedLog: 'backing off for 5m' },
+    ];
+
+    for (const scenario of scenarios) {
+      const log = [];
+      let calls = 0;
+      const service = new RefereeService({
+        repo,
+        immich: { getAssetThumbnail: async (assetId) => ({ data: Buffer.from(assetId), contentType: 'image/jpeg' }) },
+        review: fakeReview(makeRows()),
+        enrichRunner: { isRunning: () => false },
+        config: { enrichEnabled: true, curateRefereeEnabled: true, defaultProvider: 'x', providers: {} },
+        log: (message) => log.push(message),
+      });
+      service.makeProvider = () => ({
+        providerName: 'fake',
+        modelName: 'fake-vl',
+        analyzeImages: async () => {
+          calls += 1;
+          throw new ProviderRequestError('fake request failed with status 429', {
+            status: 429,
+            retryAfterMs: scenario.retryAfterMs,
+          });
+        },
+      });
+
+      await service.tick();
+      assert.equal(service._errorBackoffMs, scenario.expectedMs);
+      assert.ok(log.some((line) => line.includes(scenario.expectedLog)));
+      await service.tick();
+      assert.equal(calls, 1, 'an immediate poll must respect the active backoff');
+    }
   });
 });
 

--- a/test/enrich/runnerRetry.test.mjs
+++ b/test/enrich/runnerRetry.test.mjs
@@ -213,6 +213,79 @@ test('exhausted overload retries produce one infrastructure failure for the phot
   assert.deepEqual(repo.processing.map((row) => row.status), ['failed_infra']);
 });
 
+test('persistent overload stops multiplying capped waits across the provider-down probe', async () => {
+  const repo = makeRepo();
+  const log = [];
+  const sleeps = [];
+  let calls = 0;
+  const provider = {
+    providerName: 'venice',
+    modelName: 'test-model',
+    analyzeImage: async () => {
+      calls += 1;
+      throw new ProviderRequestError('quota remains exhausted', { status: 429, retryAfterMs: 300000 });
+    },
+  };
+
+  await assert.rejects(
+    runBatch(batchOptions({
+      repo,
+      provider,
+      retrySleep: async (ms) => sleeps.push(ms),
+      log: (message) => log.push(message),
+    })),
+    /unreachable or misconfigured/,
+  );
+
+  // Two photos receive the complete 3-call treatment; the remaining six
+  // provider-down probes are single calls, so four capped waits total 20m.
+  assert.equal(calls, 12);
+  assert.equal(sleeps.reduce((total, ms) => total + ms, 0), 20 * 60000);
+  assert.equal(repo.processing.filter((row) => row.status === 'failed_infra').length, 8);
+  assert.ok(log.some((line) => line.includes('skipping further overload waits until a request succeeds')));
+});
+
+test('a successful provider response re-enables overload retries after suppression', async () => {
+  const repo = makeRepo();
+  const log = [];
+  const sleeps = [];
+  const callsByAsset = new Map();
+  const provider = {
+    providerName: 'venice',
+    modelName: 'test-model',
+    analyzeImage: async (image) => {
+      const calls = (callsByAsset.get(image.assetId) ?? 0) + 1;
+      callsByAsset.set(image.assetId, calls);
+      if (['photo-1', 'photo-2', 'photo-3'].includes(image.assetId) || (image.assetId === 'photo-5' && calls < 3)) {
+        throw new ProviderRequestError('temporary overload', { status: 429, retryAfterMs: 0 });
+      }
+      return { rawOutput: {}, normalizedOutput: sampleOutput() };
+    },
+  };
+
+  const { counters } = await runBatch(batchOptions({
+    repo,
+    provider,
+    assetIds: IDS_9.slice(0, 5),
+    retrySleep: async (ms) => sleeps.push(ms),
+    log: (message) => log.push(message),
+  }));
+
+  assert.deepEqual(Object.fromEntries(callsByAsset), {
+    'photo-1': 3,
+    'photo-2': 3,
+    'photo-3': 1,
+    'photo-4': 1,
+    'photo-5': 3,
+  });
+  assert.equal(counters.succeeded, 2);
+  assert.equal(counters.failed, 3);
+  // Retry-After: 0 gets the polite one-second floor: four waits before
+  // suppression and two after the successful photo resets the breaker.
+  assert.equal(sleeps.reduce((total, ms) => total + ms, 0), 6000);
+  assert.ok(log.some((line) => line.includes('overload retries re-enabled')));
+});
+
 test('other provider errors are not retried merely because they are infrastructure failures', async () => {
   const repo = makeRepo();
   let calls = 0;

--- a/test/enrich/runnerRetry.test.mjs
+++ b/test/enrich/runnerRetry.test.mjs
@@ -2,8 +2,9 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import { runBatch } from '../../src/enrich/runner.mjs';
+import { ProviderRequestError } from '../../src/enrich/providers.mjs';
 import { ImmichApiError } from '../../src/immich.mjs';
-import { loadV1Taxonomy } from './helpers.mjs';
+import { loadV1Taxonomy, sampleOutput } from './helpers.mjs';
 
 // runBatch-level coverage for the retry-mode edges the jobRunner tests can't
 // reach: the provider-down abort heuristic against known-hard photos, and
@@ -38,6 +39,10 @@ function makeRepo() {
     recordProcessingRun(row) {
       processing.push(row);
     },
+    transaction(work) {
+      return work();
+    },
+    replaceAssetTags() {},
     reviewListAdd: () => 0,
     markAssetsMissing(assetIds) {
       missingMarked.push(...assetIds);
@@ -121,6 +126,144 @@ test('infrastructure failures increment the folded failed counter used by run hi
   }));
   assert.equal(counters.failed, 2);
   assert.equal(repo.processing.filter((row) => row.status === 'failed_infra').length, 2);
+});
+
+test('429 overloads honor Retry-After and retry the same photo before succeeding', async () => {
+  const repo = makeRepo();
+  const log = [];
+  const sleeps = [];
+  let calls = 0;
+  const provider = {
+    providerName: 'venice',
+    modelName: 'test-model',
+    analyzeImage: async () => {
+      calls += 1;
+      if (calls < 3) {
+        throw new ProviderRequestError('venice request failed with status 429', {
+          status: 429,
+          retryAfterMs: 2000,
+        });
+      }
+      return { rawOutput: {}, normalizedOutput: sampleOutput() };
+    },
+  };
+
+  const { counters } = await runBatch(batchOptions({
+    repo,
+    provider,
+    assetIds: ['photo-1'],
+    retrySleep: async (ms) => sleeps.push(ms),
+    log: (message) => log.push(message),
+  }));
+
+  assert.equal(calls, 3);
+  assert.equal(counters.succeeded, 1);
+  assert.equal(counters.failed, 0);
+  assert.equal(counters.retried, 2);
+  assert.equal(sleeps.reduce((total, ms) => total + ms, 0), 4000);
+  assert.equal(repo.processing.at(-1).status, 'succeeded');
+  assert.ok(log.some((line) => line.includes('429 — retrying in 2s (1/2)')));
+  assert.ok(log.some((line) => line.includes('429 — retrying in 2s (2/2)')));
+});
+
+test('503 overloads use growing fallback delays when Retry-After is absent', async () => {
+  const sleeps = [];
+  let calls = 0;
+  const provider = {
+    providerName: 'openrouter',
+    modelName: 'test-model',
+    analyzeImage: async () => {
+      calls += 1;
+      if (calls < 3) throw new ProviderRequestError('temporarily unavailable', { status: 503 });
+      return { rawOutput: {}, normalizedOutput: sampleOutput() };
+    },
+  };
+
+  const { counters } = await runBatch(batchOptions({
+    provider,
+    assetIds: ['photo-1'],
+    retrySleep: async (ms) => sleeps.push(ms),
+  }));
+
+  assert.equal(counters.succeeded, 1);
+  assert.equal(sleeps.reduce((total, ms) => total + ms, 0), 45000);
+});
+
+test('exhausted overload retries produce one infrastructure failure for the photo', async () => {
+  const repo = makeRepo();
+  let calls = 0;
+  const provider = {
+    providerName: 'venice',
+    modelName: 'test-model',
+    analyzeImage: async () => {
+      calls += 1;
+      throw new ProviderRequestError('still overloaded', { status: 429, retryAfterMs: 0 });
+    },
+  };
+
+  const { counters } = await runBatch(batchOptions({
+    repo,
+    provider,
+    assetIds: ['photo-1'],
+    retrySleep: async () => {},
+  }));
+
+  assert.equal(calls, 3);
+  assert.equal(counters.failed, 1);
+  assert.deepEqual(repo.processing.map((row) => row.status), ['failed_infra']);
+});
+
+test('other provider errors are not retried merely because they are infrastructure failures', async () => {
+  const repo = makeRepo();
+  let calls = 0;
+  const provider = {
+    providerName: 'openrouter',
+    modelName: 'test-model',
+    analyzeImage: async () => {
+      calls += 1;
+      throw new ProviderRequestError('internal provider failure', { status: 500, retryAfterMs: 1000 });
+    },
+  };
+
+  const { counters } = await runBatch(batchOptions({
+    repo,
+    provider,
+    assetIds: ['photo-1'],
+    retrySleep: async () => { throw new Error('must not wait'); },
+  }));
+
+  assert.equal(calls, 1);
+  assert.equal(counters.failed, 1);
+  assert.deepEqual(repo.processing.map((row) => row.status), ['failed_infra']);
+});
+
+test('cancellation during an overload wait stops without recording a photo failure', async () => {
+  const repo = makeRepo();
+  const log = [];
+  let cancelRequested = false;
+  let calls = 0;
+  const provider = {
+    providerName: 'venice',
+    modelName: 'test-model',
+    analyzeImage: async () => {
+      calls += 1;
+      throw new ProviderRequestError('overloaded', { status: 429, retryAfterMs: 30000 });
+    },
+  };
+
+  const { counters } = await runBatch(batchOptions({
+    repo,
+    provider,
+    assetIds: ['photo-1'],
+    shouldStop: () => cancelRequested,
+    retrySleep: async () => { cancelRequested = true; },
+    log: (message) => log.push(message),
+  }));
+
+  assert.equal(calls, 1);
+  assert.equal(counters.failed, 0);
+  assert.equal(repo.processing.length, 0);
+  assert.ok(log.some((line) => line.includes('cancellation requested during provider retry wait')));
 });
 
 test('run persistence and logs redact reflected active integration secrets', async () => {


### PR DESCRIPTION
## Outcome

Enrich now rides through short provider overloads instead of immediately leaving photos for a later cleanup run. The Curate AI referee also follows provider retry guidance when it is available.

## Changes

- Carry parsed `Retry-After` timing metadata on provider HTTP errors for both fetch and Node transports.
- Retry only provider 429 and 503 responses, at most twice per photo.
- Honor `Retry-After` up to five minutes; otherwise wait 15 seconds and then 30 seconds.
- Poll cancellation during waits so Cancel responds within 250 ms and does not record the interrupted photo as failed.
- Keep all other HTTP, transport, authentication, validation, and content failures on their existing paths.
- Let the referee use the same capped provider hint, retaining its five-minute fallback.
- Log each Enrich retry with status, delay, and attempt count.
- Document the behavior in the changelog and Enrich guide.

## Validation

- `npm test` — 1,014 passed
- `npm run check:publication`
- `npm run check:dco`
- `git diff --check`

Coverage includes fetch and Node `Retry-After` propagation, seconds/date parsing, successful and exhausted 429 retries, 503 fallback delays, cancellation during a wait, the no-retry boundary for other infrastructure failures, referee hints/fallbacks, and the five-minute cap.

## Risk and rollback

The retry boundary is deliberately narrow and bounded: only 429/503 responses receive two additional attempts. No persisted-state contract, API shape, or provider configuration changes. Reverting this PR restores the existing behavior where temporary provider errors immediately record one `failed_infra` result for later retry.

## Authorship and review

Implemented by Codex with user direction. No independent agent review has been performed yet.

Fixes PIC-119
