### PR TITLE
PIC-107: Abort active Enrich provider requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ All notable changes to Pictaria Server are documented here. This project follows
 
 ### Changed
 
+- Enrich cancellation now aborts the active AI-provider request immediately
+  instead of waiting out that photo's provider timeout. The cancelled photo
+  remains retryable on the next run, and queued work stays in place.
 - The persisted Settings contract advances to version 5 and the installation
   state contract to version 7. Existing installations take the standard
   automatic pre-migration recovery snapshot before adopting the additive

--- a/docs/ENRICH.md
+++ b/docs/ENRICH.md
@@ -238,10 +238,13 @@ latest successful run per photo is what Curate and the caption data use.
   chain advances only on clean finishes: a failure or cancel stops it (the
   stop is recorded in run history) and whatever remains stays queued, ready
   for the next Run all.
-- **Cancellation** is cooperative: the in-flight photo finishes first
-  (30–60 s on large local models). Cancel doubles as pause — a queued job
-  stays in the queue unless its run finishes cleanly, and running it again
-  continues where it left off (already-enriched photos are skipped).
+- **Cancellation** aborts an active AI-provider request immediately. That
+  photo is recorded as an infrastructure failure, so it does not consume a
+  failure strike and retries automatically the next time the job runs. If
+  Pictaria is waiting on an Immich request instead, it stops as soon as that
+  request returns. Cancel doubles as pause — a queued job stays in the queue
+  unless its run finishes cleanly, and running it again continues where it
+  left off (already-enriched photos are skipped).
 - **Recent runs** starts with the newest 20 summaries. **Load more** walks
   through all 100 retained summaries without loading their potentially large
   logs; each log is fetched only when you open it. Retry actions remain
@@ -804,7 +807,7 @@ and expect the queue to breathe a little while enrichment is running.
 - `POST /api/enrich/discarded/restore` — `{ assetIds }` → unflag; returns
   `{ restored, assets, total, truncated }`. The same 1,000-ID canonical batch
   boundary applies atomically.
-- `POST /api/enrich/cancel` — cooperative cancel.
+- `POST /api/enrich/cancel` — cancel the run and abort its active provider request.
 - `GET|POST /api/enrich/queue`, `POST /api/enrich/queue/:id/run`
   (`{ provider, sendToCurate, reopenDecided, skipAnySuccessful }`),
   `DELETE /api/enrich/queue/:id` — the Send-to-Enrich queue (deleting the

--- a/public/enrich.html
+++ b/public/enrich.html
@@ -186,7 +186,7 @@
         <strong>Status</strong>
         <div class="p-grow"></div>
         <button id="viewLogBtn" class="p-btn quiet">Log</button>
-        <button id="enrichCancel" class="p-btn danger" hidden title="Finishes the photo it's on, then stops. A queued job stays in the queue — run it again to continue where it left off.">Cancel</button>
+        <button id="enrichCancel" class="p-btn danger" hidden title="Stops the active model request. An interrupted photo retries next time, and a queued job stays in the queue.">Cancel</button>
       </div>
       <div id="enrichStatusLine" class="es-line"></div>
       <div id="enrichStatusLine2" class="es-line es-line2" hidden></div>
@@ -462,7 +462,7 @@
         }
         el('enrichStatusLine').textContent = statusLine1;
         el('enrichStatusLine').title = status.running && status.cancelRequested
-          ? 'Finishing the photo it’s on, then stopping. The queue item stays for the next run.'
+          ? 'Stopping the active model request. An interrupted photo and the queue item stay for the next run.'
           : '';
         el('enrichStatusLine2').textContent = statusLine2;
         el('enrichStatusLine2').hidden = !statusLine2;
@@ -474,9 +474,8 @@
           el('enrichBarText').textContent = `${done.toLocaleString()} / ${goal.toLocaleString()}`;
         }
         el('enrichCancel').hidden = !status.running;
-        // Cancel is cooperative — the model finishes its current photo, which
-        // can take a minute locally. Acknowledge the press instantly and keep
-        // acknowledging until the run actually stops.
+        // Acknowledge the press instantly while the server tears down the
+        // active provider request (or finishes an Immich call already underway).
         if (status.cancelRequested && status.running) {
           el('enrichCancel').disabled = true;
           el('enrichCancel').textContent = 'Cancelling…';

--- a/src/enrich/jobRunner.mjs
+++ b/src/enrich/jobRunner.mjs
@@ -39,14 +39,19 @@ export class EnrichJobRunner {
     if (!this.state.running) {
       return false;
     }
+    const firstCancellation = !this.state.cancelRequested;
     this.state.cancelRequested = true;
-    this.#log('cancel requested; finishing current photo');
+    this.runLifecycle?.providerAbortController.abort();
+    if (firstCancellation) {
+      this.#log('cancel requested; stopping current photo');
+    }
     return true;
   }
 
   // Shutdown drain: request cancellation (the run checks between photos) and
-  // wait for the run promise — bounded, because a photo mid-provider-call
-  // can't be aborted. A run that drains in time records itself as
+  // wait for the run promise — bounded, because Immich work does not yet
+  // take the run's abort signal. Provider work is aborted immediately. A run
+  // that drains in time records itself as
   // 'cancelled' through its own finally; one we give up on is recorded as
   // 'interrupted' here, or it would vanish from run history when the
   // process exits before its finally reaches the database. Per-photo
@@ -356,6 +361,7 @@ export class EnrichJobRunner {
       interruptedAt: null,
       terminalRecorded: false,
       terminalStatus: null,
+      providerAbortController: new AbortController(),
     };
     this.runLifecycle = lifecycle;
     // Stored so stop() can drain the in-flight run; #run never rejects.
@@ -389,6 +395,7 @@ export class EnrichJobRunner {
         // setting, so a mid-run toggle just pauses the queue, not the run.
         captionWriteback: Boolean(this.config.captionWriteback),
         shouldStop: () => this.state.cancelRequested,
+        signal: lifecycle.providerAbortController.signal,
         log: (message) => this.#onProgress(message),
       });
       this.state.counters = counters;

--- a/src/enrich/jobRunner.mjs
+++ b/src/enrich/jobRunner.mjs
@@ -4,7 +4,8 @@ import { createProvider } from './providers.mjs';
 import { configuredSecrets, sanitizeDiagnostic } from '../diagnostics.mjs';
 
 // Single-flight enrichment job runner for the server: one run at a time,
-// live progress counters, a bounded log tail, and cooperative cancellation.
+// live progress counters, a bounded log tail, and cancellation that aborts
+// provider requests while remaining cooperative at Immich boundaries.
 
 const LOG_TAIL_LIMIT = 500;
 

--- a/src/enrich/providers.mjs
+++ b/src/enrich/providers.mjs
@@ -11,7 +11,7 @@ import { appendHttpUrlPath, normalizeHttpUrl } from '../config.mjs';
 import { sanitizeDiagnostic, structuredUpstreamDiagnostic } from '../diagnostics.mjs';
 
 // Vision providers. Each analyzeImage(image, { systemPrompt, userPrompt,
-// jsonSchema }) returns { rawOutput, normalizedOutput }. An image is
+// jsonSchema, signal? }) returns { rawOutput, normalizedOutput }. An image is
 // { data: Buffer|Uint8Array, mimeType, assetId? }.
 // analyzeImages(images, options) sends several images in ONE request (the
 // group referee: "here are 5 frames of the same moment, rank them");
@@ -68,7 +68,7 @@ const GEMINI_JSON_SCHEMA_KEYWORDS = new Set([
 // 5xx) from "the provider judged this request's content" — the runner only
 // charges an asset's permanent failure allowance for the latter.
 export class ProviderRequestError extends Error {
-  constructor(message, { status = null, timeout = false, retryAfterMs = null } = {}) {
+  constructor(message, { status = null, timeout = false, cancelled = false, retryAfterMs = null } = {}) {
     super(message);
     this.name = 'ProviderRequestError';
     this.status = status;
@@ -81,8 +81,12 @@ export class ProviderRequestError extends Error {
     // an HTTP status. Carried explicitly rather than sniffed from the
     // message text.
     this.timeout = timeout;
+    // User-requested cancellation shares the transport teardown used by a
+    // timeout, but is kept distinct so Enrich can stop immediately without
+    // presenting the request as a provider failure.
+    this.cancelled = cancelled;
     this.infrastructure =
-      status === null || status === 401 || status === 403 || status === 429 || status >= 500;
+      cancelled || status === null || status === 401 || status === 403 || status === 429 || status >= 500;
   }
 }
 
@@ -142,7 +146,13 @@ export class OpenAiProvider {
     return this.analyzeImages([image], options);
   }
 
-  async analyzeImages(images, { systemPrompt, userPrompt, jsonSchema, schemaName = 'pictaria_photo_enrichment' }) {
+  async analyzeImages(images, {
+    systemPrompt,
+    userPrompt,
+    jsonSchema,
+    schemaName = 'pictaria_photo_enrichment',
+    signal = null,
+  }) {
     const body = {
       model: this.modelName,
       input: [
@@ -167,7 +177,7 @@ export class OpenAiProvider {
     };
     const rawOutput = await postJson(this, 'https://api.openai.com/v1/responses', body, {
       Authorization: `Bearer ${this.apiKey}`,
-    });
+    }, { signal });
     const outputText = extractOpenAiOutputText(rawOutput);
     if (!outputText) {
       throw new Error('OpenAI response did not include output_text');
@@ -234,7 +244,13 @@ export class LmStudioProvider {
     return this.analyzeImages([image], options);
   }
 
-  async analyzeImages(images, { systemPrompt, userPrompt, jsonSchema, schemaName = 'pictaria_photo_enrichment' }) {
+  async analyzeImages(images, {
+    systemPrompt,
+    userPrompt,
+    jsonSchema,
+    schemaName = 'pictaria_photo_enrichment',
+    signal = null,
+  }) {
     const body = {
       model: this.modelName,
       messages: [
@@ -265,7 +281,13 @@ export class LmStudioProvider {
       body.max_tokens = this.maxTokens;
     }
     const headers = this.apiKey ? { Authorization: `Bearer ${this.apiKey}` } : {};
-    const rawOutput = await postJson(this, appendHttpUrlPath(this.baseUrl, '/chat/completions'), body, headers);
+    const rawOutput = await postJson(
+      this,
+      appendHttpUrlPath(this.baseUrl, '/chat/completions'),
+      body,
+      headers,
+      { signal },
+    );
     const outputText = extractSchemaConstrainedChoiceContent(rawOutput);
     if (!outputText) {
       throw new Error('LM Studio response did not include message content');
@@ -329,7 +351,7 @@ export class OpenAiCompatibleProvider {
     return this.analyzeImages([image], options);
   }
 
-  async analyzeImages(images, { systemPrompt, userPrompt, jsonSchema }) {
+  async analyzeImages(images, { systemPrompt, userPrompt, jsonSchema, signal = null }) {
     // JSON-object mode constrains only the outer syntax. Unlike a strict
     // json_schema request, it does not tell the model which fields Pictaria
     // requires, so include the deterministic schema text in the prompt and
@@ -365,7 +387,13 @@ export class OpenAiCompatibleProvider {
       max_tokens: this.maxTokens,
     };
     const headers = this.apiKey ? { Authorization: `Bearer ${this.apiKey}` } : {};
-    const rawOutput = await postJson(this, appendHttpUrlPath(this.baseUrl, '/chat/completions'), body, headers);
+    const rawOutput = await postJson(
+      this,
+      appendHttpUrlPath(this.baseUrl, '/chat/completions'),
+      body,
+      headers,
+      { signal },
+    );
     const outputText = extractSchemaConstrainedChoiceContent(rawOutput);
     if (!outputText) {
       throw new Error('OpenAI-compatible response did not include message content');
@@ -434,7 +462,13 @@ export class OpenRouterProvider {
     return this.analyzeImages([image], options);
   }
 
-  async analyzeImages(images, { systemPrompt, userPrompt, jsonSchema, schemaName = 'pictaria_photo_enrichment' }) {
+  async analyzeImages(images, {
+    systemPrompt,
+    userPrompt,
+    jsonSchema,
+    schemaName = 'pictaria_photo_enrichment',
+    signal = null,
+  }) {
     const providerJsonSchema = openRouterJsonSchema(this.modelName, jsonSchema);
     const body = {
       model: this.modelName,
@@ -463,7 +497,7 @@ export class OpenRouterProvider {
       Authorization: `Bearer ${this.apiKey}`,
       'HTTP-Referer': 'https://github.com/pictaria-ai/pictaria-server',
       'X-Title': 'Pictaria',
-    });
+    }, { signal });
     const outputText = extractChoiceMessageContent(rawOutput);
     if (!outputText) {
       const detail = openRouterEmptyContentDiagnostic(rawOutput, this.apiKey);
@@ -559,7 +593,13 @@ export class VeniceProvider {
     return this.analyzeImages([image], options);
   }
 
-  async analyzeImages(images, { systemPrompt, userPrompt, jsonSchema, schemaName = 'pictaria_photo_enrichment' }) {
+  async analyzeImages(images, {
+    systemPrompt,
+    userPrompt,
+    jsonSchema,
+    schemaName = 'pictaria_photo_enrichment',
+    signal = null,
+  }) {
     // Venice's response_format constrains the output grammar but — unlike
     // OpenAI's structured outputs — does not show the model the schema, so
     // free-text fields came back as type-satisfying empty strings (caption:
@@ -611,7 +651,7 @@ export class VeniceProvider {
     };
     const rawOutput = await postJson(this, appendHttpUrlPath(this.baseUrl, '/chat/completions'), body, {
       Authorization: `Bearer ${this.apiKey}`,
-    });
+    }, { signal });
     const outputText = extractChoiceMessageContent(rawOutput);
     if (!outputText) {
       throw new Error('Venice response did not include message content');
@@ -665,7 +705,7 @@ export class OllamaCloudProvider {
     return this.analyzeImages([image], options);
   }
 
-  async analyzeImages(images, { systemPrompt, userPrompt, jsonSchema }) {
+  async analyzeImages(images, { systemPrompt, userPrompt, jsonSchema, signal = null }) {
     const schemaText = JSON.stringify(sortKeysDeep(jsonSchema));
     const strictUserPrompt =
       `${userPrompt}\n\n` +
@@ -688,7 +728,7 @@ export class OllamaCloudProvider {
     };
     const rawOutput = await postJson(this, appendHttpUrlPath(this.baseUrl, '/api/chat'), body, {
       Authorization: `Bearer ${this.apiKey}`,
-    });
+    }, { signal });
     const content = extractOllamaMessageContent(rawOutput);
     if (!content) {
       throw new Error('Ollama response did not include message content');
@@ -761,7 +801,7 @@ export class OllamaLocalProvider {
     return this.analyzeImages([image], options);
   }
 
-  async analyzeImages(images, { systemPrompt, userPrompt, jsonSchema }) {
+  async analyzeImages(images, { systemPrompt, userPrompt, jsonSchema, signal = null }) {
     const body = {
       model: this.modelName,
       messages: [
@@ -788,6 +828,7 @@ export class OllamaLocalProvider {
       appendHttpUrlPath(this.baseUrl, '/api/chat'),
       body,
       this.apiKey ? { Authorization: `Bearer ${this.apiKey}` } : {},
+      { signal },
     );
     const content = extractOllamaMessageContent(rawOutput);
     if (!content) {
@@ -808,7 +849,7 @@ export class OllamaLocalProvider {
   }
 }
 
-async function postJson(provider, url, body, extraHeaders) {
+async function postJson(provider, url, body, extraHeaders, { signal = null } = {}) {
   const headers = {
     'Content-Type': 'application/json',
     Accept: 'application/json',
@@ -819,10 +860,27 @@ async function postJson(provider, url, body, extraHeaders) {
   // group can run 10+ minutes). Default transport is node:http(s) with a
   // single wall-clock deadline; injected fetchImpl (tests, custom) is kept.
   if (provider.fetchImpl === fetch) {
-    return nodePostJson(provider, url, headers, JSON.stringify(body));
+    return nodePostJson(provider, url, headers, JSON.stringify(body), { signal });
   }
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), provider.timeoutMs);
+  let timedOut = false;
+  let cancelled = false;
+  const onCancel = () => {
+    if (timedOut || cancelled) return;
+    cancelled = true;
+    controller.abort();
+  };
+  if (signal?.aborted) {
+    onCancel();
+  } else {
+    signal?.addEventListener('abort', onCancel, { once: true });
+  }
+  const timeout = setTimeout(() => {
+    if (cancelled) return;
+    timedOut = true;
+    controller.abort();
+  }, provider.timeoutMs);
+  timeout.unref?.();
   let response;
   try {
     response = await provider.fetchImpl(url, {
@@ -833,14 +891,18 @@ async function postJson(provider, url, body, extraHeaders) {
       body: JSON.stringify(body),
     });
   } catch (error) {
-    const timedOut = error?.name === 'AbortError';
-    const reason = timedOut ? `timed out after ${provider.timeoutMs}ms` : error?.message ?? error;
+    const reason = cancelled
+      ? 'cancelled'
+      : timedOut
+        ? `timed out after ${provider.timeoutMs}ms`
+        : error?.message ?? error;
     throw new ProviderRequestError(
       `${provider.providerName} request failed: ${sanitizeDiagnostic(reason, { secrets: [provider.apiKey] })}`,
-      { timeout: timedOut },
+      { timeout: timedOut, cancelled },
     );
   } finally {
     clearTimeout(timeout);
+    signal?.removeEventListener('abort', onCancel);
   }
 
   if (!response.ok) {
@@ -899,8 +961,12 @@ async function readErrorDetail(response, provider) {
 // POST JSON over node:http(s): same semantics as the fetch path (throws the
 // provider-labelled error on failure, resolves with parsed JSON), but the
 // only timeout is our own absolute deadline.
-function nodePostJson(provider, url, headers, payload) {
+function nodePostJson(provider, url, headers, payload, { signal = null } = {}) {
   return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new ProviderRequestError(`${provider.providerName} request failed: cancelled`, { cancelled: true }));
+      return;
+    }
     const target = new URL(url);
     const makeRequest = target.protocol === 'https:' ? httpsRequest : httpRequest;
     // Lightweight OpenAI-compatible servers can close a completed keep-alive
@@ -912,16 +978,22 @@ function nodePostJson(provider, url, headers, payload) {
     // inference work upstream.
     const isolateConnection = provider.isolateConnection === true;
     const chunks = [];
-    const fail = (reason, { timeout = false } = {}) => reject(
-      new ProviderRequestError(
+    const cleanup = () => {
+      clearTimeout(deadline);
+      signal?.removeEventListener('abort', onCancel);
+    };
+    const fail = (reason, { timeout = false, cancelled = false } = {}) => {
+      cleanup();
+      reject(new ProviderRequestError(
         `${provider.providerName} request failed: ${sanitizeDiagnostic(reason, { secrets: [provider.apiKey] })}`,
-        { timeout },
-      ),
-    );
+        { timeout, cancelled },
+      ));
+    };
     // Set when our own deadline destroys the socket, so the resulting
     // 'error' event is reported as a timeout rather than a generic
     // transport failure.
     let timedOut = false;
+    let cancelled = false;
     const request = makeRequest(target, {
       method: 'POST',
       headers,
@@ -937,9 +1009,9 @@ function nodePostJson(provider, url, headers, payload) {
         }
         chunks.push(chunk);
       });
-      response.on('error', (error) => fail(error?.message ?? error));
+      response.on('error', (error) => fail(error?.message ?? error, { timeout: timedOut, cancelled }));
       response.on('end', () => {
-        clearTimeout(deadline);
+        cleanup();
         const text = Buffer.concat(chunks).toString('utf8');
         if (response.statusCode < 200 || response.statusCode >= 300) {
           const detail = providerErrorDetail(text, provider.providerName, provider.apiKey);
@@ -957,13 +1029,19 @@ function nodePostJson(provider, url, headers, payload) {
       });
     });
     const deadline = setTimeout(() => {
+      if (cancelled) return;
       timedOut = true;
       request.destroy(new Error(`timed out after ${provider.timeoutMs}ms`));
     }, provider.timeoutMs);
     if (typeof deadline.unref === 'function') deadline.unref();
+    const onCancel = () => {
+      if (timedOut || cancelled) return;
+      cancelled = true;
+      request.destroy(new Error('cancelled'));
+    };
+    signal?.addEventListener('abort', onCancel, { once: true });
     request.on('error', (error) => {
-      clearTimeout(deadline);
-      fail(error?.message ?? error, { timeout: timedOut });
+      fail(error?.message ?? error, { timeout: timedOut, cancelled });
     });
     request.end(payload);
   });

--- a/src/enrich/runner.mjs
+++ b/src/enrich/runner.mjs
@@ -383,6 +383,14 @@ export async function runBatch({
             throw fetchError;
           }
         }
+        // Immich calls do not yet take the run's abort signal. If Cancel
+        // arrived while the image was downloading, stop here rather than
+        // manufacturing a provider cancellation for a request never sent.
+        if (shouldStop()) {
+          log('stopping early: cancellation requested after image download');
+          stopped = true;
+          break;
+        }
         const { normalized, decisions, retryCount } = await analyzeWithValidationRetry(
           provider,
           { data: image.data, mimeType: image.contentType, assetId },

--- a/src/enrich/runner.mjs
+++ b/src/enrich/runner.mjs
@@ -119,6 +119,7 @@ export async function analyzeWithValidationRetry(provider, image, {
   retrySleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
   overloadRetryLimit = PROVIDER_OVERLOAD_RETRY_LIMIT,
   onProviderResponse = () => {},
+  signal = null,
 }) {
   const prompts = [userPrompt];
   // Every local provider (local_*), plus generic endpoints that explicitly
@@ -138,6 +139,7 @@ export async function analyzeWithValidationRetry(provider, image, {
           systemPrompt,
           userPrompt: prompts[attemptIndex],
           jsonSchema,
+          signal,
         });
         // A completed provider response proves a persistent 429/503 wave has
         // ended even if local schema validation later rejects its content.
@@ -196,6 +198,7 @@ export async function runBatch({
   log = () => {},
   now = Date.now,
   retrySleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  signal = null,
 }) {
   const diagnosticSecrets = configuredSecrets(immich, provider);
   if (maxAnalyzed !== null && maxAnalyzed < 1) {
@@ -393,6 +396,7 @@ export async function runBatch({
             retrySleep,
             overloadRetryLimit,
             onProviderResponse: noteProviderResponse,
+            signal,
           },
         );
         // One transaction: a run may never read as 'succeeded' without its
@@ -435,6 +439,7 @@ export async function runBatch({
           stopped = true;
           break;
         }
+        const cancelledMidRequest = error?.name === 'ProviderRequestError' && error.cancelled === true;
         if (overloadRetryLimit > 0 && isRetryableProviderOverload(error)) {
           exhaustedOverloadPhotos += 1;
           if (exhaustedOverloadPhotos >= PROVIDER_OVERLOAD_EXHAUSTION_LIMIT) {
@@ -458,6 +463,11 @@ export async function runBatch({
         counters.failed += 1;
         if (infrastructure) {
           infraFailed += 1;
+        }
+        if (cancelledMidRequest) {
+          log(`${position} cancelled mid-request; photo will retry next run`);
+          stopped = true;
+          break;
         }
         log(`  failed: ${diagnostic}`);
         // Every photo failing from the start means the provider is down or

--- a/test/enrich/jobRunner.test.mjs
+++ b/test/enrich/jobRunner.test.mjs
@@ -1,5 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
 import { fileURLToPath } from 'node:url';
 
 import { EnrichJobRunner } from '../../src/enrich/jobRunner.mjs';
@@ -23,16 +24,20 @@ function makeConfig() {
 
 function makeRepo({ alreadyEnriched = true } = {}) {
   const runs = [];
+  const processingRuns = [];
   const reviewListCalls = [];
   return {
     runs,
+    processingRuns,
     reviewListCalls,
     upsertAsset() {},
     hasAnySuccessfulRun: () => alreadyEnriched,
     hasSuccessfulRun: () => false,
     failureCount: () => 0,
     isAssetDiscarded: () => false,
-    recordProcessingRun() {},
+    recordProcessingRun(row) {
+      processingRuns.push(row);
+    },
     recordJobRun(row) {
       runs.push(row);
     },
@@ -190,6 +195,49 @@ test('a failed run never touches the review list', async () => {
   await finished(runner);
 
   assert.equal(repo.reviewListCalls.length, 0);
+});
+
+test('cancel aborts an in-flight provider request and leaves the photo retryable', { timeout: 5000 }, async () => {
+  let markRequestStarted;
+  const requestStarted = new Promise((resolve) => { markRequestStarted = resolve; });
+  const server = createServer((request) => {
+    request.resume();
+    request.once('end', markRequestStarted);
+    // Deliberately never answer: cancellation must tear down the request
+    // rather than wait for the provider timeout.
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+  const repo = makeRepo({ alreadyEnriched: false });
+  const config = makeConfig();
+  config.providers.local_lmstudio.baseUrl = `http://127.0.0.1:${server.address().port}/v1`;
+  config.providers.local_lmstudio.timeoutMs = 60000;
+  const runner = new EnrichJobRunner({
+    repo,
+    immich: {
+      getAsset: async (id) => ({ id, originalPath: `${id}.jpg` }),
+      getAssetThumbnail: async () => ({ data: Buffer.from('image'), contentType: 'image/jpeg' }),
+    },
+    taxonomy,
+    config,
+  });
+
+  try {
+    runner.start({ assetIds: ['a1'], sendToCurate: false });
+    await requestStarted;
+    assert.equal(runner.cancel(), true);
+    await finished(runner);
+
+    assert.equal(repo.processingRuns.length, 1);
+    assert.equal(repo.processingRuns[0].status, 'failed_infra');
+    assert.equal(repo.runs.length, 1);
+    assert.equal(repo.runs[0].status, 'cancelled');
+    assert.ok(runner.status().log.some((line) => line.includes('cancelled mid-request')));
+    assert.equal(runner.status().error, null);
+  } finally {
+    server.closeAllConnections?.();
+    await new Promise((resolve) => server.close(resolve));
+  }
 });
 
 test('onFinished is skipped when the run fails', async () => {

--- a/test/enrich/jobRunner.test.mjs
+++ b/test/enrich/jobRunner.test.mjs
@@ -240,6 +240,38 @@ test('cancel aborts an in-flight provider request and leaves the photo retryable
   }
 });
 
+test('cancel during an Immich download stops before provider work without a phantom failure', async () => {
+  let markDownloadStarted;
+  let finishDownload;
+  const downloadStarted = new Promise((resolve) => { markDownloadStarted = resolve; });
+  const repo = makeRepo({ alreadyEnriched: false });
+  const runner = new EnrichJobRunner({
+    repo,
+    immich: {
+      getAsset: async (id) => ({ id, originalPath: `${id}.jpg` }),
+      getAssetThumbnail: () => new Promise((resolve) => {
+        finishDownload = () => resolve({ data: Buffer.from('image'), contentType: 'image/jpeg' });
+        markDownloadStarted();
+      }),
+    },
+    taxonomy,
+    config: makeConfig(),
+  });
+
+  runner.start({ assetIds: ['a1'], sendToCurate: false });
+  await downloadStarted;
+  assert.equal(runner.cancel(), true);
+  finishDownload();
+  await finished(runner);
+
+  assert.equal(repo.processingRuns.length, 0);
+  assert.equal(repo.runs.length, 1);
+  assert.equal(repo.runs[0].status, 'cancelled');
+  assert.equal(repo.runs[0].counters.failed, 0);
+  assert.ok(runner.status().log.some((line) => line.includes('after image download')));
+  assert.equal(runner.status().log.some((line) => line.includes('cancelled mid-request')), false);
+});
+
 test('onFinished is skipped when the run fails', async () => {
   const repo = makeRepo();
   const runner = new EnrichJobRunner({

--- a/test/enrich/providers.test.mjs
+++ b/test/enrich/providers.test.mjs
@@ -518,6 +518,38 @@ test('http errors surface provider name, status, response detail, and Retry-Afte
   );
 });
 
+test('an injected provider transport distinguishes user cancellation from timeout', async () => {
+  let markStarted;
+  const started = new Promise((resolve) => { markStarted = resolve; });
+  const provider = new OpenRouterProvider({
+    apiKey: 'key',
+    modelName: 'm',
+    timeoutMs: 60000,
+    fetchImpl: async (_url, options) => new Promise((_resolve, reject) => {
+      markStarted();
+      options.signal.addEventListener('abort', () => {
+        const error = new Error('aborted');
+        error.name = 'AbortError';
+        reject(error);
+      }, { once: true });
+    }),
+  });
+  const controller = new AbortController();
+
+  const pending = provider.analyzeImage(image, { ...prompts, signal: controller.signal });
+  await started;
+  controller.abort();
+
+  await assert.rejects(pending, (error) => {
+    assert.equal(error.name, 'ProviderRequestError');
+    assert.equal(error.cancelled, true);
+    assert.equal(error.timeout, false);
+    assert.equal(error.infrastructure, true);
+    assert.match(error.message, /request failed: cancelled$/);
+    return true;
+  });
+});
+
 test('Retry-After parsing accepts seconds and future HTTP dates, but rejects stale values', () => {
   const now = Date.parse('2026-09-03T12:00:00.000Z');
   assert.equal(parseRetryAfterMs('1.5', now), 1500);


### PR DESCRIPTION
## Outcome

Enrich Cancel now terminates an active AI-provider request immediately instead of waiting for the provider timeout.

## Material changes

- threads a per-run abort signal from EnrichJobRunner through runBatch and every enrichment provider adapter
- tears down both the production node HTTP transport and injected fetch transports on cancellation
- distinguishes user cancellation from provider timeout while preserving infrastructure-failure accounting
- records the interrupted photo as retryable, stops the batch, and leaves queued work in place
- updates Enrich UI guidance, durable documentation, and the Unreleased changelog

## Validation

- npm test: 1,019 passed
- npm run check:publication: passed
- npm run check:dco: passed
- git diff --check: passed
- integration coverage verifies that a hung local provider request is closed promptly, the photo records failed_infra, and the job records cancelled

## Risk and rollback

The change is confined to Enrich analysis calls; Curate referee and voice calls continue without a run cancellation signal. Reverting this commit restores the former cooperative behavior. Immich requests remain cooperative and finish under their existing timeout because the Immich client does not yet accept this signal.

## Remaining work

None for PIC-107.

## Agent authorship

Implemented and validated by Codex Desktop at David's direction. Independent review is requested before merge.

Fixes PIC-107
