### PR TITLE
PIC-333: Prepare Pictaria Server 1.1.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,8 +33,8 @@ ALLOW_INSECURE_OPEN=false
 # ---- Server ----
 # Container image selected by docker-compose.yml. Tagged release files default
 # to their matching versioned image tag; image tags omit the `v` used by Git
-# release refs (`1.0.1` versus `v1.0.1`). Set this only for deliberate testing.
-#PICTARIA_IMAGE_TAG=1.0.1
+# release refs (`1.1.0` versus `v1.1.0`). Set this only for deliberate testing.
+#PICTARIA_IMAGE_TAG=1.1.0
 #HOST=0.0.0.0
 #PORT=4080
 #REQUEST_TIMEOUT_MS=60000

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
     attributes:
       label: Pictaria Server version
       description: Find this in Settings or the authenticated health response.
-      placeholder: "1.0.1"
+      placeholder: "1.1.0"
     validations:
       required: true
   - type: input

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to Pictaria Server are documented here. This project follows
 
 ## Unreleased
 
+## 1.1.0 - 2026-09-03
+
 ### Added
 
 - Optional **Daily Enrich** runs can process a user-set budget of new,
@@ -57,6 +59,19 @@ All notable changes to Pictaria Server are documented here. This project follows
 - A server shutdown that outlasts an Enrich run's drain now records exactly
   one interrupted Recent Runs entry. If abandoned work later settles, it
   cannot append a contradictory outcome or advance the queued job.
+
+### Compatibility
+
+- Persisted Settings advance from version 5 to 6 and the installation-state
+  contract advances from version 7 to 8. An existing installation creates and
+  verifies the standard automatic pre-migration snapshot before applying the
+  additive provider, run-context, and Daily Enrich settings.
+- A rollback to 1.0.1 after 1.1.0 has started requires restoring the complete
+  pre-migration snapshot before the older server is started. Pointing 1.0.1 at
+  a 1.1.0-migrated data directory is not the documented rollback path.
+- The Frame protocol, Node requirements, and Immich 2.0+ compatibility floor
+  are unchanged. Docker Compose installations should download the 1.1.0
+  Compose file and review the new OpenAI-compatible and Daily Enrich settings.
 
 ## 1.0.1 - 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,10 +43,11 @@ All notable changes to Pictaria Server are documented here. This project follows
 - Enrich cancellation now aborts the active AI-provider request immediately
   instead of waiting out that photo's provider timeout. The cancelled photo
   remains retryable on the next run, and queued work stays in place.
-- The persisted Settings contract advances to version 6 and the installation
-  state contract to version 8. Existing installations take the standard
-  automatic pre-migration recovery snapshot before adopting the additive
-  provider, per-run benchmark-context, and daily Enrich settings.
+- The persisted Settings contract advances from the shipped version 3 to 6
+  and the installation-state contract from the shipped version 5 to 8;
+  intermediate versions were never released. Existing installations take the
+  standard automatic pre-migration recovery snapshot before adopting the
+  additive provider, per-run benchmark-context, and Daily Enrich settings.
 - Enrich now retries a photo twice when any configured provider reports a
   temporary 429 or 503 response, honoring bounded `Retry-After` guidance and
   keeping cancellation responsive during the wait. Persistent overloads stop
@@ -62,10 +63,15 @@ All notable changes to Pictaria Server are documented here. This project follows
 
 ### Compatibility
 
-- Persisted Settings advance from version 5 to 6 and the installation-state
-  contract advances from version 7 to 8. An existing installation creates and
-  verifies the standard automatic pre-migration snapshot before applying the
-  additive provider, run-context, and Daily Enrich settings.
+- A 1.0.1 installation migrates persisted Settings from version 3 to 6 and
+  the installation-state contract from version 5 to 8. It creates and verifies
+  the standard automatic pre-migration snapshot before applying the additive
+  provider, run-context, and Daily Enrich settings.
+- Before upgrading, operators using a custom `BACKUP_DIR` must complete its
+  one-time adoption as documented in [Backup and restore](docs/BACKUP.md).
+  Startup intentionally stops if that destination is unavailable or unadopted,
+  even when scheduled backups are disabled, rather than migrating without a
+  verified recovery point.
 - A rollback to 1.0.1 after 1.1.0 has started requires restoring the complete
   pre-migration snapshot before the older server is started. Pointing 1.0.1 at
   a 1.1.0-migrated data directory is not the documented rollback path.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Production installs should select an explicit reviewed release. The source
 tag and matching versioned GHCR image keep the deployment inputs aligned.
 
 ```sh
-PICTARIA_RELEASE=v1.0.1 # replace with the release you are installing
+PICTARIA_RELEASE=v1.1.0 # replace with the release you are installing
 mkdir pictaria-server && cd pictaria-server
 curl -fsSLO \
   "https://raw.githubusercontent.com/pictaria-ai/pictaria-server/${PICTARIA_RELEASE}/docker-compose.yml"
@@ -80,7 +80,7 @@ and its online-backup API; earlier builds fail at boot — `engines` says
 newer supported versions work as well.
 
 ```sh
-PICTARIA_RELEASE=v1.0.1 # replace with the release you are installing
+PICTARIA_RELEASE=v1.1.0 # replace with the release you are installing
 git clone --branch "$PICTARIA_RELEASE" --depth 1 \
   https://github.com/pictaria-ai/pictaria-server.git
 cd pictaria-server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     # Release files default to their matching versioned image tag. A tag is a
     # release name, not a cryptographic digest. Set PICTARIA_IMAGE_TAG only
     # when deliberately testing another published tag.
-    image: ghcr.io/pictaria-ai/pictaria-server:${PICTARIA_IMAGE_TAG:-1.0.1}
+    image: ghcr.io/pictaria-ai/pictaria-server:${PICTARIA_IMAGE_TAG:-1.1.0}
     build: .
     container_name: pictaria
     restart: unless-stopped

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -36,7 +36,7 @@ deliberately testing another published tag.
 
 | Variable | Default | Notes |
 | --- | --- | --- |
-| `PICTARIA_IMAGE_TAG` | `1.0.1` | Published container image tag selected by `docker-compose.yml`. Image tags omit the `v` used by Git release refs (`1.0.1` versus `v1.0.1`). |
+| `PICTARIA_IMAGE_TAG` | `1.1.0` | Published container image tag selected by `docker-compose.yml`. Image tags omit the `v` used by Git release refs (`1.1.0` versus `v1.1.0`). |
 
 ## Required
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -24,7 +24,7 @@ upgrade.
 ## Upgrade — Docker
 
 ```sh
-PICTARIA_RELEASE=v1.0.1 # replace with the release you are installing
+PICTARIA_RELEASE=v1.1.0 # replace with the release you are installing
 curl -fsSL -o docker-compose.release.yml \
   "https://raw.githubusercontent.com/pictaria-ai/pictaria-server/${PICTARIA_RELEASE}/docker-compose.yml"
 diff -u docker-compose.yml docker-compose.release.yml
@@ -45,7 +45,7 @@ docker compose -f docker-compose.release.yml config --images
 ```
 
 The printed image must end in the numeric image version corresponding to the
-source release you selected (`v1.0.1` uses image tag `1.0.1`). Next, make a
+source release you selected (`v1.1.0` uses image tag `1.1.0`). Next, make a
 rollback definition from the currently running Compose file. It should already
 resolve to the version you noted under Settings → Server; verify it before
 replacing the active definition:
@@ -72,7 +72,7 @@ test -z "$(git status --porcelain)" || {
   echo "Stop: preserve or reconcile local changes before upgrading."
   exit 1
 }
-PICTARIA_RELEASE=v1.0.1 # replace with the release you are installing
+PICTARIA_RELEASE=v1.1.0 # replace with the release you are installing
 git fetch --tags --prune
 git switch --detach "$PICTARIA_RELEASE"
 docker compose up -d --build
@@ -97,7 +97,7 @@ test -z "$(git status --porcelain)" || {
   echo "Stop: preserve or reconcile local changes before upgrading."
   exit 1
 }
-PICTARIA_RELEASE=v1.0.1 # replace with the release you are installing
+PICTARIA_RELEASE=v1.1.0 # replace with the release you are installing
 git fetch --tags --prune
 git switch --detach "$PICTARIA_RELEASE"
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pictaria-server",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",


### PR DESCRIPTION
## Outcome

Freezes the reviewed 1.1 feature set into an exact Pictaria Server 1.1.0 release candidate. This PR changes release metadata and compatibility guidance only; its parent tree is the cumulative application tree already tested by the owner.

## Changes

- sets package metadata and the shipped Compose image default to 1.1.0
- updates environment, configuration, installation, upgrade, and bug-report version examples
- publishes the current Unreleased feature set as the dated 1.1.0 changelog entry
- records the shipped v3-to-v6 Settings and v5-to-v8 installation-state transition; intermediate versions were never released
- makes the rollback requirement explicit: restore the complete automatic pre-migration snapshot before starting 1.0.1
- warns operators that a custom BACKUP_DIR must complete its documented one-time adoption before this protected migration

## Validation

- full repository suite: 1,033/1,033 passed
- publication hygiene: passed for 249 tracked files
- diff hygiene: passed
- DCO sign-off: present
- local Docker validation was unavailable on this laptop; the required Container build and boot smoke CI job covers Compose validation, image construction, closed-by-default startup, and authenticated health boot

## Risk and rollback

The release advances persisted contracts. A 1.0.1 installation migrates Settings v3 to v6 and installation state v5 to v8. It must create and verify its automatic pre-migration snapshot before migrating. Operators using a custom BACKUP_DIR must have adopted that destination first. The exact candidate must be rehearsed from a real 1.0.1 installation, rolled back by restoring that complete snapshot, and upgraded again before this PR is merged. Merely starting the 1.0.1 image against 1.1.0-migrated data is not the rollback test.

## Remaining work

- wait for every required CI check
- independently review and owner-approve this release PR
- rehearse the exact candidate commit through 1.0.1 → 1.1.0 candidate → restored 1.0.1 → 1.1.0 candidate
- after approval and rehearsal, merge, create and push annotated v1.1.0, verify multi-architecture publication, record the manifest digest, create the GitHub Release, and smoke-test the public image
- only then merge/deploy website PR #29 and close PIC-329/PIC-333

Related to PIC-333.

Authored by Codex. Ready for review and exact-candidate rehearsal.