### PR TITLE
PIC-47: Record one terminal Enrich outcome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ All notable changes to Pictaria Server are documented here. This project follows
   Curate AI referee also uses bounded provider retry guidance before its
   existing five-minute fallback.
 
+### Fixed
+
+- A server shutdown that outlasts an Enrich run's drain now records exactly
+  one interrupted Recent Runs entry. If abandoned work later settles, it
+  cannot append a contradictory outcome or advance the queued job.
+
 ## 1.0.1 - 2026-09-02
 
 ### Changed

--- a/docs/ENRICH.md
+++ b/docs/ENRICH.md
@@ -439,14 +439,16 @@ your approved tags on every request.
   the job again.
 - **Cancel or restart mid-run**: results already produced are saved
   per-photo the moment they finish. A cancelled run leaves its queue item
-  in place; a server restart records the run as *interrupted*. Either way,
-  running the item again continues where it left off.
+  in place; a server restart records exactly one *interrupted* run and leaves
+  its queue item in place even if abandoned provider work later settles.
+  Either way, running the item again continues where it left off.
 
 ## Run history
 
 The Enrich page lists recent runs: what ran (slice title or library sweep),
 when, provider + model, taxonomy + prompt versions, counters
-(analyzed / ok / failed), and outcome (finished / cancelled / failed). Model
+(analyzed / ok / failed), and outcome (finished / cancelled / interrupted /
+failed). Model
 comparisons stay honest — you can always see which model and prompt produced
 a batch of tags. Runs with at least one successful photo also show two
 end-to-end rates: successful photos per minute and average wall-clock seconds

--- a/src/enrich/jobRunner.mjs
+++ b/src/enrich/jobRunner.mjs
@@ -16,6 +16,7 @@ export class EnrichJobRunner {
     this.config = config;
     this.state = idleState();
     this.runPromise = null;
+    this.runLifecycle = null;
     // One-way shutdown latch: a request landing during the drain window
     // must not start a run nobody will drain or record.
     this.stopped = false;
@@ -73,10 +74,26 @@ export class EnrichJobRunner {
   // record the run synchronously here or it vanishes from history. Per-photo
   // results are already committed; a queued item stays queued and resumes.
   recordInterrupted() {
-    if (!this.state.running) {
+    const lifecycle = this.runLifecycle;
+    if (!this.state.running || !lifecycle || lifecycle.terminalRecorded) {
       return false;
     }
-    this.#log('server shutting down — run interrupted; results so far are saved and the job stays queued');
+    if (!lifecycle.interrupted) {
+      lifecycle.interrupted = true;
+      lifecycle.terminalStatus = 'interrupted';
+      lifecycle.interruptedAt = new Date().toISOString();
+      this.#log('server shutting down — run interrupted; results so far are saved and the job stays queued');
+    }
+    this.#recordTerminal(lifecycle, {
+      status: 'interrupted',
+      error: null,
+      finishedAt: lifecycle.interruptedAt,
+    });
+    return true;
+  }
+
+  #recordTerminal(lifecycle, { status, error, finishedAt }) {
+    if (lifecycle.terminalRecorded) return false;
     this.repo.recordJobRun({
       title: this.state.title,
       provider: this.state.provider,
@@ -85,13 +102,15 @@ export class EnrichJobRunner {
       taxonomyVersion: this.taxonomy.version,
       inferenceHostLabel: this.state.inferenceHostLabel,
       targeted: this.state.options.targeted,
-      status: 'interrupted',
-      error: null,
+      status,
+      error,
       counters: this.state.counters,
       log: this.state.log,
       startedAt: this.state.startedAt,
-      finishedAt: new Date().toISOString(),
+      finishedAt,
     });
+    lifecycle.terminalRecorded = true;
+    lifecycle.terminalStatus = status;
     return true;
   }
 
@@ -328,12 +347,23 @@ export class EnrichJobRunner {
       this.#log('when this run finishes, earlier Curate decisions for these photos will be cleared for re-review');
     }
 
+    // Per-run latch: an interruption record written after a timed-out drain
+    // remains the sole terminal history row even if abandoned async work
+    // later settles. Kept separate from UI state so queue completion cannot
+    // accidentally reset it while the old promise unwinds.
+    const lifecycle = {
+      interrupted: false,
+      interruptedAt: null,
+      terminalRecorded: false,
+      terminalStatus: null,
+    };
+    this.runLifecycle = lifecycle;
     // Stored so stop() can drain the in-flight run; #run never rejects.
-    this.runPromise = this.#run(provider, prompts, assetIds);
+    this.runPromise = this.#run(provider, prompts, assetIds, lifecycle);
     return this.status();
   }
 
-  async #run(provider, prompts, assetIds = null) {
+  async #run(provider, prompts, assetIds, lifecycle) {
     let listed = 0;
     try {
       const { counters, listedForReview } = await runBatch({
@@ -374,23 +404,27 @@ export class EnrichJobRunner {
       this.state.running = false;
       this.state.cancelRequested = false;
       try {
-        this.repo.recordJobRun({
-          title: this.state.title,
-          provider: this.state.provider,
-          model: this.state.model,
-          promptVersion: this.state.promptVersion,
-          taxonomyVersion: this.taxonomy.version,
-          inferenceHostLabel: this.state.inferenceHostLabel,
-          targeted: this.state.options.targeted,
-          status: this.state.error ? 'failed' : this.state.cancelled ? 'cancelled' : 'finished',
-          error: this.state.error,
-          counters: this.state.counters,
-          log: this.state.log,
-          startedAt: this.state.startedAt,
-          finishedAt: this.state.finishedAt,
+        this.#recordTerminal(lifecycle, {
+          status: lifecycle.interrupted
+            ? 'interrupted'
+            : this.state.error
+              ? 'failed'
+              : this.state.cancelled
+                ? 'cancelled'
+                : 'finished',
+          error: lifecycle.interrupted ? null : this.state.error,
+          finishedAt: lifecycle.interrupted ? lifecycle.interruptedAt : this.state.finishedAt,
         });
       } catch (error) {
         this.#log(`could not record run history: ${error instanceof Error ? error.message : error}`);
+      }
+      // Once interruption has been published, the abandoned promise may
+      // only settle and clear in-memory state. It must never remove/advance
+      // its queue item or invoke a clean-finish callback after shutdown gave
+      // up waiting for it.
+      if (lifecycle.interrupted) {
+        this.onRunFinished = null;
+        return;
       }
       // "Send results to Curate": photos join the review list as they are
       // enriched (or were already enriched) during the run — never on

--- a/test/enrich/jobRunner.test.mjs
+++ b/test/enrich/jobRunner.test.mjs
@@ -243,6 +243,8 @@ test('recordInterrupted writes an interrupted run to history while running', asy
   assert.equal(repo.runs[0].status, 'interrupted');
   assert.equal(repo.runs[0].title, 'Interrupted slice');
   assert.ok(runner.status().log.some((line) => line.includes('run interrupted')));
+  assert.equal(runner.recordInterrupted(), false, 'the terminal row is idempotent');
+  assert.equal(repo.runs.length, 1);
 });
 
 test('needsWorkFilter resolves the run key start() would use and delegates to the repo in batch', () => {

--- a/test/lifecycle.test.mjs
+++ b/test/lifecycle.test.mjs
@@ -291,7 +291,7 @@ test('jobRunner stop() cancels and drains the run — one cancelled record, no i
   assert.equal(runs[0].status, 'cancelled');
 });
 
-test('jobRunner stop() past its budget records the run as interrupted', async () => {
+test('jobRunner stop() past its budget records exactly one interrupted row and never completes its queue', async () => {
   const { opened, release } = gate();
   const { runner, runs } = runnerFixture({
     getAsset: async (id) => {
@@ -299,14 +299,23 @@ test('jobRunner stop() past its budget records the run as interrupted', async ()
       return { id, originalPath: `${id}.jpg` };
     },
   });
-  runner.start({ assetIds: ['a1'], title: 'Stuck run' });
+  let completed = 0;
+  runner.start({
+    assetIds: ['a1'],
+    title: 'Stuck run',
+    onFinished: () => { completed += 1; },
+  });
 
   assert.equal(await runner.stop(50), false);
-  assert.ok(runs.some((run) => run.status === 'interrupted'), 'a stuck run must not vanish from history');
+  assert.equal(runs.length, 1);
+  assert.equal(runs[0].status, 'interrupted', 'a stuck run must not vanish from history');
 
   release(); // let the dangling run settle before the test ends
   await runner.runPromise;
   assert.equal(runner.isRunning(), false);
+  assert.equal(runs.length, 1, 'late settlement must not append a contradictory terminal row');
+  assert.equal(runs[0].status, 'interrupted');
+  assert.equal(completed, 0, 'late settlement must not invoke queue completion');
 });
 
 test('jobRunner stop() while idle is an immediate true', async () => {


### PR DESCRIPTION
## Outcome

An Enrich run whose shutdown drain times out now owns exactly one terminal history outcome: `interrupted`. Late-settling async work cannot append a contradictory `cancelled` or `failed` row, remove its queue item, or advance a Run-all chain.

## Changes

- Add a per-run terminal lifecycle latch shared by shutdown interruption and normal finalization.
- Make `recordInterrupted()` idempotent and preserve interruption as the winning terminal outcome.
- Let a failed immediate history write retry as `interrupted` when the abandoned promise later settles.
- Stop all clean-finish and queue-completion bookkeeping after an interruption has been published.
- Document the exactly-once Recent Runs behavior and add the fix to the changelog.

## Validation

- `npm test` — 1,017 passed
- `npm run check:publication`
- `npm run check:dco`
- `git diff --check`

Lifecycle coverage asserts that a normal drain creates exactly one `cancelled` row, a timed-out drain creates exactly one `interrupted` row after late settlement, repeated interruption recording is idempotent, and the late queue-completion callback never runs.

## Risk and rollback

This is an in-memory lifecycle guard with no database migration or persisted-state contract change. Per-photo results remain committed as before. Reverting the PR restores the former append-on-finally behavior, including the duplicate terminal-history race.

## Authorship and review

Implemented by Codex with user direction. No independent agent review has been performed yet.

Fixes PIC-47
