### PR TITLE
PIC-343: Record photo and provider-request timing for Enrich

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to Pictaria Server are documented here. This project follows
 
 ### Added
 
+- Enrich records per-photo processing time and each actual provider request's
+  duration and outcome, including retries, timeouts, invalid responses, and
+  cancellation. Completed requests survive interrupted runs; incomplete and
+  historical measurements remain explicitly unknown. Bounded timing APIs
+  provide the foundation for the upcoming native performance view.
+
 - Named Enrich profiles: manage reusable prompts and taxonomy in Settings.
   One server-saved **Active profile** on Enrich controls new sweeps, queued
   groups, retries, and Daily Enrich. Queueing saves photos only; execution

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -201,8 +201,20 @@ data/               all persistent state (gitignored): enrichment.sqlite,
 - **Ports**: Pictaria Server listens on `4080`. It must be the only writer of
   its enrichment database (see Scale: review state is cached in-process and
   projected at write time, so external writes are invisible until restart).
+- **Enrich timing**: `enrich/timing.mjs` owns compact execution/request records
+  and their schema, appended to the base enrichment schema by the repository.
+  Schema 10 / persistent-state contract 12 adds timing tables and a nullable
+  job-summary link. The job runner starts a timing run before asynchronous
+  processing; the batch runner measures photo execution through persistence.
+  An AsyncLocalStorage context scoped to each Enrich analysis instruments the
+  providers' common HTTP boundary without changing or sharing provider state
+  with voice or the referee. HTTP completion and local result acceptance are
+  separate outcomes. Server startup reconciles unfinished records; opening
+  a repository read handle does not interrupt another process's work.
+  Retention deletes only telemetry, with bounded pages and explicit coverage
+  gaps. See [the timing contract](ENRICH.md#photo-and-provider-request-timing).
 - **Enrich profiles**: `enrich/profiles.mjs` owns named profiles and immutable
-  revisions in enrichment.sqlite (schema 9, persistent-state contract 11).
+  revisions in enrichment.sqlite (introduced in schema 9 / state contract 11).
   `routes/enrichProfiles.mjs` exposes bounded management APIs;
   `public/enrich-profiles.js` owns the Settings profile manager and the Enrich
   profile picker. Settings uses a profile list and focused editor with draft

--- a/docs/ENRICH.md
+++ b/docs/ENRICH.md
@@ -645,6 +645,99 @@ For each photo it keeps the newest normalized enrichment result needed by
 Curate and caption search; older run metadata remains, but raw provider
 response envelopes and superseded normalized payloads are not retained.
 
+## Photo and provider-request timing
+
+New Enrich work records two separate measurements. **Photo duration** starts
+before image download and ends after local result persistence, including
+image preparation, validation, all request attempts, and retry waits. It does
+not include earlier metadata discovery, queue waiting, or later background
+caption/tag synchronization. **Request duration** measures a dispatched HTTP
+request through response-body reading and outer JSON decoding, including
+upload/network/provider wait. Image encoding and local output validation are
+outside this request timer. This is observed request latency, not pure model
+inference time or tokens per second.
+
+Durations are nonnegative milliseconds measured with a monotonic clock.
+UTC ISO timestamps provide chronology and may move independently when the
+system clock changes. A received HTTP response is not automatically a usable
+result: only attempts marked `accepted` passed adapter extraction and local
+schema/taxonomy validation. Other bounded outcomes are `http_error`,
+`transport_error`, `timeout`, `cancelled`, `invalid_response`, `other_error`,
+`response_received` (acceptance not established), and `interrupted`.
+`running` marks work still in progress. HTTP status is stored when known;
+no prompt text, image bytes, raw response bodies, headers, or free-form
+errors are stored in timing records.
+
+Every processed photo gets its own execution ID and each actual HTTP request
+gets an ordinal within that execution. Validation and overload retries,
+including extra requests made inside an adapter, remain separate requests.
+Retry waits add to photo duration, not request latency. Existing retry rules
+are unchanged: timeouts do not gain an automatic retry from instrumentation;
+a later manual rerun has a new execution ID. A successful valid attempt
+remains usable even if result persistence fails or the enclosing job later
+fails or is cancelled. Latest-success results and human decisions remain
+independent of this telemetry.
+
+Skipped photos increment run counters by reason (already succeeded, human
+discard, failure limit); they do not create measured executions or requests.
+A download failure creates a failed photo execution with no provider attempt.
+Cancellation before dispatch also creates no request. Photos excluded during
+metadata selection are not executions. These distinctions prevent large
+mostly-enriched scans from filling detailed history with zero-work rows.
+
+A confirmed request timeout or cancellation has a measured finish and
+elapsed duration. On shutdown or restart, unfinished work instead becomes
+`interrupted`, retaining null finish/duration fields. Already completed
+requests retain their exact measurements. A response received without
+established validation stays `response_received`; it never enters a
+successful-request sample. Late completion cannot overwrite interrupted
+telemetry. Hard-crash runs remain discoverable in timing history even if no
+terminal job summary was written. Older processing rows and logs cannot
+supply accurate historical timings and are not backfilled as zero.
+
+### Bounded timing storage and API
+
+`enrich_timing_runs` links to the saved configuration, which retains provider,
+model, and immutable profile-revision attribution. Modern job summaries and
+active status expose `timingRunId`; a legacy/selection-only job may have none.
+`enrich_photo_executions` links to a timing run, asset, and terminal processing
+record where available. `enrich_provider_attempts` links to a photo execution.
+The timing store is separate from the durable latest-success/results contract.
+
+Retention keeps the newest 100 timing runs, up to 10,000 detailed photo
+executions, and up to 60,000 individual requests across runs. Photo/request
+pruning is batched every 100 inserts (also on the first insert after opening),
+so at most 99 additional terminal rows can accrue between passes. Running
+work is protected. Deleting a timing run removes its photo/request details;
+deleting photo detail removes its requests. Summary `photo_count` and
+`attempt_count` are lifetime counts for that timing run, independent of
+retained detail. Photo counts exclude skips, which have separate counters.
+Timing expiration never deletes enrichment results, configuration snapshots,
+profiles, human decisions, or queues. These fixed limits are independent of
+job-log storage; configurable summary/log retention remains PIC-327 work.
+
+Authenticated read APIs, using the existing run cursor convention:
+
+- `GET /api/enrich/timings` lists retained timing runs, including interrupted
+  runs without a job summary; `job_run_id` is nullable.
+- `GET /api/enrich/timings/:timingRunId/photos` returns photo execution detail
+  plus the run metadata, retained count, and `truncated` coverage flag.
+- `GET /api/enrich/timings/photos/:photoExecutionId/attempts` returns request
+  detail plus the photo metadata, retained count, and `truncated` flag.
+
+Each response has `items` and a nullable `nextCursor`. Pass that cursor back
+with `cursor`; ordering is ascending record ID. HTTP `limit` defaults to 20
+and is restricted to 1–50; repository reads clamp to at most 100. Detail fields
+use the database's descriptive names (`duration_ms`, `started_at`, `outcome`,
+`ordinal`, etc.). Expired/missing detail returns 404. A null `timingRunId`
+means no trustworthy timing was recorded, not zero-duration work. Increasing
+future retention cannot recover records already expired. Views must account
+for `truncated` when interpreting samples or reliability totals.
+
+PIC-343 supplies this data contract; PIC-332 owns the native comparison and
+per-photo display. The current dashboard continues showing whole-run
+throughput until that work is implemented.
+
 ## Writing captions to Immich descriptions
 
 Every enrichment produces a one-sentence caption. With **Settings →

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -280,3 +280,27 @@ Rollback requires restoring that snapshot into a clean volume with the older
 image; do not run an older server directly against the new database. Profile
 revisions and the active choice live in enrichment.sqlite and are included
 in standard backups.
+
+
+## Enrich timing (unreleased v1.2 work)
+
+Schema 10 / persistent-state contract 12 adds timing runs, photo executions,
+and provider attempts, plus a nullable `job_runs.timing_run_id` link. No
+historical measurements are reconstructed from logs or processing-row
+creation timestamps. Older job summaries have no timing link. Enrichment
+results, active profiles and immutable revisions, queue selections, and
+human decisions keep their existing meaning.
+
+The automatic pre-migration recovery point precedes this change. Timing
+records live in enrichment.sqlite and are covered by the existing complete
+backup/restore path. Tests cover upgrading the schema-9 profile release,
+restoring its pre-upgrade snapshot with contract 11 and no timing tables,
+and round-tripping new measurements and profile attribution through backup.
+Rollback requires that snapshot and the corresponding older server; never
+open contract-12 state with an older build.
+
+On startup, unfinished photo executions and requests become **interrupted**,
+with unknown finish times/durations left null. Completed requests retain
+their measurements, even when the enclosing run never wrote a job summary.
+Repeated startup does not replace completed measurements or invent elapsed
+wall time. See [timing and retention](ENRICH.md#photo-and-provider-request-timing).

--- a/src/enrich/jobRunner.mjs
+++ b/src/enrich/jobRunner.mjs
@@ -159,7 +159,9 @@ export class EnrichJobRunner {
 
   #recordTerminal(lifecycle, { status, error, finishedAt }) {
     if (lifecycle.terminalRecorded) return false;
+    this.repo.timings?.finishRun(lifecycle.timingRunId, status);
     this.repo.recordJobRun({
+      timingRunId: lifecycle.timingRunId,
       title: this.state.title,
       provider: this.state.provider,
       model: this.state.model,
@@ -400,8 +402,11 @@ export class EnrichJobRunner {
       throw new Error('Retrying failure-limited photos needs an explicit asset list.');
     }
 
+    // Fail before claiming the runner if durable timing cannot be started.
+    const timingRunId = this.repo.timings?.startRun(configuration) ?? null;
     this.state = {
       ...idleState(),
+      timingRunId,
       running: true,
       startedAt: new Date().toISOString(),
       provider: providerName,
@@ -454,6 +459,7 @@ export class EnrichJobRunner {
     // later settles. Kept separate from UI state so queue completion cannot
     // accidentally reset it while the old promise unwinds.
     const lifecycle = {
+      timingRunId,
       configuration,
       interrupted: false,
       interruptedAt: null,
@@ -476,6 +482,7 @@ export class EnrichJobRunner {
         repo: this.repo,
         provider,
         configuration,
+        timingRunId: lifecycle.timingRunId,
         taxonomy: configuration.taxonomy,
         systemPrompt: configuration.systemPrompt,
         userTemplate: configuration.userTemplate,

--- a/src/enrich/providers.mjs
+++ b/src/enrich/providers.mjs
@@ -1,3 +1,4 @@
+import { measureProviderRequest } from './timing.mjs';
 import { execFileSync } from 'node:child_process';
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { request as httpRequest } from 'node:http';
@@ -91,7 +92,7 @@ const GEMINI_JSON_SCHEMA_KEYWORDS = new Set([
 // 5xx) from "the provider judged this request's content" — the runner only
 // charges an asset's permanent failure allowance for the latter.
 export class ProviderRequestError extends Error {
-  constructor(message, { status = null, timeout = false, cancelled = false, retryAfterMs = null } = {}) {
+  constructor(message, { status = null, timeout = false, cancelled = false, invalidResponse = false, retryAfterMs = null } = {}) {
     super(message);
     this.name = 'ProviderRequestError';
     this.status = status;
@@ -104,6 +105,7 @@ export class ProviderRequestError extends Error {
     // an HTTP status. Carried explicitly rather than sniffed from the
     // message text.
     this.timeout = timeout;
+    this.invalidResponse = invalidResponse;
     // User-requested cancellation shares the transport teardown used by a
     // timeout, but is kept distinct so Enrich can stop immediately without
     // presenting the request as a provider failure.
@@ -873,6 +875,13 @@ export class OllamaLocalProvider {
 }
 
 async function postJson(provider, url, body, extraHeaders, { signal = null } = {}) {
+  if (signal?.aborted) throw new ProviderRequestError(`${provider.providerName} request failed: cancelled`, { cancelled: true });
+  // Serialize image/prompt data before measuring the dispatched HTTP request.
+  const payload = JSON.stringify(body);
+  return measureProviderRequest((onResponse) => postJsonTransport(provider, url, payload, extraHeaders, { signal, onResponse }));
+}
+
+async function postJsonTransport(provider, url, payload, extraHeaders, { signal, onResponse }) {
   const headers = {
     'Content-Type': 'application/json',
     Accept: 'application/json',
@@ -883,7 +892,7 @@ async function postJson(provider, url, body, extraHeaders, { signal = null } = {
   // group can run 10+ minutes). Default transport is node:http(s) with a
   // single wall-clock deadline; injected fetchImpl (tests, custom) is kept.
   if (provider.fetchImpl === fetch) {
-    return nodePostJson(provider, url, headers, JSON.stringify(body), { signal });
+    return nodePostJson(provider, url, headers, payload, { signal, onResponse });
   }
   const controller = new AbortController();
   let timedOut = false;
@@ -911,7 +920,7 @@ async function postJson(provider, url, body, extraHeaders, { signal = null } = {
       redirect: 'error',
       signal: controller.signal,
       headers,
-      body: JSON.stringify(body),
+      body: payload,
     });
   } catch (error) {
     const reason = cancelled
@@ -928,6 +937,7 @@ async function postJson(provider, url, body, extraHeaders, { signal = null } = {
     signal?.removeEventListener('abort', onCancel);
   }
 
+  onResponse(response.status);
   if (!response.ok) {
     const detail = await readErrorDetail(response, provider);
     throw new ProviderRequestError(providerStatusMessage(provider.providerName, response.status, detail), {
@@ -955,6 +965,7 @@ async function postJson(provider, url, body, extraHeaders, { signal = null } = {
   } catch (error) {
     throw new ProviderRequestError(
       `${provider.providerName} request failed: ${sanitizeDiagnostic(error?.message ?? error, { secrets: [provider.apiKey] })}`,
+      { invalidResponse: error instanceof SyntaxError },
     );
   }
 }
@@ -984,7 +995,7 @@ async function readErrorDetail(response, provider) {
 // POST JSON over node:http(s): same semantics as the fetch path (throws the
 // provider-labelled error on failure, resolves with parsed JSON), but the
 // only timeout is our own absolute deadline.
-function nodePostJson(provider, url, headers, payload, { signal = null } = {}) {
+function nodePostJson(provider, url, headers, payload, { signal = null, onResponse = () => {} } = {}) {
   return new Promise((resolve, reject) => {
     if (signal?.aborted) {
       reject(new ProviderRequestError(`${provider.providerName} request failed: cancelled`, { cancelled: true }));
@@ -1005,11 +1016,11 @@ function nodePostJson(provider, url, headers, payload, { signal = null } = {}) {
       clearTimeout(deadline);
       signal?.removeEventListener('abort', onCancel);
     };
-    const fail = (reason, { timeout = false, cancelled = false } = {}) => {
+    const fail = (reason, { timeout = false, cancelled = false, invalidResponse = false } = {}) => {
       cleanup();
       reject(new ProviderRequestError(
         `${provider.providerName} request failed: ${sanitizeDiagnostic(reason, { secrets: [provider.apiKey] })}`,
-        { timeout, cancelled },
+        { timeout, cancelled, invalidResponse },
       ));
     };
     // Set when our own deadline destroys the socket, so the resulting
@@ -1022,6 +1033,7 @@ function nodePostJson(provider, url, headers, payload, { signal = null } = {}) {
       headers,
       ...(isolateConnection ? { agent: false } : {}),
     }, (response) => {
+      onResponse(response.statusCode);
       let received = 0;
       response.on('data', (chunk) => {
         received += chunk.length;
@@ -1047,7 +1059,7 @@ function nodePostJson(provider, url, headers, payload, { signal = null } = {}) {
         try {
           resolve(JSON.parse(text));
         } catch {
-          fail('response was not valid JSON');
+          fail('response was not valid JSON', { invalidResponse: true });
         }
       });
     });

--- a/src/enrich/repository.mjs
+++ b/src/enrich/repository.mjs
@@ -7,6 +7,7 @@ import { addColumnIfMissing, migrateDatabase, tableExists } from '../migrations.
 import { preparePrivateDatabasePath, restrictPrivateDatabaseModes } from '../privateDatabase.mjs';
 import { sanitizeDiagnostic } from '../diagnostics.mjs';
 import { validateAssetBatch } from './assetBatch.mjs';
+import { EnrichTimingStore, TIMING_SCHEMA } from './timing.mjs';
 import { ACTION_RULES } from './reviewActions.mjs';
 import { canonicalJson, MAX_RUN_CONFIGURATION_BYTES } from './runConfiguration.mjs';
 
@@ -48,6 +49,7 @@ const SCHEMA_PATH = join(dirname(fileURLToPath(import.meta.url)), 'schema.sql');
 // migration-time base-schema exec fail before the rebuild can happen. Indexes
 // are backward-compatible metadata, not a persisted-data contract change.
 const ACTIVITY_HISTORY_INDEXES = [
+  { table: 'job_runs', columns: ['timing_run_id'], sql: 'CREATE INDEX IF NOT EXISTS idx_job_runs_timing ON job_runs(timing_run_id)' },
   {
     table: 'processing_runs',
     columns: ['inference_id', 'status', 'asset_id'],
@@ -495,6 +497,14 @@ const ENRICH_MIGRATIONS = [
       }
     },
   },
+  {
+    version: 10,
+    up(db) {
+      db.exec(TIMING_SCHEMA);
+      addColumnIfMissing(db, 'job_runs', 'timing_run_id', 'INTEGER');
+      db.exec('CREATE INDEX IF NOT EXISTS idx_job_runs_timing ON job_runs(timing_run_id)');
+    },
+  },
 ];
 
 // The review projection of a normalized output: exactly the fields the
@@ -577,6 +587,7 @@ export class Repository {
     this.databasePath = String(databasePath);
     preparePrivateDatabasePath(this.databasePath);
     this.db = new DatabaseSync(this.databasePath);
+    this.timings = new EnrichTimingStore(this.db);
     this.db.exec('PRAGMA journal_mode = WAL');
     // Decisions, tags, and captions are personal data: keep the DB (and its
     // WAL/SHM sidecars) private to the server user even under a permissive
@@ -589,7 +600,7 @@ export class Repository {
   }
 
   initSchema() {
-    const schemaSql = readFileSync(SCHEMA_PATH, 'utf8');
+    const schemaSql = readFileSync(SCHEMA_PATH, 'utf8') + TIMING_SCHEMA;
     const result = migrateDatabase(this.db, {
       schema: schemaSql,
       migrations: ENRICH_MIGRATIONS,
@@ -1967,16 +1978,16 @@ export class Repository {
     return this.db.prepare('DELETE FROM enrich_queue WHERE id = ?').run(id).changes > 0;
   }
 
-  recordJobRun({ title, provider, model, promptVersion, taxonomyVersion, inferenceHostLabel, configurationId = null, inferenceId = null, retrySourceRunId = null, targeted, status, error, counters, log, startedAt, finishedAt }) {
+  recordJobRun({ timingRunId = null, title, provider, model, promptVersion, taxonomyVersion, inferenceHostLabel, configurationId = null, inferenceId = null, retrySourceRunId = null, targeted, status, error, counters, log, startedAt, finishedAt }) {
     const safeError = error === null || error === undefined ? null : sanitizeDiagnostic(error);
     const safeLog = boundedJobLog(log);
     const safeHostLabel = jobRunHostLabel(inferenceHostLabel);
     this.db.prepare(`
-      INSERT INTO job_runs (title, provider, model, prompt_version, taxonomy_version, inference_host_label, targeted, status, error, counters_json, log_json, started_at, finished_at, configuration_id, inference_id, retry_source_run_id)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO job_runs (title, provider, model, prompt_version, taxonomy_version, inference_host_label, targeted, status, error, counters_json, log_json, started_at, finished_at, configuration_id, inference_id, retry_source_run_id, timing_run_id)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).run(title, provider, model ?? null, promptVersion ?? null, taxonomyVersion ?? null, safeHostLabel, targeted ?? null,
       status, safeError, counters ? JSON.stringify(counters) : null,
-      safeLog?.length > 0 ? JSON.stringify(safeLog) : null, startedAt, finishedAt, configurationId, inferenceId, retrySourceRunId);
+      safeLog?.length > 0 ? JSON.stringify(safeLog) : null, startedAt, finishedAt, configurationId, inferenceId, retrySourceRunId, timingRunId);
     this.db.prepare(`
       DELETE FROM job_runs
       WHERE id NOT IN (SELECT id FROM job_runs ORDER BY id DESC LIMIT ?)
@@ -2065,11 +2076,11 @@ export class Repository {
     const hasCursor = Number.isSafeInteger(cursor) && cursor > 0;
     const rows = (hasCursor ? this.db.prepare(`
       SELECT id, title, provider, model, prompt_version, taxonomy_version, inference_host_label, targeted,
-             configuration_id, inference_id, retry_source_run_id, status, error, counters_json, log_json IS NOT NULL AS has_log, started_at, finished_at
+             configuration_id, inference_id, retry_source_run_id, timing_run_id, status, error, counters_json, log_json IS NOT NULL AS has_log, started_at, finished_at
       FROM job_runs WHERE id < ? ORDER BY id DESC LIMIT ?
     `).all(cursor, boundedLimit + 1) : this.db.prepare(`
       SELECT id, title, provider, model, prompt_version, taxonomy_version, inference_host_label, targeted,
-             configuration_id, inference_id, retry_source_run_id, status, error, counters_json, log_json IS NOT NULL AS has_log, started_at, finished_at
+             configuration_id, inference_id, retry_source_run_id, timing_run_id, status, error, counters_json, log_json IS NOT NULL AS has_log, started_at, finished_at
       FROM job_runs ORDER BY id DESC LIMIT ?
     `).all(boundedLimit + 1));
     const hasMore = rows.length > boundedLimit;
@@ -2094,6 +2105,7 @@ export class Repository {
         configurationId: row.configuration_id ?? null,
         inferenceId: row.inference_id ?? null,
         retrySourceRunId: row.retry_source_run_id ?? null,
+        timingRunId: row.timing_run_id ?? null,
         targeted: row.targeted === null ? null : Number(row.targeted),
         status: row.status,
         error: row.error,

--- a/src/enrich/runner.mjs
+++ b/src/enrich/runner.mjs
@@ -1,3 +1,4 @@
+import { timingErrorKind } from './timing.mjs';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
@@ -117,6 +118,7 @@ export async function analyzeWithValidationRetry(provider, image, {
   overloadRetryLimit = PROVIDER_OVERLOAD_RETRY_LIMIT,
   onProviderResponse = () => {},
   signal = null,
+  photoTiming = null,
 }) {
   const prompts = [userPrompt];
   // Every local provider (local_*), plus generic endpoints that explicitly
@@ -132,18 +134,21 @@ export async function analyzeWithValidationRetry(provider, image, {
   for (let attemptIndex = 0; attemptIndex < prompts.length; attemptIndex += 1) {
     while (true) {
       try {
-        const result = await provider.analyzeImage(image, {
-          systemPrompt,
-          userPrompt: prompts[attemptIndex],
-          jsonSchema,
-          signal,
-        });
-        // A completed provider response proves a persistent 429/503 wave has
-        // ended even if local schema validation later rejects its content.
-        onProviderResponse();
-        const normalized = validateAiOutput(result.normalizedOutput, taxonomy);
-        const decisions = mapOutputToTags(normalized, taxonomy);
-        return { result, normalized, decisions, retryCount: attemptIndex + overloadRetryCount };
+        const analyze = async () => {
+          const result = await provider.analyzeImage(image, {
+            systemPrompt,
+            userPrompt: prompts[attemptIndex],
+            jsonSchema,
+            signal,
+          });
+          // A completed provider response proves a persistent 429/503 wave has
+          // ended even if local schema validation later rejects its content.
+          onProviderResponse();
+          const normalized = validateAiOutput(result.normalizedOutput, taxonomy);
+          const decisions = mapOutputToTags(normalized, taxonomy);
+          return { result, normalized, decisions, retryCount: attemptIndex + overloadRetryCount };
+        };
+        return await (photoTiming ? photoTiming.analyze(analyze) : analyze());
       } catch (error) {
         if (isRetryableProviderOverload(error) && overloadRetryCount < overloadRetryLimit) {
           const retryIndex = overloadRetryCount;
@@ -169,7 +174,21 @@ export async function analyzeWithValidationRetry(provider, image, {
   throw lastError ?? new Error('model analysis did not run');
 }
 
-export async function runBatch({
+export async function runBatch(options) {
+  const timingSession = { id: options.timingRunId ?? null };
+  let outcome = 'failed';
+  try {
+    const result = await executeBatch({ ...options, timingSession });
+    outcome = options.shouldStop?.() || options.signal?.aborted ? 'cancelled' : 'finished';
+    return result;
+  } finally {
+    if (timingSession.id !== null && options.timingRunId == null) {
+      options.repo.timings.finishRun(timingSession.id, outcome);
+    }
+  }
+}
+
+async function executeBatch({
   immich,
   repo,
   provider,
@@ -197,6 +216,7 @@ export async function runBatch({
   retrySleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
   signal = null,
   configuration = null,
+  timingSession,
 }) {
   immich = captureClient(immich);
   if (provider) provider = captureClient(provider);
@@ -236,6 +256,7 @@ export async function runBatch({
     systemPrompt = configuration.systemPrompt;
     imageSource = configuration.snapshot.inference.image.source;
     repo.saveRunConfiguration(configuration);
+    timingSession.id ??= repo.timings?.startRun(configuration) ?? null;
   }
 
   // Only Immich traversal time belongs to this deadline. Provider inference
@@ -307,6 +328,7 @@ export async function runBatch({
   const { userPrompt, jsonSchema, runKey } = configuration;
 
   const assetDecisions = {};
+  const recordSkip = reason => repo.timings?.skip(timingSession.id, reason);
   const counters = emptyCounters();
   let analyzed = 0;
   let scanned = 0;
@@ -341,6 +363,7 @@ export async function runBatch({
 
       if (skipAnySuccessful && repo.hasAnySuccessfulRun(assetId)) {
         counters.skippedSuccessful += 1;
+        recordSkip('already_succeeded');
         // Already enriched, so it belongs in Curate just like a fresh success.
         if (listForReview) listedForReview += repo.reviewListAdd([assetId], 'enrich');
         log(`${position} skipping ${assetId}; successful run already exists`);
@@ -348,6 +371,7 @@ export async function runBatch({
       }
       if (!reprocess && repo.hasSuccessfulRun({ assetId, ...runKey })) {
         counters.skippedSuccessful += 1;
+        recordSkip('already_succeeded');
         if (listForReview) listedForReview += repo.reviewListAdd([assetId], 'enrich');
         log(`${position} skipping ${assetId}; matching successful run already exists`);
         continue;
@@ -356,6 +380,7 @@ export async function runBatch({
       // and reprocessing; Restore is the one door back in.
       if (repo.isAssetDiscarded(assetId)) {
         counters.skippedDiscarded += 1;
+        recordSkip('human_discard');
         log(`${position} skipping ${assetId}; discarded from enrichment`);
         continue;
       }
@@ -365,6 +390,7 @@ export async function runBatch({
         repo.failureCount({ assetId, ...runKey }) >= maxFailuresPerAsset
       ) {
         counters.skippedFailureLimit += 1;
+        recordSkip('failure_limit');
         log(`${position} skipping ${assetId}; reached ${maxFailuresPerAsset} failed run(s)`);
         continue;
       }
@@ -374,6 +400,11 @@ export async function runBatch({
         break;
       }
 
+      const photoTiming = repo.timings?.startPhoto(timingSession.id, assetId);
+      let photoOutcome = 'failed';
+      let photoErrorKind = null;
+      let processingRunId = null;
+      let stage = 'download';
       analyzed += 1;
       counters.analyzed += 1;
       log(`${position} analyzing ${assetId}`);
@@ -397,10 +428,12 @@ export async function runBatch({
         // arrived while the image was downloading, stop here rather than
         // manufacturing a provider cancellation for a request never sent.
         if (shouldStop()) {
+          photoOutcome = 'cancelled';
           log('stopping early: cancellation requested after image download');
           stopped = true;
           break;
         }
+        stage = 'provider';
         const { normalized, decisions, retryCount } = await analyzeWithValidationRetry(
           provider,
           { data: image.data, mimeType: image.contentType, assetId },
@@ -415,13 +448,15 @@ export async function runBatch({
             overloadRetryLimit,
             onProviderResponse: noteProviderResponse,
             signal,
+            photoTiming,
           },
         );
         // One transaction: a run may never read as 'succeeded' without its
         // tags, caption index, review listing, and caption-writeback marker.
         // A failure at any write rolls the whole asset back to unprocessed.
+        stage = 'persistence';
         listedForReview += repo.transaction(() => {
-          repo.recordProcessingRun({
+          processingRunId = repo.recordProcessingRun({
             assetId,
             ...runKey,
             status: 'succeeded',
@@ -446,12 +481,15 @@ export async function runBatch({
           }
           return listed;
         });
+        photoOutcome = 'succeeded';
         assetDecisions[assetId] = decisions;
         counters.succeeded += 1;
         counters.retried += retryCount;
         log(`  tags: ${decisions.map((decision) => decision.tag).join(', ') || '(none)'}`);
         log(`  caption: ${typeof normalized.caption === 'string' && normalized.caption ? normalized.caption : '(none)'}`);
       } catch (error) {
+        photoErrorKind = stage === 'provider' ? timingErrorKind(error) : `${stage}_error`;
+        if (error?.cancelled || error instanceof RetryWaitCancelledError) photoOutcome = 'cancelled';
         if (error instanceof RetryWaitCancelledError) {
           log('stopping early: cancellation requested during provider retry wait');
           stopped = true;
@@ -472,7 +510,7 @@ export async function runBatch({
         const diagnostic = sanitizeDiagnostic(error instanceof Error ? error.message : error, {
           secrets: diagnosticSecrets,
         });
-        repo.recordProcessingRun({
+        processingRunId = repo.recordProcessingRun({
           assetId,
           ...runKey,
           status: infrastructure ? 'failed_infra' : 'failed',
@@ -503,6 +541,8 @@ export async function runBatch({
             + 'Nothing succeeded, so the job can simply be run again once the provider is back.',
           );
         }
+      } finally {
+        photoTiming?.finish(photoOutcome, photoErrorKind, processingRunId ?? null);
       }
     }
     scanned += assets.length;

--- a/src/enrich/timing.mjs
+++ b/src/enrich/timing.mjs
@@ -1,0 +1,265 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+// Only Enrich enters this context. Concurrent referee/voice calls, even on
+// the same provider object, cannot be attributed to an enrichment photo.
+const invocation = new AsyncLocalStorage();
+export const TIMING_LIMITS = Object.freeze({ runs: 100, photos: 10000, attempts: 60000, page: 100 });
+
+export const TIMING_SCHEMA = `
+CREATE TABLE IF NOT EXISTS enrich_timing_runs (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  configuration_id TEXT NOT NULL,
+  provider TEXT NOT NULL,
+  model TEXT,
+  started_at TEXT NOT NULL,
+  finished_at TEXT,
+  outcome TEXT NOT NULL DEFAULT 'running',
+  photo_count INTEGER NOT NULL DEFAULT 0,
+  skipped_successful INTEGER NOT NULL DEFAULT 0,
+  skipped_discarded INTEGER NOT NULL DEFAULT 0,
+  skipped_failure_limit INTEGER NOT NULL DEFAULT 0,
+  attempt_count INTEGER NOT NULL DEFAULT 0
+);
+CREATE TABLE IF NOT EXISTS enrich_photo_executions (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  timing_run_id INTEGER NOT NULL,
+  asset_id TEXT NOT NULL,
+  processing_run_id INTEGER,
+  started_at TEXT NOT NULL,
+  finished_at TEXT,
+  duration_ms REAL CHECK(duration_ms IS NULL OR duration_ms >= 0),
+  outcome TEXT NOT NULL DEFAULT 'running',
+  error_kind TEXT,
+  attempt_count INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_enrich_photo_timing_run ON enrich_photo_executions(timing_run_id, id);
+CREATE TABLE IF NOT EXISTS enrich_provider_attempts (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  photo_execution_id INTEGER NOT NULL,
+  ordinal INTEGER NOT NULL,
+  started_at TEXT NOT NULL,
+  finished_at TEXT,
+  duration_ms REAL CHECK(duration_ms IS NULL OR duration_ms >= 0),
+  outcome TEXT NOT NULL DEFAULT 'running',
+  http_status INTEGER,
+  UNIQUE(photo_execution_id, ordinal)
+);
+CREATE INDEX IF NOT EXISTS idx_enrich_attempt_photo_id ON enrich_provider_attempts(photo_execution_id, id);
+CREATE TRIGGER IF NOT EXISTS enrich_timing_delete_run AFTER DELETE ON enrich_timing_runs BEGIN
+  DELETE FROM enrich_photo_executions WHERE timing_run_id = OLD.id;
+END;
+CREATE TRIGGER IF NOT EXISTS enrich_timing_delete_photo AFTER DELETE ON enrich_photo_executions BEGIN
+  DELETE FROM enrich_provider_attempts WHERE photo_execution_id = OLD.id;
+END;
+`;
+
+function pageOptions({ afterId = 0, limit = 50 } = {}) {
+  return {
+    afterId: Number.isSafeInteger(afterId) && afterId >= 0 ? afterId : 0,
+    limit: Number.isSafeInteger(limit) ? Math.max(1, Math.min(TIMING_LIMITS.page, limit)) : 50,
+  };
+}
+function page(rows, limit) {
+  const items = rows.slice(0, limit).map((row) => ({ ...row }));
+  return { items, nextAfterId: rows.length > limit ? items.at(-1).id : null };
+}
+function elapsed(start, clock) {
+  const value = clock() - start;
+  return Number.isFinite(value) ? Math.max(0, value) : null;
+}
+export function timingErrorKind(error) {
+  if (error?.cancelled || error?.name === 'RetryWaitCancelledError') return 'cancelled';
+  if (error?.timeout) return 'timeout';
+  if (error?.invalidResponse || error?.name === 'OutputValidationError') return 'invalid_response';
+  if (error?.status != null) return 'http_error';
+  return error?.name === 'ProviderRequestError' ? 'transport_error' : 'other_error';
+}
+
+export class EnrichTimingStore {
+  constructor(db, { wallNow = () => new Date().toISOString(), monotonicNow = () => performance.now() } = {}) {
+    this.db = db;
+    this.wallNow = wallNow;
+    this.monotonicNow = monotonicNow;
+    this.photoWrites = 0;
+    this.attemptWrites = 0;
+  }
+
+  atomic(work) {
+    this.db.exec('SAVEPOINT enrich_timing_write');
+    try {
+      const result = work();
+      this.db.exec('RELEASE enrich_timing_write');
+      return result;
+    } catch (error) {
+      this.db.exec('ROLLBACK TO enrich_timing_write; RELEASE enrich_timing_write');
+      throw error;
+    }
+  }
+
+  startRun(configuration) {
+    return this.atomic(() => {
+      const id = Number(this.db.prepare(`INSERT INTO enrich_timing_runs
+        (configuration_id, provider, model, started_at) VALUES (?, ?, ?, ?)`).run(
+        configuration.id, configuration.runKey.provider, configuration.runKey.model ?? null, this.wallNow(),
+      ).lastInsertRowid);
+      // Preserve active work; the server is single-flight. Every terminal run
+      // remains discoverable here even if a crash prevented its job summary.
+      this.db.prepare(`DELETE FROM enrich_timing_runs WHERE outcome != 'running' AND id NOT IN
+        (SELECT id FROM enrich_timing_runs ORDER BY id DESC LIMIT ?)`).run(TIMING_LIMITS.runs);
+      return id;
+    });
+  }
+
+  finishRun(id, outcome) {
+    if (outcome === 'interrupted') return this.interrupt(id);
+    return this.atomic(() => {
+      this.#interruptPhotos(id);
+      this.db.prepare(`UPDATE enrich_timing_runs SET outcome = ?, finished_at = ?
+        WHERE id = ? AND outcome = 'running'`).run(outcome, this.wallNow(), id);
+    });
+  }
+
+  interrupt(id = null) {
+    return this.atomic(() => {
+      this.#interruptPhotos(id);
+      this.db.prepare(`UPDATE enrich_timing_runs SET outcome = 'interrupted'
+        WHERE outcome = 'running' AND (? IS NULL OR id = ?)`).run(id, id);
+    });
+  }
+
+  #interruptPhotos(id) {
+    // Unknown completion is not a measured cancellation. Keep completed
+    // requests (including response_received) and never fabricate an end time.
+    this.db.prepare(`UPDATE enrich_provider_attempts SET outcome = 'interrupted'
+      WHERE outcome = 'running' AND photo_execution_id IN
+      (SELECT id FROM enrich_photo_executions WHERE (? IS NULL OR timing_run_id = ?))`).run(id, id);
+    this.db.prepare(`UPDATE enrich_photo_executions SET outcome = 'interrupted'
+      WHERE outcome = 'running' AND (? IS NULL OR timing_run_id = ?)`).run(id, id);
+  }
+
+  skip(runId, reason) {
+    const column = { already_succeeded: 'skipped_successful', human_discard: 'skipped_discarded', failure_limit: 'skipped_failure_limit' }[reason];
+    if (!column) throw new Error('Unknown enrichment skip reason');
+    // A library sweep may skip 100k photos. Preserve counters rather than
+    // evicting useful measured executions with rows for work never started.
+    this.db.prepare(`UPDATE enrich_timing_runs SET ${column} = ${column} + 1 WHERE id = ? AND outcome = 'running'`).run(runId);
+  }
+
+  startPhoto(runId, assetId) {
+    return this.atomic(() => {
+      if (!this.db.prepare("SELECT id FROM enrich_timing_runs WHERE id = ? AND outcome = 'running'").get(runId)) return null;
+      const start = this.monotonicNow();
+      const id = Number(this.db.prepare(`INSERT INTO enrich_photo_executions
+        (timing_run_id, asset_id, started_at) VALUES (?, ?, ?)`).run(runId, assetId, this.wallNow()).lastInsertRowid);
+      this.db.prepare('UPDATE enrich_timing_runs SET photo_count = photo_count + 1 WHERE id = ?').run(runId);
+      // Prune once per 100 inserts (and the first after opening). At most 99
+      // extra terminal rows accrue between passes; avoid a full retention scan
+      // per photo when traversing a mostly enriched library.
+      if (this.photoWrites++ % 100 === 0) {
+        this.db.prepare(`DELETE FROM enrich_photo_executions WHERE outcome != 'running' AND id <=
+          (SELECT id FROM enrich_photo_executions ORDER BY id DESC LIMIT 1 OFFSET ?)`).run(TIMING_LIMITS.photos);
+      }
+      return new PhotoTiming(this, id, runId, start);
+    });
+  }
+
+  runs(options) {
+    const { afterId, limit } = pageOptions(options);
+    const rows = this.db.prepare(`SELECT r.*,
+      (SELECT id FROM job_runs j WHERE j.timing_run_id = r.id LIMIT 1) AS job_run_id
+      FROM enrich_timing_runs r WHERE r.id > ? ORDER BY r.id LIMIT ?`).all(afterId, limit + 1);
+    return page(rows, limit);
+  }
+
+  photos(runId, options) {
+    const run = this.db.prepare('SELECT * FROM enrich_timing_runs WHERE id = ?').get(runId);
+    if (!run) return null;
+    const { afterId, limit } = pageOptions(options);
+    const rows = this.db.prepare('SELECT * FROM enrich_photo_executions WHERE timing_run_id = ? AND id > ? ORDER BY id LIMIT ?')
+      .all(runId, afterId, limit + 1);
+    const retained = this.db.prepare('SELECT COUNT(*) AS n FROM enrich_photo_executions WHERE timing_run_id = ?').get(runId).n;
+    return { ...page(rows, limit), run: { ...run }, retained, truncated: retained < run.photo_count };
+  }
+
+  attempts(photoId, options) {
+    const photo = this.db.prepare('SELECT * FROM enrich_photo_executions WHERE id = ?').get(photoId);
+    if (!photo) return null;
+    const { afterId, limit } = pageOptions(options);
+    const rows = this.db.prepare('SELECT * FROM enrich_provider_attempts WHERE photo_execution_id = ? AND id > ? ORDER BY id LIMIT ?')
+      .all(photoId, afterId, limit + 1);
+    const retained = this.db.prepare('SELECT COUNT(*) AS n FROM enrich_provider_attempts WHERE photo_execution_id = ?').get(photoId).n;
+    return { ...page(rows, limit), photo: { ...photo }, retained, truncated: retained < photo.attempt_count };
+  }
+}
+
+class PhotoTiming {
+  constructor(store, id, runId, start) {
+    Object.assign(this, { store, id, runId, start });
+  }
+
+  finish(outcome, errorKind = null, processingRunId = null) {
+    const s = this.store;
+    s.db.prepare(`UPDATE enrich_photo_executions SET finished_at = ?, duration_ms = ?, outcome = ?, error_kind = ?, processing_run_id = ?
+      WHERE id = ? AND outcome = 'running'`).run(s.wallNow(), elapsed(this.start, s.monotonicNow), outcome, errorKind, processingRunId, this.id);
+  }
+
+  async analyze(work) {
+    const context = { photo: this, lastRequestId: null };
+    return invocation.run(context, async () => {
+      try {
+        const result = await work();
+        this.accept(context.lastRequestId, 'accepted');
+        return result;
+      } catch (error) {
+        // Includes adapter extraction/JSON errors as well as taxonomy/schema
+        // validation failures, but never rewrites a transport failure.
+        this.accept(context.lastRequestId, 'invalid_response');
+        throw error;
+      }
+    });
+  }
+
+  accept(id, outcome) {
+    if (id === null) return;
+    this.store.db.prepare(`UPDATE enrich_provider_attempts SET outcome = ? WHERE id = ? AND outcome = 'response_received'
+      AND EXISTS (SELECT 1 FROM enrich_photo_executions WHERE id = ? AND outcome = 'running')`).run(outcome, id, this.id);
+  }
+
+  async request(work, context) {
+    const s = this.store;
+    const photo = s.db.prepare("SELECT attempt_count FROM enrich_photo_executions WHERE id = ? AND outcome = 'running'").get(this.id);
+    // An abandoned request may unwind after shutdown recorded interruption.
+    // It must not create new records or overwrite unknown measurements.
+    if (!photo) return work(() => {});
+    const id = s.atomic(() => {
+      const id = Number(s.db.prepare(`INSERT INTO enrich_provider_attempts
+        (photo_execution_id, ordinal, started_at) VALUES (?, ?, ?)`).run(this.id, photo.attempt_count + 1, s.wallNow()).lastInsertRowid);
+      s.db.prepare('UPDATE enrich_photo_executions SET attempt_count = attempt_count + 1 WHERE id = ?').run(this.id);
+      s.db.prepare('UPDATE enrich_timing_runs SET attempt_count = attempt_count + 1 WHERE id = ?').run(this.runId);
+      if (s.attemptWrites++ % 100 === 0) {
+        s.db.prepare(`DELETE FROM enrich_provider_attempts WHERE outcome != 'running' AND id <=
+          (SELECT id FROM enrich_provider_attempts ORDER BY id DESC LIMIT 1 OFFSET ?)`).run(TIMING_LIMITS.attempts);
+      }
+      s.db.prepare('UPDATE enrich_provider_attempts SET started_at = ? WHERE id = ?').run(s.wallNow(), id);
+      return id;
+    });
+    context.lastRequestId = id;
+    const start = s.monotonicNow();
+    let outcome = 'response_received';
+    let status = null;
+    try {
+      return await work((value) => { status = value; });
+    } catch (error) {
+      outcome = timingErrorKind(error);
+      throw error;
+    } finally {
+      s.db.prepare(`UPDATE enrich_provider_attempts SET finished_at = ?, duration_ms = ?, outcome = ?, http_status = ?
+        WHERE id = ? AND outcome = 'running'`).run(s.wallNow(), elapsed(start, s.monotonicNow), outcome, status, id);
+    }
+  }
+}
+
+export function measureProviderRequest(work) {
+  const context = invocation.getStore();
+  return context ? context.photo.request(work, context) : work(() => {});
+}

--- a/src/routes/enrich.mjs
+++ b/src/routes/enrich.mjs
@@ -924,6 +924,25 @@ export function createEnrichRoutes({ review, enrichRunner, taxonomy, profiles = 
       return true;
     }
 
+    // Timing history is separate from results: legacy summaries have no
+    // timingRunId, and crash-interrupted runs remain discoverable here.
+    const timingMatch = url.pathname.match(/^\/api\/enrich\/timings(?:\/(\d+)\/photos|\/photos\/(\d+)\/attempts)?$/);
+    if (request.method === 'GET' && timingMatch) {
+      const options = {
+        afterId: decodeRunCursor(url.searchParams.get('cursor')) ?? 0,
+        limit: runPageLimit(url.searchParams.get('limit')),
+      };
+      const result = timingMatch[1] ? repo.timings.photos(Number(timingMatch[1]), options)
+        : timingMatch[2] ? repo.timings.attempts(Number(timingMatch[2]), options)
+          : repo.timings.runs(options);
+      if (!result) sendError(response, 404, 'timing_not_found', 'Timing history is unavailable or has expired.');
+      else {
+        const { nextAfterId, ...data } = result;
+        sendJson(response, 200, { ...data, nextCursor: nextAfterId === null ? null : encodeRunCursor(nextAfterId) });
+      }
+      return true;
+    }
+
     const runRetryMatch = url.pathname.match(/^\/api\/enrich\/runs\/(\d+)\/retry$/);
     if (request.method === 'POST' && runRetryMatch) {
       if (!requireImmich(response)) {

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -163,6 +163,8 @@ const publicDir = join(config.rootDir, 'public');
 const taxonomy = loadActiveTaxonomy(config);
 const repo = new Repository(config.databasePath);
 repo.initSchema();
+// Reconcile only at process startup, never when another reader opens the DB.
+repo.timings.interrupt();
 const profiles = new EnrichmentProfiles({ repo, config });
 profiles.initialize();
 const activityLog = createActivityLog({ repo, setIntervalFn: lifecycle.setInterval });

--- a/src/upgradeSafety.mjs
+++ b/src/upgradeSafety.mjs
@@ -4,7 +4,7 @@ import { backupTargets, readSnapshotStatus, runBackup } from './backup.mjs';
 
 // Bump only when a release changes a persisted contract and therefore needs
 // a pre-migration recovery point. Ordinary server releases keep this value.
-export const PERSISTENT_STATE_VERSION = 11;
+export const PERSISTENT_STATE_VERSION = 12;
 
 export class UpgradeSafetyError extends Error {
   constructor(message, { code = 'upgrade_safety_error' } = {}) {

--- a/test/enrich/profiles.test.mjs
+++ b/test/enrich/profiles.test.mjs
@@ -186,7 +186,7 @@ test('schema-8 fixture migrates to profiles without inventing old run attributio
   db.close();
   const repo = new Repository(path);
   try {
-    assert.deepEqual(repo.initSchema().applied, [9]);
+    assert.deepEqual(repo.initSchema().applied, [9, 10]);
     const config = { promptsDir: join(REPO_ROOT, 'prompts'), promptVersion: 'v1', taxonomyPath: join(REPO_ROOT, 'taxonomy/v1.json'),
       promptOverrides: { systemPrompt: 'Migrated customization' } };
     const profiles = new EnrichmentProfiles({ repo, config }); profiles.initialize();

--- a/test/enrich/runConfiguration.test.mjs
+++ b/test/enrich/runConfiguration.test.mjs
@@ -329,7 +329,7 @@ test('v7 upgrade preserves successes as unknown identity, with no invented snaps
   db.close();
   const repo = new Repository(path);
   try {
-    assert.deepEqual(repo.initSchema().applied, [8, 9]);
+    assert.deepEqual(repo.initSchema().applied, [8, 9, 10]);
     const config = snapshot();
     assert.equal(repo.hasAnySuccessfulRun('a1'), true);
     assert.equal(repo.hasSuccessfulRun({ assetId: 'a1', ...config.runKey }), false);

--- a/test/enrich/scale.test.mjs
+++ b/test/enrich/scale.test.mjs
@@ -160,7 +160,7 @@ test('a pre-v3 database backfills latest_success from the latest succeeded runs'
     // Simulate a pre-v3 database, then re-init as an upgraded server would.
     repo.db.exec('DROP TABLE latest_success');
     repo.db.exec('PRAGMA user_version = 2');
-    assert.deepEqual(repo.initSchema().applied, [3, 4, 5, 6, 7, 8, 9]);
+    assert.deepEqual(repo.initSchema().applied, [3, 4, 5, 6, 7, 8, 9, 10]);
 
     const rows = repo.db.prepare('SELECT * FROM latest_success ORDER BY asset_id').all();
     assert.equal(rows.length, 1, 'only assets with a succeeded run are projected');

--- a/test/enrich/timing.test.mjs
+++ b/test/enrich/timing.test.mjs
@@ -1,0 +1,304 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import { Repository } from '../../src/enrich/repository.mjs';
+import { EnrichTimingStore, TIMING_LIMITS, measureProviderRequest } from '../../src/enrich/timing.mjs';
+import { runBatch } from '../../src/enrich/runner.mjs';
+import { createProvider } from '../../src/enrich/providers.mjs';
+import { captureRunConfiguration } from '../../src/enrich/runConfiguration.mjs';
+import { EnrichJobRunner } from '../../src/enrich/jobRunner.mjs';
+import { createEnrichRoutes } from '../../src/routes/enrich.mjs';
+import { loadV1Taxonomy, sampleOutput, REPO_ROOT } from './helpers.mjs';
+
+const taxonomy = loadV1Taxonomy();
+const response = (output = sampleOutput()) => Response.json({ choices: [{ message: { content: JSON.stringify(output) } }] });
+function fixture(t, fetchImpl = async () => response()) {
+  const dir = mkdtempSync(join(tmpdir(), 'pictaria-timing-'));
+  const repo = new Repository(join(dir, 'enrichment.sqlite')); repo.initSchema();
+  t.after(() => { repo.close(); rmSync(dir, { recursive: true, force: true }); });
+  const clock = { ms: 0, wall: '2026-09-08T12:00:00.000Z' };
+  repo.timings = new EnrichTimingStore(repo.db, { monotonicNow: () => clock.ms, wallNow: () => clock.wall });
+  const provider = createProvider('local_lmstudio', { modelName: 'timing-model', fetchImpl });
+  const immich = {
+    getAsset: async id => ({ id }),
+    getAssetThumbnail: async () => { clock.ms += 25; return { data: Buffer.from('image'), contentType: 'image/jpeg' }; },
+  };
+  const options = { repo, immich, provider, taxonomy, systemPrompt: 'System', userTemplate: '{approved_tags}', assetIds: ['a'], reprocess: true };
+  return { repo, clock, provider, immich, options, dir };
+}
+function photos(h, index = 0) { return h.repo.timings.photos(h.repo.timings.runs().items[index].id).items; }
+function attempts(h, photo) { return h.repo.timings.attempts(photo.id).items; }
+
+test('photo timing includes download and persistence; request latency uses monotonic time and survives a later failed rerun', async t => {
+  let h; let fail = false;
+  h = fixture(t, async () => { h.clock.ms += 120; h.clock.wall = '2026-09-08T11:59:00.000Z'; if (fail) throw new Error('connection refused'); return response(); });
+  const persist = h.repo.replaceAssetTags.bind(h.repo);
+  h.repo.replaceAssetTags = (...args) => { h.clock.ms += 35; return persist(...args); };
+  await runBatch(h.options);
+  const first = photos(h)[0];
+  assert.equal(first.duration_ms, 180); assert.equal(first.outcome, 'succeeded');
+  assert.ok(first.processing_run_id > 0);
+  const attempt = attempts(h, first)[0];
+  assert.equal(attempt.duration_ms, 120); assert.equal(attempt.outcome, 'accepted'); assert.equal(attempt.http_status, 200);
+  assert.ok(attempt.finished_at < attempt.started_at, 'wall clock can move backwards without corrupting elapsed time');
+  fail = true; await runBatch(h.options);
+  const later = photos(h, 1)[0];
+  assert.notEqual(first.id, later.id); assert.equal(later.asset_id, first.asset_id);
+  assert.equal(later.outcome, 'failed'); assert.equal(attempts(h, later)[0].outcome, 'transport_error');
+  assert.equal(h.repo.db.prepare("SELECT run_id FROM latest_success WHERE asset_id = 'a'").get().run_id, first.processing_run_id);
+  assert.deepEqual(attempts(h, first)[0], attempt);
+});
+
+test('overload and validation retries record each request, while retry waits belong only to the photo', async t => {
+  let h; let calls = 0;
+  h = fixture(t, async () => {
+    h.clock.ms += 50; calls++;
+    if (calls === 1) return new Response('{}', { status: 503, headers: { 'retry-after': '1' } });
+    return response(calls === 2 ? {} : sampleOutput());
+  });
+  await runBatch({ ...h.options, retrySleep: async ms => { h.clock.ms += ms; } });
+  const photo = photos(h)[0]; const rows = attempts(h, photo);
+  assert.equal(photo.outcome, 'succeeded'); assert.equal(photo.duration_ms, 1175);
+  assert.deepEqual(rows.map(r => [r.ordinal, r.duration_ms, r.outcome, r.http_status]), [
+    [1, 50, 'http_error', 503], [2, 50, 'invalid_response', 200], [3, 50, 'accepted', 200],
+  ]);
+});
+
+test('invalid outer JSON, adapter extraction, HTTP errors, skips and download failures are distinct', async t => {
+  for (const [fetchImpl, expected] of [
+    [async () => new Response('not json'), 'invalid_response'],
+    [async () => Response.json({ choices: [] }), 'invalid_response'],
+    [async () => new Response('{}', { status: 401 }), 'http_error'],
+  ]) {
+    const h = fixture(t, fetchImpl); await runBatch(h.options);
+    assert.equal(attempts(h, photos(h)[0])[0].outcome, expected);
+  }
+  const h = fixture(t); await runBatch(h.options);
+  await runBatch({ ...h.options, reprocess: false });
+  assert.deepEqual(photos(h, 1), []);
+  assert.equal(h.repo.timings.runs().items[1].skipped_successful, 1);
+  assert.equal(h.repo.timings.runs().items[1].attempt_count, 0);
+  h.immich.getAssetThumbnail = async () => { throw new Error('download failed'); };
+  await runBatch(h.options);
+  assert.equal(photos(h, 2)[0].error_kind, 'download_error'); assert.deepEqual(attempts(h, photos(h, 2)[0]), []);
+});
+
+test('cancellation during retry wait preserves the completed HTTP attempt; cancellation after download makes none', async t => {
+  const h = fixture(t, async () => new Response('{}', { status: 503 }));
+  let cancelled = false;
+  await runBatch({ ...h.options, shouldStop: () => cancelled, retrySleep: async ms => { h.clock.ms += ms; cancelled = true; } });
+  const photo = photos(h)[0];
+  assert.equal(photo.outcome, 'cancelled'); assert.equal(attempts(h, photo)[0].outcome, 'http_error');
+  assert.equal(h.repo.timings.runs().items[0].outcome, 'cancelled');
+  cancelled = false;
+  h.immich.getAssetThumbnail = async () => { cancelled = true; return { data: Buffer.from('image'), contentType: 'image/jpeg' }; };
+  await runBatch({ ...h.options, shouldStop: () => cancelled });
+  assert.equal(photos(h, 1)[0].outcome, 'cancelled'); assert.deepEqual(attempts(h, photos(h, 1)[0]), []);
+});
+
+async function httpProvider(t, handler, timeoutMs = 500) {
+  const server = createServer(handler);
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  t.after(() => { server.closeAllConnections(); return new Promise(resolve => server.close(resolve)); });
+  return createProvider('local_lmstudio', { modelName: 'native-model', baseUrl: `http://127.0.0.1:${server.address().port}`, timeoutMs });
+}
+
+test('native HTTP timeout and cancellation are measured, and pre-dispatch cancellation makes no request', async t => {
+  const h = fixture(t);
+  let notified; const received = new Promise(resolve => { notified = resolve; });
+  const provider = await httpProvider(t, () => notified(), 250);
+  h.repo.timings = new EnrichTimingStore(h.repo.db);
+  await runBatch({ ...h.options, provider });
+  assert.equal(attempts(h, photos(h)[0])[0].outcome, 'timeout');
+  assert.ok(attempts(h, photos(h)[0])[0].duration_ms >= 20);
+  const controller = new AbortController();
+  const secondReceived = new Promise(resolve => { notified = resolve; });
+  const running = runBatch({ ...h.options, provider, signal: controller.signal, shouldStop: () => controller.signal.aborted });
+  await received; await secondReceived; controller.abort(); await running;
+  assert.equal(attempts(h, photos(h, 1)[0])[0].outcome, 'cancelled');
+  await runBatch({ ...h.options, provider, signal: controller.signal });
+  assert.deepEqual(attempts(h, photos(h, 2)[0]), []);
+});
+
+test('multiple actual requests inside an adapter are distinct, and unrelated provider calls are excluded', async t => {
+  const h = fixture(t);
+  let calls = 0;
+  const native = await httpProvider(t, (req, res) => {
+    calls++;
+    if (calls === 1) return; // timeout, followed by a custom adapter's fallback
+    res.end(JSON.stringify({ choices: [{ message: { content: JSON.stringify(sampleOutput()) } }] }));
+  }, 250);
+  const provider = { providerName: 'local_lmstudio', modelName: 'native-model', async analyzeImage(image, options) {
+    try { await native.analyzeImage(image, options); } catch { /* adapter-specific fallback */ }
+    return native.analyzeImage(image, options);
+  } };
+  await runBatch({ ...h.options, provider });
+  assert.deepEqual(attempts(h, photos(h)[0]).map(r => r.outcome), ['timeout', 'accepted']);
+  await native.analyzeImage({ data: Buffer.from('other'), mimeType: 'image/jpeg' }, { systemPrompt: 'other', userPrompt: 'other', jsonSchema: {} });
+  assert.equal(attempts(h, photos(h)[0]).length, 2);
+});
+
+test('crash recovery and late completion preserve completed requests and leave incomplete durations unknown', async t => {
+  const h = fixture(t); const configuration = captureRunConfiguration(h.options);
+  h.repo.saveRunConfiguration(configuration);
+  const runId = h.repo.timings.startRun(configuration); const photo = h.repo.timings.startPhoto(runId, 'a');
+  let release;
+  await photo.analyze(() => measureProviderRequest(async () => 'valid'));
+  const completed = attempts(h, { id: photo.id })[0];
+  const pending = photo.analyze(() => measureProviderRequest(() => new Promise(resolve => { release = resolve; })));
+  const readerDuringRun = new Repository(h.repo.databasePath);
+  try { readerDuringRun.initSchema(); assert.equal(readerDuringRun.timings.runs().items[0].outcome, 'running'); } finally { readerDuringRun.close(); }
+  h.repo.timings.interrupt();
+  let rows = attempts(h, { id: photo.id });
+  assert.deepEqual(rows[0], completed);
+  assert.equal(rows[1].outcome, 'interrupted'); assert.equal(rows[1].duration_ms, null); assert.equal(rows[1].finished_at, null);
+  release('late result'); await pending; photo.finish('succeeded'); h.repo.timings.finishRun(runId, 'finished');
+  assert.deepEqual(attempts(h, { id: photo.id }), rows);
+  const interrupted = h.repo.timings.photos(runId).items[0];
+  assert.equal(interrupted.outcome, 'interrupted'); assert.equal(interrupted.finished_at, null); assert.equal(interrupted.duration_ms, null);
+  // Opening a read handle must not interrupt active work. Recovery is explicit at server startup.
+  const reader = new Repository(h.repo.databasePath); reader.initSchema();
+  try { assert.equal(reader.timings.runs().items[0].outcome, 'interrupted'); } finally { reader.close(); }
+});
+
+test('a received response without validation at interruption never becomes an accepted sample', async t => {
+  const h = fixture(t); const runId = h.repo.timings.startRun(captureRunConfiguration(h.options));
+  const photo = h.repo.timings.startPhoto(runId, 'a'); let release; let received;
+  const wait = new Promise(resolve => { received = resolve; });
+  const pending = photo.analyze(async () => { await measureProviderRequest(async () => 'body'); received(); await new Promise(resolve => { release = resolve; }); });
+  await wait; h.repo.timings.interrupt(); release(); await pending;
+  const row = attempts(h, { id: photo.id })[0];
+  assert.equal(row.outcome, 'response_received'); assert.notEqual(row.duration_ms, null);
+});
+
+test('timing reads paginate with strict bounds; retention exposes gaps and preserves result history', async t => {
+  const h = fixture(t); await runBatch(h.options);
+  const runId = h.repo.timings.runs().items[0].id;
+  // Bulk seed terminal telemetry to exercise actual retention limits cheaply.
+  h.repo.transaction(() => {
+    const insert = h.repo.db.prepare(`INSERT INTO enrich_photo_executions(timing_run_id, asset_id, started_at, outcome) VALUES (?, 'bulk', '2026-09-08', 'skipped')`);
+    for (let i = 0; i < TIMING_LIMITS.photos + 1; i++) insert.run(runId);
+    h.repo.db.prepare('UPDATE enrich_timing_runs SET photo_count = ? WHERE id = ?').run(TIMING_LIMITS.photos + 2, runId);
+  });
+  h.repo.timings.photoWrites = 0;
+  const active = h.repo.timings.startRun(captureRunConfiguration(h.options));
+  h.repo.timings.startPhoto(active, 'new').finish('skipped');
+  assert.equal(h.repo.timings.photos(runId, { limit: 999999 }).items.length, TIMING_LIMITS.page);
+  assert.equal(h.repo.timings.photos(runId).truncated, true);
+  assert.equal(h.repo.timings.attempts(1), null, 'photo pruning cascades its attempts');
+  assert.equal(h.repo.hasAnySuccessfulRun('a'), true);
+  const first = h.repo.timings.photos(runId, { limit: 2 });
+  const second = h.repo.timings.photos(runId, { limit: 2, afterId: first.nextAfterId });
+  assert.ok(first.items[1].id < second.items[0].id);
+  const currentPhoto = h.repo.timings.startPhoto(active, 'attempt-cap');
+  h.repo.transaction(() => {
+    const insert = h.repo.db.prepare(`INSERT INTO enrich_provider_attempts(photo_execution_id, ordinal, started_at, outcome) VALUES (?, ?, '2026-09-08', 'accepted')`);
+    for (let i = 1; i <= TIMING_LIMITS.attempts + 1; i++) insert.run(currentPhoto.id, i);
+    h.repo.db.prepare('UPDATE enrich_photo_executions SET attempt_count = ? WHERE id = ?').run(TIMING_LIMITS.attempts + 1, currentPhoto.id);
+  });
+  h.repo.timings.attemptWrites = 0;
+  await currentPhoto.analyze(() => measureProviderRequest(async () => 'ok'));
+  assert.equal(h.repo.timings.attempts(currentPhoto.id).retained, TIMING_LIMITS.attempts);
+  assert.equal(h.repo.timings.attempts(currentPhoto.id).truncated, true);
+  assert.equal(h.repo.timings.attempts(currentPhoto.id, { limit: Infinity }).items.length, 50);
+  currentPhoto.finish('succeeded'); h.repo.timings.finishRun(active, 'finished');
+  for (let i = 0; i < TIMING_LIMITS.runs; i++) h.repo.timings.finishRun(h.repo.timings.startRun(captureRunConfiguration(h.options)), 'finished');
+  assert.equal(h.repo.timings.photos(runId), null);
+  assert.equal(h.repo.hasAnySuccessfulRun('a'), true);
+});
+
+test('job history links the timing run and read-only API exposes bounded pages and legacy unknowns', async t => {
+  const h = fixture(t);
+  const config = { defaultProvider: 'local_lmstudio', imageSource: 'preview', promptsDir: join(REPO_ROOT, 'prompts'), promptVersion: 'v1',
+    providers: { local_lmstudio: { modelName: 'timing-model', fetchImpl: async () => response() } } };
+  const runner = new EnrichJobRunner({ repo: h.repo, immich: h.immich, taxonomy, config });
+  h.repo.db.exec(`CREATE TRIGGER fail_timing_run BEFORE INSERT ON enrich_timing_runs BEGIN SELECT RAISE(ABORT, 'timing unavailable'); END;`);
+  assert.throws(() => runner.start({ assetIds: ['a'] }), /timing unavailable/);
+  assert.equal(runner.isBusy(), false, 'failed telemetry startup must not leave a stuck runner');
+  h.repo.db.exec('DROP TRIGGER fail_timing_run');
+  runner.start({ assetIds: ['a', 'b'] }); await runner.runPromise;
+  const job = h.repo.listJobRuns()[0];
+  assert.ok(job.timingRunId); assert.equal(h.repo.timings.runs().items[0].job_run_id, job.id);
+  const handler = createEnrichRoutes({ repo: h.repo, enrichRunner: runner, config, taxonomy, requireImmich: () => true });
+  async function get(path) {
+    const result = {}; await handler({ method: 'GET' }, { writeHead(status) { result.status = status; }, end(body) { result.body = JSON.parse(body); } }, new URL(path, 'http://test'));
+    return result;
+  }
+  const first = await get(`/api/enrich/timings/${job.timingRunId}/photos?limit=1`);
+  assert.equal(first.status, 200); assert.equal(first.body.items.length, 1); assert.ok(first.body.nextCursor);
+  const second = await get(`/api/enrich/timings/${job.timingRunId}/photos?limit=1&cursor=${first.body.nextCursor}`);
+  assert.equal(second.body.nextCursor, null); assert.notEqual(second.body.items[0].id, first.body.items[0].id);
+  const requests = await get(`/api/enrich/timings/photos/${first.body.items[0].id}/attempts`);
+  assert.equal(requests.body.items[0].outcome, 'accepted');
+  assert.equal((await get('/api/enrich/timings/999999/photos')).status, 404);
+  await assert.rejects(get('/api/enrich/timings?limit=999999'), /pages must contain/);
+  await assert.rejects(get('/api/enrich/timings?cursor=invalid!'), /Invalid/);
+  h.repo.recordJobRun({ title: 'Legacy', provider: 'local_lmstudio', status: 'finished', counters: { failed: 0 }, startedAt: '2026-09-01', finishedAt: '2026-09-01' });
+  assert.equal(h.repo.listJobRuns()[0].timingRunId, null);
+});
+
+test('schema 9 upgrades without inventing old timing, and the migration is restart-idempotent', t => {
+  const dir = mkdtempSync(join(tmpdir(), 'pictaria-timing-upgrade-')); t.after(() => rmSync(dir, { recursive: true, force: true }));
+  const path = join(dir, 'enrichment.sqlite'); const db = new DatabaseSync(path);
+  db.exec(readFileSync(join(REPO_ROOT, 'test/fixtures/upgrades/enrichment-v9.sql'), 'utf8'));
+  db.exec("PRAGMA user_version = 9; INSERT INTO job_runs(title, provider, status, started_at, finished_at) VALUES ('Old', 'venice', 'finished', '2026-09-01', '2026-09-01');"); db.close();
+  const repo = new Repository(path);
+  try {
+    assert.deepEqual(repo.initSchema().applied, [10]);
+    assert.equal(repo.listJobRuns()[0].timingRunId, null); assert.deepEqual(repo.timings.runs().items, []);
+    assert.deepEqual(repo.initSchema().applied, []);
+  } finally { repo.close(); }
+});
+
+test('a successful request remains available when a later scan failure aborts the job', async t => {
+  const h = fixture(t); let scans = 0;
+  h.immich.listImageAssets = async () => {
+    if (++scans > 1) throw new Error('metadata scan failed');
+    return [{ id: 'a', type: 'IMAGE' }];
+  };
+  await assert.rejects(runBatch({ ...h.options, assetIds: null, limit: 1, maxAnalyzed: 2 }), /metadata scan failed/);
+  assert.equal(h.repo.timings.runs().items[0].outcome, 'failed');
+  assert.equal(attempts(h, photos(h)[0])[0].outcome, 'accepted');
+});
+
+test('cold restart preserves completed attempts and marks only pending work interrupted', async t => {
+  const dir = mkdtempSync(join(tmpdir(), 'pictaria-timing-restart-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  const path = join(dir, 'enrichment.sqlite');
+  const repo = new Repository(path); repo.initSchema();
+  const configuration = captureRunConfiguration({ provider: createProvider('local_lmstudio', { modelName: 'fixture' }), taxonomy, systemPrompt: 'System', userTemplate: '{approved_tags}' });
+  repo.saveRunConfiguration(configuration);
+  const runId = repo.timings.startRun(configuration); const photo = repo.timings.startPhoto(runId, 'a');
+  await photo.analyze(() => measureProviderRequest(async () => 'accepted'));
+  const before = repo.timings.attempts(photo.id).items[0];
+  // A dispatched request whose promise never settles models process death.
+  photo.analyze(() => measureProviderRequest(() => new Promise(() => {})));
+  repo.close();
+  const restarted = new Repository(path);
+  try {
+    restarted.initSchema(); restarted.timings.interrupt();
+    const rows = restarted.timings.attempts(photo.id).items;
+    assert.deepEqual(rows[0], before);
+    assert.equal(rows[1].outcome, 'interrupted'); assert.equal(rows[1].duration_ms, null); assert.equal(rows[1].finished_at, null);
+    assert.equal(restarted.timings.runs().items[0].outcome, 'interrupted');
+    restarted.timings.interrupt(); assert.deepEqual(restarted.timings.attempts(photo.id).items, rows);
+  } finally { restarted.close(); }
+});
+
+test('a failed timing write cannot commit a photo or request without its lifetime counters', async t => {
+  const h = fixture(t); const runId = h.repo.timings.startRun(captureRunConfiguration(h.options));
+  h.repo.db.exec(`CREATE TRIGGER fail_photo_count BEFORE UPDATE OF photo_count ON enrich_timing_runs BEGIN SELECT RAISE(ABORT, 'counter unavailable'); END;`);
+  assert.throws(() => h.repo.timings.startPhoto(runId, 'a'), /counter unavailable/);
+  assert.equal(h.repo.timings.photos(runId).items.length, 0);
+  h.repo.db.exec('DROP TRIGGER fail_photo_count');
+  const photo = h.repo.timings.startPhoto(runId, 'a'); let dispatched = false;
+  h.repo.db.exec(`CREATE TRIGGER fail_attempt_count BEFORE UPDATE OF attempt_count ON enrich_timing_runs BEGIN SELECT RAISE(ABORT, 'counter unavailable'); END;`);
+  await assert.rejects(photo.analyze(() => measureProviderRequest(async () => { dispatched = true; })), /counter unavailable/);
+  assert.equal(dispatched, false);
+  assert.equal(h.repo.timings.attempts(photo.id).items.length, 0);
+  assert.equal(h.repo.timings.attempts(photo.id).photo.attempt_count, 0);
+});

--- a/test/fixtures/upgrades/enrichment-v9.sql
+++ b/test/fixtures/upgrades/enrichment-v9.sql
@@ -145,7 +145,6 @@ CREATE TABLE IF NOT EXISTS job_runs (
   inference_host_label TEXT,
   configuration_id TEXT REFERENCES enrich_configurations(id),
   inference_id TEXT,
-  timing_run_id INTEGER,
   retry_source_run_id INTEGER,
   targeted INTEGER,
   status TEXT NOT NULL,

--- a/test/migrations.test.mjs
+++ b/test/migrations.test.mjs
@@ -129,7 +129,7 @@ test('a fresh enrichment database is stamped and fully shaped', () => {
     const repo = new Repository(join(dir, 'enrichment.sqlite'));
     const result = repo.initSchema();
     assert.equal(result.fresh, true);
-    assert.equal(getUserVersion(repo.db), 9);
+    assert.equal(getUserVersion(repo.db), 10);
     for (const column of ['subject_group']) {
       const names = repo.db.prepare("SELECT name FROM pragma_table_info('referee_picks')").all().map((row) => row.name);
       assert.ok(names.includes(column));
@@ -178,8 +178,8 @@ test('a legacy enrichment database lands in the current shape via migration 1', 
     const repo = new Repository(path);
     const result = repo.initSchema();
     assert.equal(result.fresh, false);
-    assert.deepEqual(result.applied, [1, 2, 3, 4, 5, 6, 7, 8, 9]);
-    assert.equal(getUserVersion(repo.db), 9);
+    assert.deepEqual(result.applied, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    assert.equal(getUserVersion(repo.db), 10);
 
     // manual_overrides rebuilt append-only with data preserved.
     const overrideColumns = repo.db.prepare("SELECT name FROM pragma_table_info('manual_overrides')").all().map((row) => row.name);
@@ -227,7 +227,7 @@ test('provider-payload migration removes raw envelopes and superseded normalized
       .run(JSON.stringify({ caption: 'old', short_caption: 'old' }), rows[0].id);
     repo.db.exec('PRAGMA user_version = 5');
 
-    assert.deepEqual(repo.initSchema().applied, [6, 7, 8, 9]);
+    assert.deepEqual(repo.initSchema().applied, [6, 7, 8, 9, 10]);
     const migrated = repo.db.prepare(`
       SELECT raw_output_json, normalized_output_json
       FROM processing_runs ORDER BY id

--- a/test/upgrade/upgrade-safety.test.mjs
+++ b/test/upgrade/upgrade-safety.test.mjs
@@ -79,7 +79,7 @@ test('the activity schema contract creates a recovery point before changing an e
       currentServerVersion: '0.1.0-with-activity',
       now: new Date('2026-08-08T02:00:00Z'),
     });
-    assert.equal(PERSISTENT_STATE_VERSION, 11);
+    assert.equal(PERSISTENT_STATE_VERSION, 12);
     assert.equal(prepared.action, 'create');
 
     const snapshot = new DatabaseSync(join(config.backup.dir, prepared.snapshotName, 'enrichment.sqlite'), {
@@ -96,7 +96,7 @@ test('the activity schema contract creates a recovery point before changing an e
       successfulStateVersion: PERSISTENT_STATE_VERSION,
       successfulServerVersion: '0.1.0-with-activity',
     });
-    assert.equal(sealed.upgrade.stateVersion, 11);
+    assert.equal(sealed.upgrade.stateVersion, 12);
     assert.equal(sealed.upgrade.recoveryPoint.snapshotName, prepared.snapshotName);
   });
 });
@@ -116,7 +116,7 @@ test('a zero-model v2 installation creates a complete schedule-confirmation reco
       now: new Date('2026-08-08T02:00:00Z'),
     });
 
-    assert.equal(PERSISTENT_STATE_VERSION, 11);
+    assert.equal(PERSISTENT_STATE_VERSION, 12);
     assert.deepEqual({
       action: prepared.action,
       fromStateVersion: prepared.fromStateVersion,
@@ -124,7 +124,7 @@ test('a zero-model v2 installation creates a complete schedule-confirmation reco
     }, {
       action: 'create',
       fromStateVersion: 2,
-      toStateVersion: 11,
+      toStateVersion: 12,
     });
     assert.equal(
       readFileSync(join(config.backup.dir, prepared.snapshotName, 'smart-albums.json'), 'utf8'),
@@ -146,7 +146,7 @@ test('a zero-model v2 installation creates a complete schedule-confirmation reco
       purpose: {
         type: 'pre-migration',
         fromStateVersion: 2,
-        toStateVersion: 11,
+        toStateVersion: 12,
         fromServerVersion: '0.1.0-before-schedule-confirmation',
         toServerVersion: '0.1.0-with-schedule-confirmation',
       },

--- a/test/upgrade/whole-install.test.mjs
+++ b/test/upgrade/whole-install.test.mjs
@@ -16,6 +16,10 @@ import { DatabaseSync } from 'node:sqlite';
 import { SmartAlbumStore } from '../../src/albums/store.mjs';
 import { backupTargets, runBackup } from '../../src/backup.mjs';
 import { loadConfig } from '../../src/config.mjs';
+import { runBatch } from '../../src/enrich/runner.mjs';
+import { createProvider } from '../../src/enrich/providers.mjs';
+import { captureRunConfiguration } from '../../src/enrich/runConfiguration.mjs';
+import { sampleOutput } from '../enrich/helpers.mjs';
 import { EnrichmentProfiles } from '../../src/enrich/profiles.mjs';
 import { Repository } from '../../src/enrich/repository.mjs';
 import { createFrameLedger } from '../../src/frame/ledger.mjs';
@@ -43,7 +47,7 @@ test('a complete legacy installation upgrades, restarts, backs up, and restores 
     const sourceConfig = fixtureConfig(sourceRoot);
 
     const first = await openInstallation(sourceConfig, 'initialize');
-    assert.deepEqual(first.enrichmentMigration.applied, [1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    assert.deepEqual(first.enrichmentMigration.applied, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     await assertRepresentativeState(first, sourceConfig);
 
     const migratedDefault = first.profiles.activeProfile();
@@ -52,6 +56,19 @@ test('a complete legacy installation upgrades, restarts, backs up, and restores 
     first.enrichment.queueAdd({ title: 'Active profile fixture', filters: { city: 'Fixture City' } });
     first.profiles.update(travel.id, { ...travel, name: 'Renamed travel', expectedRevisionId: travel.revisionId });
     first.profiles.setActive(travel.id);
+    const selected = first.profiles.resolve();
+    const provider = createProvider('local_lmstudio', { modelName: 'fixture-model', fetchImpl: async () =>
+      Response.json({ choices: [{ message: { content: JSON.stringify(sampleOutput()) } }] }) });
+    const configuration = captureRunConfiguration({ provider, taxonomy: selected.taxonomy,
+      systemPrompt: selected.systemPrompt, userTemplate: selected.userTemplate, profile: selected.attribution });
+    await runBatch({ repo: first.enrichment, provider, configuration, assetIds: ['timing-fixture'],
+      immich: { getAsset: async id => ({ id }), getAssetThumbnail: async () => ({ data: Buffer.from('fixture'), contentType: 'image/jpeg' }) } });
+    const timingRun = first.enrichment.timings.runs().items[0];
+    assert.equal(timingRun.configuration_id, configuration.id);
+    assert.equal(first.enrichment.configurationProfile(configuration.id).revisionId, selected.revisionId);
+    const photo = first.enrichment.timings.photos(timingRun.id).items[0];
+    assert.equal(first.enrichment.timings.attempts(photo.id).items[0].outcome, 'accepted');
+
 
     const migratedSettings = readFileSync(sourceConfig.settingsPath, 'utf8');
     const firstSnapshot = semanticSnapshot(first);
@@ -117,7 +134,7 @@ test('contract 10 upgrade snapshots queue pins before clearing them and retains 
     writeFileSync(config.persistentState.inventoryPath, JSON.stringify(inventory));
 
     const upgraded = await openInstallation(config, 'verify');
-    assert.equal(upgraded.inventory.upgrade.stateVersion, 11);
+    assert.equal(upgraded.inventory.upgrade.stateVersion, 12);
     assert.deepEqual(semanticSnapshot(upgraded), before);
     assert.equal(upgraded.profiles.activeProfile().id, travel.id);
     assert.equal(upgraded.enrichment.db.prepare('SELECT COUNT(*) AS n FROM enrich_queue WHERE profile_revision_id IS NOT NULL').get().n, 0);
@@ -174,6 +191,36 @@ function createDatabaseFromSql(databasePath, fixturePath) {
   }
 }
 
+test('contract 11 upgrade saves a schema-9 recovery point before introducing timings', async () => {
+  const workspace = mkdtempSync(join(tmpdir(), 'pictaria-timing-recovery-'));
+  try {
+    const sourceRoot = join(workspace, 'source'); materializeLegacyInstallation(sourceRoot);
+    const config = fixtureConfig(sourceRoot);
+    const installed = await openInstallation(config, 'initialize'); closeInstallation(installed);
+    // The fixture is the exact schema from the approved PIC-340 merge.
+    rmSync(config.databasePath);
+    const old = new DatabaseSync(config.databasePath);
+    old.exec(readFileSync(join(FIXTURES, 'enrichment-v9.sql'), 'utf8'));
+    old.exec("PRAGMA user_version = 9; INSERT INTO job_runs(title, provider, status, started_at, finished_at) VALUES ('Before timing', 'venice', 'finished', '2026-09-01', '2026-09-01');");
+    old.close();
+    const inventory = JSON.parse(readFileSync(config.persistentState.inventoryPath, 'utf8'));
+    inventory.upgrade.stateVersion = 11; writeFileSync(config.persistentState.inventoryPath, JSON.stringify(inventory));
+    const upgraded = await openInstallation(config, 'verify');
+    assert.deepEqual(upgraded.enrichmentMigration.applied, [10]);
+    assert.equal(upgraded.enrichment.listJobRuns()[0].timingRunId, null);
+    const snapshotDir = join(config.backup.dir, upgraded.inventory.upgrade.recoveryPoint.snapshotName);
+    closeInstallation(upgraded);
+    const restoredConfig = fixtureConfig(join(workspace, 'restored')); restoreSnapshot(snapshotDir, restoredConfig);
+    assert.equal(JSON.parse(readFileSync(restoredConfig.persistentState.inventoryPath, 'utf8')).upgrade.stateVersion, 11);
+    const restored = new DatabaseSync(restoredConfig.databasePath);
+    try {
+      assert.equal(getUserVersion(restored), 9);
+      assert.equal(restored.prepare("SELECT COUNT(*) AS n FROM sqlite_master WHERE name = 'enrich_timing_runs'").get().n, 0);
+      assert.equal(restored.prepare('SELECT title FROM job_runs').get().title, 'Before timing');
+    } finally { restored.close(); }
+  } finally { rmSync(workspace, { recursive: true, force: true }); }
+});
+
 async function openInstallation(config, expectedMode) {
   const guard = new PersistentStateGuard({
     inventoryPath: config.persistentState.inventoryPath,
@@ -192,6 +239,7 @@ async function openInstallation(config, expectedMode) {
   const settings = new SettingsStore({ filePath: config.settingsPath, config, env: {} }).load();
   const enrichment = new Repository(config.databasePath);
   const enrichmentMigration = enrichment.initSchema();
+  enrichment.timings.interrupt();
   const profiles = new EnrichmentProfiles({ repo: enrichment, config });
   profiles.initialize();
   const albums = new SmartAlbumStore(config.albums.dataFile, {
@@ -241,6 +289,9 @@ function semanticSnapshot(installation) {
     .get();
 
   return {
+    timingRuns: installation.enrichment.db.prepare('SELECT * FROM enrich_timing_runs ORDER BY id').all(),
+    photoTimings: installation.enrichment.db.prepare('SELECT * FROM enrich_photo_executions ORDER BY id').all(),
+    providerAttempts: installation.enrichment.db.prepare('SELECT * FROM enrich_provider_attempts ORDER BY id').all(),
     profiles: installation.profiles.list(),
     profileRevisions: installation.enrichment.db.prepare('SELECT * FROM enrich_profile_revisions ORDER BY id').all(),
     queue: installation.enrichment.queuePage().items,


### PR DESCRIPTION
Venice and other Enrich runs can combine fast successful responses with slow timeouts and retries. Whole-run throughput cannot separate these effects. This change records each processed photo and each actual provider request, retaining usable measurements from partially failed or interrupted jobs for PIC-332's native performance view.

- Measure photo execution through download, retries/waits, validation, and result persistence. Measure actual HTTP requests separately with monotonic millisecond durations and UTC chronology. Distinguish received responses, accepted results, invalid responses, HTTP/transport errors, timeouts, cancellation, and interruption.
- Link timing runs to immutable configurations/profiles and job summaries. Record skips as counters, preventing mostly-enriched scans from displacing useful request measurements. Preserve completed attempts on restart and prevent late completion from replacing unknown interrupted measurements.
- Add bounded, indexed read APIs and independent telemetry retention: 100 timing runs, 10,000 photo executions, 60,000 provider attempts, with up to 99 extra detail rows between batched pruning passes. Expose retained counts and coverage gaps; leave historical timings unknown.
- Keep timing rows and lifetime counters atomic. Preserve the existing retry, active-profile, latest-success, and human-decision behavior. Dashboard presentation follows in PIC-332.

Validation: [CI](https://github.com/pictaria-ai/pictaria-server/actions/runs/34312313179) passed on `ec7ceb24f77fd222ee6cbc2fb2aeae060eac7c5e`: all 1,084 Node 22 tests (zero failures/skips), upgrade compatibility, container build/boot, and DCO sign-off. Local full-suite and targeted timing, fault-injection, startup-failure, lifecycle, migration, backup/restore, publication-hygiene, and whitespace checks also passed.

Persistence/rollback: enrichment schema 10 and persistent-state contract 12 require the standard pre-migration recovery point. Tests cover upgrading the exact schema-9 fixture from PIC-340, preserving legacy unknowns, round-tripping measured timing and immutable profile attribution through complete backup/restore, and restoring a contract-11/schema-9 snapshot. Rollback uses that snapshot with the corresponding older server. Telemetry retention deletes only timing detail; it does not delete enrichment results or human decisions.

Implemented by Codex; self-reviewed with targeted fault-injection and lifecycle tests. Independent review is pending.

Fixes PIC-343
