### PR TITLE
PIC-311: Scale Enrich sweeps with resumable inventory discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to Pictaria Server are documented here. This project follows
   discovery cliff. Refreshes track visibility/trash changes; stale candidate
   bursts trigger reconciliation. Incomplete discovery keeps a checkpoint and
   reports a failure rather than claiming the library is caught up.
+- Unexpected eligibility metadata excludes the affected photos instead of
+  blocking every library sweep at the same page. Discovery logs include
+  metadata refresh time and bounded diagnostics for uncertain eligibility.
 - Send to Curate on a library sweep adds only that run's successful photos.
   Explicit targeted selections can still send previously enriched results.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable changes to Pictaria Server are documented here. This project follows
 
 ### Changed
 
+- Library sweeps and Daily Enrich select work from a resumable Enrich inventory,
+  avoiding repeated walks through already-enriched photos and the old 100k
+  discovery cliff. Refreshes track visibility/trash changes; stale candidate
+  bursts trigger reconciliation. Incomplete discovery keeps a checkpoint and
+  reports a failure rather than claiming the library is caught up.
+- Send to Curate on a library sweep adds only that run's successful photos.
+  Explicit targeted selections can still send previously enriched results.
+
 - Enrich performance labels median request times explicitly instead of using
   “Typical,” with a short median/average explanation in run details.
 

--- a/docs/ENRICH-DISCOVERY-PROTOTYPE.md
+++ b/docs/ENRICH-DISCOVERY-PROTOTYPE.md
@@ -23,7 +23,8 @@ as well as repeated discovery work.
 Both variants use real repository schemas and identical Enrich history:
 
 - **Enrich-owned:** an experimental inventory in the Enrich database, fed only
-  eligible timeline images.
+  eligible timeline images. This original benchmark mode intentionally retains
+  the filtered-delta defect described below.
 - **Strengthened Insights reuse:** an experimental inventory in a real separate
   Insights database, with the Enrich database attached for SQL history queries.
   The source also supplies hidden photos, stack children, and videos, which SQL
@@ -85,7 +86,7 @@ The focused tests cover:
   run. Previously enriched photos are not added implicitly. This is the approved
   production behavior, but the real runner has not yet been changed.
 
-Two tests deliberately demonstrate unresolved upstream constraints:
+The tests deliberately demonstrate three unresolved upstream constraints:
 
 1. **Equal-timestamp imports:** an overlapping `updatedAfter` watermark can
    repeatedly fetch a large import when many records share the latest timestamp.
@@ -96,11 +97,84 @@ Two tests deliberately demonstrate unresolved upstream constraints:
    cause a later item to be missed even when a scan reaches the end. The test
    recovers it through a subsequent full reconciliation. Atomic publication
    protects local state; it does not make remote pages a consistent snapshot.
+3. **Transitions out of eligibility:** a delta filtered to eligible photos never
+   reports photos that became hidden, stacked, or absent. The regression builds
+   150,000 photos, hides 3,000 and permanently removes another 3,000 ahead of 50
+   eligible photos. The delta returns zero records; selection exhausts six
+   separate 1,000-validation budgets before finding the 50 on attempt seven.
+   Every empty attempt correctly returns `limited: true`; production must not
+   translate that into "library caught up" or wait six Daily Enrich runs.
+
+A second regression exercises an **Enrich-owned broad-delta contract**: full
+builds still filter eligibility, while deltas include retained records regardless
+of eligibility or trash state. SQL invalidates 1,000 hidden, 1,000 stacked, and
+1,000 trashed photos before selection. Another 1,000 permanently removed photos
+cannot appear in that delta and still exhaust one validation budget. The test
+then explicitly starts bounded full reconciliation, resumes it after reopening
+the database, and selects the remaining 50 with 50 validations. This demonstrates
+the recovery building blocks, not an automatic catch-up scheduler.
+
+`enrich-with-broad-delta` is a synthetic contract mode, not an Immich request.
+The fixture's `deleted` flag means retained trash; `remove()` means the record
+is gone. Timestamp filtering now uses inclusive `>=`, matching the upstream
+query builders. The original benchmark modes and their recorded measurements
+remain separate from this proposed contract.
 
 The normalized synthetic source is not an Immich adapter. In particular,
 `stackChild`, `visibility`, and integer `updatedAt` are fixture fields, not a
 claim about exact API response fields or guarantees. Candidate validation also
 cannot eliminate changes occurring after validation and before processing.
+
+## Immich source audit following prototype review
+
+Read-only inspection of the pinned **v2.0.0 and v3.0.0** implementations confirms
+the following. This is source verification, not a live-server acceptance test
+or a guarantee about every intermediate 2.x release.
+
+- **Broad search differs by version.** In v2.0.0, an omitted visibility becomes
+  `timeline`; dropping the filter does not expose hidden or archived transitions.
+  A possible v2 adapter must page explicit timeline/archive/hidden partitions
+  and complete all of them before advancing a shared watermark. In v3.0.0,
+  omission allows broader visibility, with the service restricting ordinary
+  credentials to non-locked records. Locked/access-revoked transitions remain
+  a reconciliation concern; do not require elevated permissions to discover
+  enrichment work. Sources: [v2 query builder](https://github.com/immich-app/immich/blob/v2.0.0/server/src/utils/database.ts#L304),
+  [v3 query builder](https://github.com/immich-app/immich/blob/v3.0.0/server/src/utils/database.ts#L374),
+  [v3 search service](https://github.com/immich-app/immich/blob/v3.0.0/server/src/services/search.service.ts#L65).
+- **`withDeleted` is not a deletion feed.** It removes the `deletedAt IS NULL`
+  predicate on the existing asset table. Responses expose `isTrashed`, and
+  permanent removal deletes the asset row. A row already removed cannot appear
+  in metadata search, even with that option. Sources: [v2 filter](https://github.com/immich-app/immich/blob/v2.0.0/server/src/utils/database.ts#L397),
+  [v3 filter](https://github.com/immich-app/immich/blob/v3.0.0/server/src/utils/database.ts#L491),
+  [response mapping](https://github.com/immich-app/immich/blob/v3.0.0/server/src/dtos/asset-response.dto.ts#L226),
+  [permanent removal](https://github.com/immich-app/immich/blob/v3.0.0/server/src/repositories/asset.repository.ts#L647).
+- **Update bounds are inclusive; pagination is by capture date.** Both builders
+  implement `updatedAfter` as `>=`. Both metadata searches sort by
+  `fileCreatedAt` and use offsets, without an ID tie-breaker or update-time
+  ordering. A completed local generation therefore does not establish a remote
+  snapshot. Do not stop a delta when its first recent update is seen. Sources:
+  [v2 search](https://github.com/immich-app/immich/blob/v2.0.0/server/src/repositories/search.repository.ts#L185),
+  [v3 search](https://github.com/immich-app/immich/blob/v3.0.0/server/src/repositories/search.repository.ts#L197),
+  and the query builders above.
+- **Asset updates and stack membership are different contracts.** Asset-table
+  updates maintain `updatedAt` through a database trigger; stack creation also
+  explicitly updates member assets. However, changing a stack's primary photo
+  updates the stack record in the inspected path. Do not assume every stack
+  role change bumps every member's asset timestamp. Metadata search maps assets
+  without `withStack`, so the synthetic `stackChild` field is not directly
+  available there. In v3, `withStacked: false` excludes all assets with a stack
+  ID, including the primary; it is not a "skip children only" filter. The
+  production adapter still needs a verified membership/primary lookup and a
+  policy consistent with existing Enrich behavior. Sources:
+  [stack creation/update](https://github.com/immich-app/immich/blob/v3.0.0/server/src/repositories/stack.repository.ts#L63),
+  [asset timestamp trigger](https://github.com/immich-app/immich/blob/v3.0.0/server/src/schema/tables/asset.table.ts#L24),
+  [mapping default](https://github.com/immich-app/immich/blob/v3.0.0/server/src/dtos/asset-response.dto.ts#L193),
+  [stack filter](https://github.com/immich-app/immich/blob/v3.0.0/server/src/utils/database.ts#L488).
+
+Consequently, the earlier assumption that an omitted visibility filter works on
+both versions is superseded. Likewise, `IMAGE` + `timeline` alone does not prove
+the prototype's stack-child exclusion. These are adapter constraints, not a
+reason to couple inventory ownership to Insights.
 
 ## Recommendation and production gates
 
@@ -113,10 +187,17 @@ and introduces a cross-database dependency into core enrichment.
 Keep the production change small, but settle these points before shipping:
 
 1. Verify the actual supported Immich API fields and behavior for eligibility,
-   update filtering, restores, access changes, and pagination under mutation.
+   update filtering, restores, access changes, and pagination under mutation
+   against test instances, using the version differences above.
    Define a bounded freshness policy for large equal-timestamp imports and a
    reconciliation policy for changes incremental reads cannot observe. Do not
    claim an exhaustive inventory merely because offset pagination ended.
+   Refresh must observe transitions out of eligibility; a burst of rejected
+   validations must request bounded, resumable catch-up rather than wait for
+   another daily run. `limited` means discovery is incomplete. Report candidate,
+   validated, rejected, and processed counts in diagnostics; do not claim that a
+   zero-selection result means there is no remaining work. Automatic scheduling,
+   rejection thresholds, and user-facing status are still production work.
 2. Decide the minimal inventory projection in the Enrich database, migration
    and backup behavior, and reset rules when the Immich server or authorization
    context changes. Experimental tables are not the proposed final schema.

--- a/docs/ENRICH-DISCOVERY-PROTOTYPE.md
+++ b/docs/ENRICH-DISCOVERY-PROTOTYPE.md
@@ -1,8 +1,13 @@
 # Enrich discovery feasibility prototype (PIC-311)
 
-Status: isolated experiment, September 2026. This does not change runtime
-behavior or implement PIC-311. The proposed production direction is a small
-Enrich-owned inventory, with the correctness constraints below resolved first.
+Status: historical isolated experiment, September 2026. The scripts remain
+separate from production. The production implementation and its deliberate
+freshness limits are now described in [Enrich](ENRICH.md#library-discovery-and-freshness)
+and [Upgrading](UPGRADING.md#enrich-discovery-unreleased-v12-work). In particular,
+production preserves timeline-image eligibility, does not adopt the synthetic
+stack-child rule, and uses daily full reconciliation for late timestamp-boundary
+arrivals. The measurements and open questions below record the prototype stage;
+live Immich acceptance remains outstanding.
 
 ## Why an inventory is needed
 

--- a/docs/ENRICH-DISCOVERY-PROTOTYPE.md
+++ b/docs/ENRICH-DISCOVERY-PROTOTYPE.md
@@ -1,0 +1,143 @@
+# Enrich discovery feasibility prototype (PIC-311)
+
+Status: isolated experiment, September 2026. This does not change runtime
+behavior or implement PIC-311. The proposed production direction is a small
+Enrich-owned inventory, with the correctness constraints below resolved first.
+
+## Why an inventory is needed
+
+Enrich's existing history only knows photos it has encountered. Querying that
+database alone cannot discover unseen photos in Immich. An inventory supplies
+the missing IDs; SQL can then exclude completed, discarded, and failure-limited
+photos before applying the run limit.
+
+The baseline script exercises the real `runBatch` and
+`ImmichClient.listImageAssets` against a synthetic source. With 100,050 photos,
+the newest 100,000 already enriched, a run requesting 50 new photos fails at
+the 100,000-item traversal limit with zero provider calls. In this local run it
+took 11.9 seconds and fetched 1,001 metadata pages. This is a correctness issue
+as well as repeated discovery work.
+
+## What the experiment compares
+
+Both variants use real repository schemas and identical Enrich history:
+
+- **Enrich-owned:** an experimental inventory in the Enrich database, fed only
+  eligible timeline images.
+- **Strengthened Insights reuse:** an experimental inventory in a real separate
+  Insights database, with the Enrich database attached for SQL history queries.
+  The source also supplies hidden photos, stack children, and videos, which SQL
+  excludes before its limit.
+
+The second variant models changes Insights would need. It does **not** use the
+current `swept_assets` table or run the Insights collector unchanged. Its
+inventory needs eligibility and source-update fields absent from that table,
+plus freshness and completion guarantees suitable for dispatching Enrich work.
+
+Both variants stage pages, persist a checkpoint after each page, resume with a
+fixed page size, and publish a generation only after reaching the end. Existing
+published data remains available during refresh. Selection uses stable capture
+date/ID ordering, applies history eligibility in SQL, and checks selected assets
+against the source before simulated dispatch. Rejected candidates do not consume
+the photo processing limit; validation has a separate budget.
+
+## Results
+
+Synthetic source, local SQLite, no HTTP or provider latency. Each row includes
+50 eligible photos behind an already-enriched prefix. The broad source adds
+5% hidden photos, 5% stack children, and 5% videos.
+
+| Eligible library photos | Inventory | Full metadata pages | Resumable batches | Build time | Median SQL selection |
+| ---: | --- | ---: | ---: | ---: | ---: |
+| 10,000 | Enrich | 10 | 5 | 35 ms | 1.9 ms |
+| 10,000 | Strengthened Insights | 12 | 6 | 33 ms | 1.9 ms |
+| 100,000 | Enrich | 100 | 50 | 151 ms | 23.6 ms |
+| 100,000 | Strengthened Insights | 115 | 58 | 341 ms | 23.6 ms |
+| 150,000 | Enrich | 150 | 75 | 233 ms | 35.7 ms |
+| 150,000 | Strengthened Insights | 173 | 87 | 332 ms | 35.9 ms |
+
+Each batch reads at most two pages of 1,000 items. SQL timing is the median of
+five reads. Both approaches select the same 50 photos, validate exactly those
+50, and return no candidates after success history is recorded. In this fixture,
+an unchanged incremental pass fetches one metadata page containing an overlapping
+boundary row. These timings are not end-to-end production forecasts, and the
+small difference between SQL timings does not favor either architecture.
+
+An Enrich-owned inventory adds another initial scan if Insights also scans the
+library. The broad-source counts above are not proof it saves total system work:
+an existing Insights inventory may already have paid that cost.
+
+## Correctness evidence and limits
+
+The focused tests cover:
+
+- 150,000 photos, bounded batches, checkpoint recovery after reopening the
+  database, and no cold-start completeness claim before publication.
+- SQL selection parity with `Repository.assetIdsNeedingWork`: prior success,
+  inference changes, legacy configuration matching, discard, retry limits,
+  infrastructure failures, and applying the run limit after eligibility.
+- Deletion, hiding, or stack membership changes before selection; invalid
+  candidates do not consume the requested photo budget.
+- New uploads with old capture dates, restores with changed source timestamps,
+  empty incremental passes, and malformed or failed pages preserving state.
+- Full reconciliation recovering changes that leave source timestamps unchanged.
+- Simulated Send to Curate adding only photos successfully processed in that
+  run. Previously enriched photos are not added implicitly. This is the approved
+  production behavior, but the real runner has not yet been changed.
+
+Two tests deliberately demonstrate unresolved upstream constraints:
+
+1. **Equal-timestamp imports:** an overlapping `updatedAfter` watermark can
+   repeatedly fetch a large import when many records share the latest timestamp.
+   The 10,000-photo equal-timestamp fixture requires ten pages on the next pass,
+   rather than the benchmark's one. A source timestamp is safer than advancing
+   to local wall-clock time, but is not a complete bounded freshness policy.
+2. **Mutable offset pagination:** deleting an earlier item between pages can
+   cause a later item to be missed even when a scan reaches the end. The test
+   recovers it through a subsequent full reconciliation. Atomic publication
+   protects local state; it does not make remote pages a consistent snapshot.
+
+The normalized synthetic source is not an Immich adapter. In particular,
+`stackChild`, `visibility`, and integer `updatedAt` are fixture fields, not a
+claim about exact API response fields or guarantees. Candidate validation also
+cannot eliminate changes occurring after validation and before processing.
+
+## Recommendation and production gates
+
+Prefer an **Enrich-owned inventory** because Enrich controls its lifecycle,
+freshness, and dispatch rules independently of Insights. Both versions have
+similar SQL cost; ownership and coupling are the deciding factors. Reusing
+Insights would still require extending its projection and collector guarantees,
+and introduces a cross-database dependency into core enrichment.
+
+Keep the production change small, but settle these points before shipping:
+
+1. Verify the actual supported Immich API fields and behavior for eligibility,
+   update filtering, restores, access changes, and pagination under mutation.
+   Define a bounded freshness policy for large equal-timestamp imports and a
+   reconciliation policy for changes incremental reads cannot observe. Do not
+   claim an exhaustive inventory merely because offset pagination ended.
+2. Decide the minimal inventory projection in the Enrich database, migration
+   and backup behavior, and reset rules when the Immich server or authorization
+   context changes. Experimental tables are not the proposed final schema.
+3. Integrate refresh and selection with manual and Daily Enrich runs, restart,
+   cancellation, concurrency protections, saved run settings, and existing
+   history writes. Share production eligibility SQL rather than copying it.
+4. Implement and verify the approved Curate rule in the real runner, including
+   its existing tests. Validate the complete flow against a test Immich instance.
+
+## Reproduce
+
+From the repository root with the project's supported Node version:
+
+```sh
+node --test test/enrich/discoveryPrototype.test.mjs
+node scripts/prototypes/benchmark-discovery.mjs
+node scripts/prototypes/baseline-discovery.mjs
+```
+
+The scripts create synthetic SQLite databases in the operating system's temp
+directory and remove them on normal completion. They accept no database path,
+server configuration, or credentials, and never call Immich or an AI provider.
+No production module imports this prototype. Benchmark output is printed rather
+than committed as generated evidence.

--- a/docs/ENRICH.md
+++ b/docs/ENRICH.md
@@ -237,6 +237,17 @@ processed, matching the previous library-search scope; this change introduces
 no new stack-child exclusion rule. Changing profiles keeps the inventory and
 re-evaluates history using the captured inference configuration.
 
+Unknown photo types, visibility values, or non-boolean trash flags make a
+record ineligible without blocking the rest of discovery. Missing visibility
+in a search row inherits that request's explicit visibility partition. Before
+processing, a separate live photo lookup must confirm an image with timeline
+visibility and `isTrashed: false`; it never inherits search visibility.
+Diagnostics for incomplete eligibility metadata are bounded to one per
+refresh and one for live validation per run. Missing IDs or invalid update
+timestamps, malformed capture dates, and broken page structure still stop the
+refresh without advancing its checkpoint. Corrected records are reconsidered
+on a newer source update or full reconciliation.
+
 Each completed refresh advances from the largest source `updatedAt`, never
 from Pictaria's clock. The next incremental pass starts one millisecond later
 to avoid repeatedly reading a large import sharing the boundary timestamp.
@@ -258,7 +269,9 @@ if either is reached. Candidate validation has a separate bound (at least
 10,000, or the requested photo budget plus 1,000). Exhaustion is reported in
 run history as **Library discovery is incomplete**, with instructions to run
 again; it is never reported as no remaining work. The log records scanned
-metadata, candidates, validations, and rejections. Very large/slow libraries
+metadata, candidates, validations, rejections, and elapsed metadata refresh
+time (including interrupted refreshes, excluding AI processing and live
+candidate lookups). Very large/slow libraries
 may need another run to finish construction; Daily Enrich retains its existing
 once-per-day attempt policy. Discovery resumes the next time it is invoked.
 

--- a/docs/ENRICH.md
+++ b/docs/ENRICH.md
@@ -201,10 +201,11 @@ light even on remote links.
 
 ## Starting runs
 
-- **Library sweep** — the Enrich page's *Start*: scans newest-first,
-  analyzes up to the *Photos* budget (skips don't consume the budget).
-  *Only unenriched* (default on) skips photos that already have a
-  successful run from any model.
+- **Library sweep** — the Enrich page's *Start*: selects newest-first from
+  Enrich's local inventory and analyzes up to the *Photos* budget. SQL excludes
+  covered, discarded, and failure-limited photos before applying that budget.
+  *Only unenriched* (default on) excludes photos with a successful run from
+  any model. Each selected photo is checked against Immich before processing.
 - **Daily Enrich** — an optional set-it-and-forget-it library sweep under
   **Settings → Enrich**. Choose a local time and daily photo budget; Pictaria
   uses the provider currently selected on the Enrich page, analyzes only
@@ -214,10 +215,59 @@ light even on remote links.
   queued run already in progress keeps priority and the daily sweep waits
   quietly. Enabling the schedule after today's chosen time starts that day's
   catch-up promptly. Each attempt appears in **Recent runs** as `Daily Enrich`,
-  including a zero-photo run when the library was already caught up. A run
+  including a zero-photo run when no eligible photos were found. A run
   that starts but fails is recorded there and waits until the next day rather
   than retrying automatically; after correcting the problem, start a manual
   run if you do not want to wait.
+
+### Library discovery and freshness
+
+The first budgeted sweep builds an Enrich-owned inventory in 1,000-record
+metadata pages. It saves each page and publishes only after finishing the
+pass. A restart, cancellation, outage, or bounded incomplete pass can resume
+from its checkpoint. It does not download images or call the AI provider
+during inventory construction. The existing Enrich database holds this
+rebuildable cache separately from processing history and human decisions.
+
+Later sweeps query changes with explicit timeline, archive, and hidden
+visibility partitions and include retained trash records, then compute
+eligibility locally. This works with the inspected v2/v3 search defaults
+without requiring locked-library permissions. Only timeline images are
+processed, matching the previous library-search scope; this change introduces
+no new stack-child exclusion rule. Changing profiles keeps the inventory and
+re-evaluates history using the captured inference configuration.
+
+Each completed refresh advances from the largest source `updatedAt`, never
+from Pictaria's clock. The next incremental pass starts one millisecond later
+to avoid repeatedly reading a large import sharing the boundary timestamp.
+Late arrivals at that exact timestamp, silent access changes, and photos missed
+by mutable remote offset pagination are handled by a full reconciliation on
+the next sweep after 24 hours. This is eventual discovery, not a remote
+snapshot or an instant notification stream. Ordinary newer uploads are found
+by the next incremental pass even when their capture dates are old.
+
+Permanent deletions and locked/inaccessible transitions cannot all appear in
+search results. A burst of 100 consecutive rejected candidates starts a full
+catch-up within the same run. Rejected candidates do not consume the AI photo
+budget. Permission/server failures propagate instead of being recorded as
+confirmed deletions. Only one catch-up is attempted per run; continuing churn
+can still produce an explicit incomplete result.
+
+A refresh is bounded to 2,000 pages and ten minutes, with a checkpoint retained
+if either is reached. Candidate validation has a separate bound (at least
+10,000, or the requested photo budget plus 1,000). Exhaustion is reported in
+run history as **Library discovery is incomplete**, with instructions to run
+again; it is never reported as no remaining work. The log records scanned
+metadata, candidates, validations, and rejections. Very large/slow libraries
+may need another run to finish construction; Daily Enrich retains its existing
+once-per-day attempt policy. Discovery resumes the next time it is invoked.
+
+Changing the Immich URL or API key rebuilds the inventory, preserving Enrich
+history and human decisions. A database lease prevents concurrent inventory
+writers; a process killed without releasing it can delay a restart by up to
+five minutes. Explicit targeted queue/retry jobs keep their existing selection
+path. Low-level CLI calls with offsets or no photo budget retain their bounded
+metadata-window semantics.
 
 **“Enriched” is per effective inference configuration.** With *Only
 unenriched* on, any previous success covers a photo. With it off, Pictaria
@@ -284,8 +334,9 @@ captions, and search; existing human decisions remain authoritative.
 
 Enriching and reviewing are separate pipelines that compose. Every run has a
 **Send to Curate** option (on by default): photos join the Curate review
-queue as the run enriches them (photos that were already enriched count
-too). Photos that fail are never listed — they stay with the queued job and
+queue as the run enriches them. Library sweeps send only their new successes;
+they do not send the already-enriched library implicitly. Explicit targeted
+selections can still send existing results. Photos that fail are never listed — they stay with the queued job and
 enter Curate when a later run enriches them, so the review queue only ever
 holds photos with real AI signal. Turn the option off to enrich purely for
 tags, captions, and albums — Curate never hears about it.
@@ -754,10 +805,11 @@ Retries, failures, and incomplete timing retain their request details.
 Routine already-enriched photos are omitted from run outcome summaries and
 future per-photo logs. Discovery shows “Finding photos to enrich…” before
 processing starts; an empty completed selection is described without claiming
-the entire library is complete. Failure-limit and discarded counts remain
-explicit. Internal skip counters and metadata-window diagnostics are retained;
-existing saved logs are unchanged. This presentation does not optimize the
-underlying Immich metadata scan.
+the entire library is complete. Targeted runs retain explicit failure-limit
+and discarded counts; library discovery filters those candidates in SQL.
+Internal skip counters and discovery diagnostics are retained;
+existing saved logs are unchanged. Budgeted library sweeps now use the
+inventory discovery described above.
 
 The **Compare setups** view starts with the three most recently used setups; **Show all comparisons**
 includes every setup within the retained timing window (at most 100 runs).

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -282,6 +282,25 @@ revisions and the active choice live in enrichment.sqlite and are included
 in standard backups.
 
 
+## Enrich discovery (unreleased v1.2 work)
+
+Schema 11 / persistent-state contract 13 adds a rebuildable Enrich inventory,
+a staging table, and a checkpoint/lease record to enrichment.sqlite. Existing
+processing history, results, queues, profiles, and human decisions remain
+unchanged. No historical assets are assumed to form a complete inventory;
+the first budgeted library sweep constructs one from Immich.
+
+The standard pre-migration recovery point is created before this migration.
+Normal backups include both the published inventory and any saved in-progress
+scan. Resume uses the same source credentials; a URL/key change starts a fresh
+inventory without clearing enrichment history. A restored active lease can
+delay discovery for up to five minutes before it expires.
+
+Rollback requires the pre-upgrade snapshot and its matching older build. Do
+not run an older server directly against contract-13 state. The upgrade tests
+verify that a contract-12/schema-10 recovery snapshot contains neither the
+new tables nor changes to existing job history.
+
 ## Enrich timing (unreleased v1.2 work)
 
 Schema 10 / persistent-state contract 12 adds timing runs, photo executions,

--- a/scripts/prototypes/baseline-discovery.mjs
+++ b/scripts/prototypes/baseline-discovery.mjs
@@ -1,0 +1,27 @@
+// Reproduce the production traversal cliff with synthetic data, not a live server.
+import assert from 'node:assert/strict';
+import { performance } from 'node:perf_hooks';
+import { ImmichClient } from '../../src/immich.mjs';
+import { runBatch } from '../../src/enrich/runner.mjs';
+import { loadV1Taxonomy } from '../../test/enrich/helpers.mjs';
+import { library, sandbox, SyntheticSource, history } from './discovery-fixture.mjs';
+const rows = library(100050, false), source = new SyntheticSource(rows), box = sandbox();
+let calls = 0;
+try {
+  box.repo.transaction(() => { for (const row of rows.slice(0, -50)) history(box.repo, row); });
+  const immich = { listImageAssets: ImmichClient.prototype.listImageAssets,
+    async searchMetadata({ page, size }) {
+      const result = await source.scan({ page, size, updatedAfter: null });
+      return { assets: { items: result.items, nextPage: result.nextPage } };
+    } };
+  const provider = { providerName: 'cloud_openai', modelName: 'fixture',
+    async analyzeImage() { calls++; throw Error('Unexpected provider dispatch'); } };
+  const started = performance.now(); let error;
+  try { await runBatch({ repo: box.repo, immich, provider, taxonomy: loadV1Taxonomy(), systemPrompt: 'fixture',
+    userTemplate: '{approved_tags}', promptVersion: 'v1', skipAnySuccessful: true, limit: 1000, maxAnalyzed: 50 }); }
+  catch (e) { error = e; }
+  assert.match(error?.message ?? '', /100000-item traversal limit/);
+  assert.equal(calls, 0);
+  console.log(JSON.stringify({ libraryPhotos: rows.length, enrichedPrefix: 100000,
+    localMs: Math.round(performance.now() - started), ...source.calls, providerCalls: calls, error: error.message }));
+} finally { box.close(); }

--- a/scripts/prototypes/benchmark-discovery.mjs
+++ b/scripts/prototypes/benchmark-discovery.mjs
@@ -1,0 +1,29 @@
+// Standalone synthetic experiment, never connects to Immich or a provider.
+import { performance } from 'node:perf_hooks';
+import { library, sandbox, SyntheticSource, history, finish, key } from './discovery-fixture.mjs';
+for (const size of [10000, 100000, 150000]) {
+  const rows = library(size);
+  for (const mode of ['enrich', 'insights-with-eligibility-columns']) {
+    const box = sandbox();
+    try {
+      box.repo.transaction(() => { for (const row of rows.slice(0, size - 50)) history(box.repo, row); });
+      const index = box.index(mode), source = new SyntheticSource(rows, mode);
+      index.begin(); const start = performance.now();
+      const batches = await finish(index, source, { maxPages: 2 });
+      const buildMs = performance.now() - start;
+      const samples = [];
+      for (let i = 0; i < 5; i++) { const t = performance.now(); index.candidates({ runKey: key }); samples.push(performance.now() - t); }
+      const full = { ...source.calls };
+      index.begin('delta'); const deltaSteps = await finish(index, source);
+      const chosen = await index.select(source, { runKey: key, limit: 50 });
+      box.repo.transaction(() => { for (const row of chosen.selected) history(box.repo, row); });
+      const afterProcessing = index.candidates({ runKey: key }).length;
+      console.log(JSON.stringify({ size, mode, inventoryRows: index.db.prepare('SELECT COUNT(*) AS n FROM prototype_inventory').get().n,
+        fullPages: full.pages, fullRows: full.rows, batches, buildMs: Math.round(buildMs),
+        sqlMedianMs: Math.round(samples.sort((a, b) => a - b)[2] * 10) / 10,
+        // Includes the overlapped boundary row; these are metadata requests.
+        overlapPages: source.calls.pages - full.pages, deltaSteps,
+        selected: chosen.selected.length, validations: chosen.validated, afterProcessing }));
+    } finally { box.close(); }
+  }
+}

--- a/scripts/prototypes/discovery-fixture.mjs
+++ b/scripts/prototypes/discovery-fixture.mjs
@@ -1,0 +1,66 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { InsightsRepository } from '../../src/insights/repository.mjs';
+import { Repository } from '../../src/enrich/repository.mjs';
+import { DiscoveryPrototype, isEligible } from './enrich-discovery.mjs';
+
+export const key = { provider: 'cloud_openai', model: 'fixture', promptVersion: 'v1', taxonomyVersion: 'v1', inferenceId: 'a'.repeat(64) };
+export function photo(id, overrides = {}) {
+  return { id, type: 'IMAGE', visibility: 'timeline', stackChild: false, deleted: false,
+    takenAt: '2026-01-01T00:00:00.000Z', updatedAt: 10000, ...overrides };
+}
+export class SyntheticSource {
+  constructor(rows, mode = 'enrich') {
+    this.rows = new Map(rows.map(r => [r.id, { ...r }])); this.mode = mode; this.cache = new Map();
+    this.calls = { pages: 0, rows: 0, gets: 0 };
+  }
+  change(id, patch) { Object.assign(this.rows.get(id), patch); this.cache.clear(); }
+  add(row) { this.rows.set(row.id, { ...row }); this.cache.clear(); }
+  remove(id) { this.rows.delete(id); this.cache.clear(); }
+  async scan({ page, size, updatedAfter }) {
+    this.calls.pages++;
+    const cacheKey = `${this.mode}:${updatedAfter}`;
+    if (!this.cache.has(cacheKey)) this.cache.set(cacheKey, [...this.rows.values()]
+      .filter(r => !r.deleted && (this.mode !== 'enrich' || isEligible(r)) && (updatedAfter === null || r.updatedAt > updatedAfter))
+      .sort((a, b) => (b.takenAt ?? '').localeCompare(a.takenAt ?? '') || b.id.localeCompare(a.id)));
+    const rows = this.cache.get(cacheKey), items = rows.slice((page - 1) * size, page * size).map(r => ({ ...r }));
+    this.calls.rows += items.length;
+    return { items, nextPage: page * size < rows.length ? page + 1 : null };
+  }
+  async get(id) { this.calls.gets++; const row = this.rows.get(id); return row && !row.deleted ? { ...row } : null; }
+}
+export function sandbox() {
+  const dir = mkdtempSync(join(tmpdir(), 'pictaria-discovery-prototype-'));
+  const path = join(dir, 'prototype.sqlite'); let repo = new Repository(path); repo.initSchema(); let insights = null;
+  return { get repo() { return repo; },
+    index(mode = 'enrich') {
+      if (mode === 'enrich') return new DiscoveryPrototype(repo);
+      insights ??= new InsightsRepository(join(dir, 'insights.sqlite'));
+      insights.db.prepare('ATTACH DATABASE ? AS enrich_history').run(path);
+      return new DiscoveryPrototype(insights, { historySchema: 'enrich_history', enrichRepo: repo });
+    },
+    reopen() { repo.close(); repo = new Repository(path); repo.initSchema(); return new DiscoveryPrototype(repo); },
+    close() { insights?.close(); repo.close(); rmSync(dir, { recursive: true, force: true }); } };
+}
+export function history(repo, row, { status = 'succeeded', runKey = key, discarded = false } = {}) {
+  const date = '2026-01-01T00:00:00.000Z';
+  repo.db.prepare(`INSERT OR IGNORE INTO assets(asset_id,file_created_at,first_seen_at,last_seen_at,enrich_discarded_at)
+    VALUES(?,?,?,?,?)`).run(row.id, row.takenAt, date, date, discarded ? date : null);
+  if (discarded) repo.db.prepare('UPDATE assets SET enrich_discarded_at=? WHERE asset_id=?').run(date, row.id);
+  if (status) repo.db.prepare(`INSERT INTO processing_runs(asset_id,provider,model,prompt_version,taxonomy_version,status,started_at,finished_at,inference_id)
+    VALUES(?,?,?,?,?,?,?,?,?)`).run(row.id, runKey.provider, runKey.model, runKey.promptVersion, runKey.taxonomyVersion, status, date, date, runKey.inferenceId ?? null);
+}
+export function library(size, extras = true) {
+  const rows = Array.from({ length: size }, (_, i) => photo(`photo-${String(i).padStart(7, '0')}`,
+    { takenAt: new Date(Date.UTC(2026, 0, 1) - i * 1000).toISOString(), updatedAt: 10000 + (size - i) * 2000 }));
+  if (extras) for (let i = 0; i < Math.floor(size / 20); i++) {
+    rows.push(photo(`hidden-${i}`, { visibility: 'hidden' }), photo(`stack-${i}`, { stackChild: true }), photo(`video-${i}`, { type: 'VIDEO' }));
+  }
+  return rows;
+}
+export async function finish(index, source, options = {}) {
+  let steps = 0;
+  do { await index.step(source, options); steps++; } while (index.state().scan);
+  return steps;
+}

--- a/scripts/prototypes/discovery-fixture.mjs
+++ b/scripts/prototypes/discovery-fixture.mjs
@@ -20,9 +20,13 @@ export class SyntheticSource {
   remove(id) { this.rows.delete(id); this.cache.clear(); }
   async scan({ page, size, updatedAfter }) {
     this.calls.pages++;
+    // Contract experiment only, NOT a version-aware Immich adapter. `deleted`
+    // models retained trash; remove() models a permanently absent record.
+    const broadDelta = this.mode === 'enrich-with-broad-delta' && updatedAfter !== null;
+    const eligibleOnly = this.mode === 'enrich' || (this.mode === 'enrich-with-broad-delta' && !broadDelta);
     const cacheKey = `${this.mode}:${updatedAfter}`;
     if (!this.cache.has(cacheKey)) this.cache.set(cacheKey, [...this.rows.values()]
-      .filter(r => !r.deleted && (this.mode !== 'enrich' || isEligible(r)) && (updatedAfter === null || r.updatedAt > updatedAfter))
+      .filter(r => (broadDelta || !r.deleted) && (!eligibleOnly || isEligible(r)) && (updatedAfter === null || r.updatedAt >= updatedAfter))
       .sort((a, b) => (b.takenAt ?? '').localeCompare(a.takenAt ?? '') || b.id.localeCompare(a.id)));
     const rows = this.cache.get(cacheKey), items = rows.slice((page - 1) * size, page * size).map(r => ({ ...r }));
     this.calls.rows += items.length;

--- a/scripts/prototypes/enrich-discovery.mjs
+++ b/scripts/prototypes/enrich-discovery.mjs
@@ -1,0 +1,142 @@
+// PIC-311 feasibility prototype. Synthetic databases only; no production imports
+// this module. The source adapter is deliberately NOT an Immich implementation.
+// See docs/ENRICH-DISCOVERY-PROTOTYPE.md for unproven upstream guarantees.
+export class DiscoveryPrototype {
+  constructor(repo, { historySchema = 'main', enrichRepo = repo } = {}) {
+    if (!['main', 'enrich_history'].includes(historySchema)) throw Error('Unknown prototype history schema');
+    this.historySchema = historySchema; this.enrichRepo = enrichRepo;
+    this.repo = repo;
+    this.db = repo.db;
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS prototype_inventory (
+        asset_id TEXT PRIMARY KEY, taken_at TEXT, updated_at INTEGER NOT NULL,
+        eligible INTEGER NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS prototype_inventory_order
+        ON prototype_inventory(eligible, taken_at DESC, asset_id DESC);
+      CREATE TABLE IF NOT EXISTS prototype_stage (
+        asset_id TEXT PRIMARY KEY, taken_at TEXT, updated_at INTEGER NOT NULL,
+        eligible INTEGER NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS prototype_state (id INTEGER PRIMARY KEY, value TEXT NOT NULL);
+      INSERT OR IGNORE INTO prototype_state VALUES (1, '{"ready":false,"watermark":0,"scan":null}');
+    `);
+  }
+  state() { return JSON.parse(this.db.prepare('SELECT value FROM prototype_state WHERE id=1').get().value); }
+  save(state) { this.db.prepare('UPDATE prototype_state SET value=? WHERE id=1').run(JSON.stringify(state)); }
+  begin(kind = 'full') {
+    if (!['full', 'delta'].includes(kind)) throw Error('Unknown scan kind');
+    const state = this.state();
+    if (state.scan) throw Error('Resume the unfinished scan first');
+    if (kind === 'delta' && !state.ready) throw Error('Full inventory required');
+    // Source timestamps only. Empty delta passes do not advance the watermark.
+    state.scan = { kind, page: 1, after: kind === 'delta' ? Math.max(0, state.watermark - 1000) : null,
+      maxUpdated: state.watermark, rows: 0 };
+    this.repo.transaction(() => { this.db.exec('DELETE FROM prototype_stage'); this.save(state); });
+  }
+  async step(source, { maxPages = 2, pageSize = 1000 } = {}) {
+    if (!Number.isInteger(maxPages) || maxPages < 1 || maxPages > 100 ||
+        !Number.isInteger(pageSize) || pageSize < 1 || pageSize > 1000) throw Error('Invalid page budget');
+    let pages = 0;
+    while (this.state().scan && pages < maxPages) {
+      const state = this.state(), scan = state.scan;
+      if (scan.pageSize && scan.pageSize !== pageSize) throw Error('Resume with the same page size');
+      scan.pageSize = pageSize;
+      const page = await source.scan({ page: scan.page, size: pageSize, updatedAfter: scan.after });
+      if (!Array.isArray(page.items) || page.items.length > pageSize ||
+          (page.nextPage !== null && (!Number.isInteger(page.nextPage) || page.nextPage <= scan.page))) {
+        throw Error('Invalid upstream page');
+      }
+      const rows = page.items.map(asset => {
+        if (typeof asset.id !== 'string' || !asset.id || !Number.isSafeInteger(asset.updatedAt) || asset.updatedAt < 0 ||
+            (asset.takenAt !== null && (typeof asset.takenAt !== 'string' || !Number.isFinite(Date.parse(asset.takenAt))))) {
+          throw Error('Invalid upstream asset');
+        }
+        return { ...asset, eligible: isEligible(asset) ? 1 : 0 };
+      });
+      this.repo.transaction(() => {
+        const insert = this.db.prepare(`INSERT INTO prototype_stage VALUES(?,?,?,?)
+          ON CONFLICT(asset_id) DO UPDATE SET taken_at=excluded.taken_at,
+          updated_at=excluded.updated_at, eligible=excluded.eligible
+          WHERE excluded.updated_at >= prototype_stage.updated_at`);
+        for (const row of rows) {
+          insert.run(row.id, row.takenAt, row.updatedAt, row.eligible);
+          scan.maxUpdated = Math.max(scan.maxUpdated, row.updatedAt);
+        }
+        scan.rows += rows.length;
+        scan.page = page.nextPage;
+        if (scan.page === null) {
+          if (scan.kind === 'full') this.db.exec('DELETE FROM prototype_inventory');
+          this.db.exec(`INSERT INTO prototype_inventory SELECT * FROM prototype_stage WHERE true
+            ON CONFLICT(asset_id) DO UPDATE SET taken_at=excluded.taken_at,
+            updated_at=excluded.updated_at, eligible=excluded.eligible
+            WHERE excluded.updated_at > prototype_inventory.updated_at`);
+          state.ready = true; state.watermark = scan.maxUpdated;
+          state.lastScan = { kind: scan.kind, rows: scan.rows }; state.scan = null;
+          this.db.exec('DELETE FROM prototype_stage');
+        }
+        this.save(state);
+      });
+      pages++;
+    }
+    return { pages, complete: !this.state().scan };
+  }
+  candidates({ runKey, onlyUnenriched = true, maxFailures = 2, limit = 50, after = null }) {
+    if (!this.state().ready) throw Error('Inventory incomplete; no completeness claim is possible');
+    if (!Number.isInteger(limit) || limit < 1 || limit > 1000 || !Number.isInteger(maxFailures) || maxFailures < 0) throw Error('Invalid selection budget');
+    // Prototype-only mirror, checked against Repository.assetIdsNeedingWork.
+    // Production should share an eligibility builder with that repository API.
+    const match = runKey.inferenceId ? { sql: 'p.inference_id = ?', args: [runKey.inferenceId] }
+      : { sql: 'p.provider=? AND p.model=? AND p.prompt_version=? AND p.taxonomy_version=?',
+        args: [runKey.provider, runKey.model, runKey.promptVersion, runKey.taxonomyVersion] };
+    const success = onlyUnenriched ? '1=1' : match.sql;
+    const args = onlyUnenriched ? [] : [...match.args];
+    const failures = maxFailures ? `AND (SELECT COUNT(*) FROM ${this.historySchema}.processing_runs p
+      WHERE p.asset_id=i.asset_id AND p.status='failed' AND ${match.sql}) < ?` : '';
+    if (maxFailures) args.push(...match.args, maxFailures);
+    // ISO capture timestamps; null dates last, with deterministic ID ties.
+    const cursor = after ? `AND (COALESCE(i.taken_at,'') < ? OR (COALESCE(i.taken_at,'') = ? AND i.asset_id < ?))` : '';
+    if (after) args.push(after.taken_at ?? '', after.taken_at ?? '', after.asset_id);
+    return this.db.prepare(`SELECT i.* FROM prototype_inventory i
+      LEFT JOIN ${this.historySchema}.assets a ON a.asset_id=i.asset_id
+      WHERE i.eligible=1 AND a.enrich_discarded_at IS NULL
+      AND NOT EXISTS(SELECT 1 FROM ${this.historySchema}.processing_runs p WHERE p.asset_id=i.asset_id AND p.status='succeeded' AND ${success})
+      ${failures} ${cursor} ORDER BY i.taken_at DESC, i.asset_id DESC LIMIT ?`).all(...args, limit);
+  }
+  async run(source, options, { process, sendToCurate = false }) {
+    // Simulated dispatch contract only: no provider/scheduler integration.
+    const result = await this.select(source, options); let succeeded = 0, failed = 0, listed = 0;
+    for (const asset of result.selected) {
+      const outcome = await process(asset);
+      if (outcome === 'succeeded') {
+        succeeded++;
+        if (sendToCurate) listed += this.enrichRepo.reviewListAdd([asset.id], 'enrich');
+      } else failed++;
+    }
+    return { ...result, succeeded, failed, listed };
+  }
+  async select(source, options) {
+    const selected = []; let after = null, candidates = 0, validated = 0;
+    // Budget validation separately; rejecting candidates never consumes the AI budget.
+    const maxValidations = options.maxValidations ?? 1000;
+    while (selected.length < options.limit && validated < maxValidations) {
+      const rows = this.candidates({ ...options, after, limit: Math.min(100, maxValidations - validated) });
+      if (!rows.length) break;
+      for (const row of rows) {
+        after = row; candidates++; validated++;
+        const asset = await source.get(row.asset_id); // null means confirmed absent, errors propagate
+        if (asset && asset.id !== row.asset_id) throw Error('Upstream returned the wrong asset');
+        if (!asset || !isEligible(asset)) {
+          this.db.prepare('UPDATE prototype_inventory SET eligible=0 WHERE asset_id=?').run(row.asset_id);
+          continue;
+        }
+        selected.push(asset);
+        if (selected.length === options.limit || validated === maxValidations) break;
+      }
+    }
+    return { selected, candidates, validated, limited: validated === maxValidations && selected.length < options.limit };
+  }
+}
+export function isEligible(asset) {
+  return asset.type === 'IMAGE' && asset.visibility === 'timeline' && !asset.stackChild && !asset.deleted;
+}

--- a/src/enrich/discovery.mjs
+++ b/src/enrich/discovery.mjs
@@ -1,0 +1,215 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { setImmediate as yieldToLoop } from 'node:timers/promises';
+import { ImmichApiError } from '../immich.mjs';
+import { parseProgressingPage } from '../pagination.mjs';
+import { workEligibility } from './eligibility.mjs';
+
+export const DISCOVERY_SCHEMA = `
+CREATE TABLE IF NOT EXISTS enrich_inventory (
+  asset_id TEXT PRIMARY KEY, taken_at TEXT NOT NULL, updated_at INTEGER NOT NULL, eligible INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_enrich_inventory_selection ON enrich_inventory(eligible, taken_at DESC, asset_id DESC);
+CREATE TABLE IF NOT EXISTS enrich_inventory_stage (
+  asset_id TEXT PRIMARY KEY, taken_at TEXT NOT NULL, updated_at INTEGER NOT NULL, eligible INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS enrich_discovery (
+  id INTEGER PRIMARY KEY CHECK(id=1), source_key TEXT NOT NULL, state_json TEXT NOT NULL,
+  lease TEXT, lease_until INTEGER NOT NULL DEFAULT 0
+);`;
+
+const PAGE_SIZE = 1000;
+const RECONCILE_MS = 24 * 60 * 60 * 1000;
+const LEASE_MS = 5 * 60 * 1000;
+const MAX_PAGES = 2000;
+const MAX_REFRESH_MS = 10 * 60 * 1000;
+const MAX_VALIDATIONS = 10000;
+const REJECTION_BURST = 100;
+const VISIBILITIES = ['timeline', 'archive', 'hidden'];
+
+export class DiscoveryIncompleteError extends Error {
+  constructor() {
+    super('Library discovery is incomplete. Progress is saved. Run Enrich again to continue.');
+    this.name = 'DiscoveryIncompleteError';
+    this.code = 'enrich_discovery_incomplete';
+  }
+}
+
+function normalize(asset) {
+  const updated = typeof asset?.updatedAt === 'string' ? Date.parse(asset.updatedAt) : NaN;
+  const takenMs = asset?.fileCreatedAt == null ? null
+    : typeof asset.fileCreatedAt === 'string' ? Date.parse(asset.fileCreatedAt) : NaN;
+  if (typeof asset?.id !== 'string' || !asset.id || asset.id.length > 200 || !Number.isFinite(updated)
+      || (takenMs !== null && !Number.isFinite(takenMs))
+      || !['IMAGE', 'VIDEO', 'AUDIO', 'OTHER'].includes(asset.type)
+      || !['timeline', 'archive', 'hidden', 'locked'].includes(asset.visibility)
+      || typeof asset.isTrashed !== 'boolean') throw new Error('Immich returned incomplete discovery metadata.');
+  const taken = takenMs === null ? '' : new Date(takenMs).toISOString();
+  return { id: asset.id, taken, updated, eligible: asset.type === 'IMAGE' && asset.visibility === 'timeline' && !asset.isTrashed ? 1 : 0 };
+}
+
+// Owns only a rebuildable inventory. Never deletes processing history or human
+// decisions. The server's run slot is the primary owner; the durable lease also
+// prevents a second process from interleaving refresh transactions.
+export class EnrichDiscovery {
+  constructor(repo, immich, { shouldStop = () => false, log = () => {}, now = Date.now,
+    maxPages = MAX_PAGES, maxRefreshMs = MAX_REFRESH_MS, maxValidations = MAX_VALIDATIONS,
+    rejectionBurst = REJECTION_BURST } = {}) {
+    Object.assign(this, { repo, immich, shouldStop, log, now, maxPages, maxRefreshMs, maxValidations, rejectionBurst });
+    this.db = repo.db;
+    this.sourceKey = createHash('sha256').update(JSON.stringify([immich.baseUrl, immich.apiKey])).digest('hex');
+    this.lease = randomUUID(); this.owned = false;
+    this.after = null; this.buffer = []; this.seen = new Set(); this.reconciled = false;
+    this.diagnostics = { pages: 0, scanned: 0, candidates: 0, validated: 0, rejected: 0 };
+  }
+  state() { return JSON.parse(this.db.prepare('SELECT state_json FROM enrich_discovery WHERE id=1').get().state_json); }
+  save(state) {
+    const result = this.db.prepare('UPDATE enrich_discovery SET state_json=?, lease_until=? WHERE id=1 AND lease=? AND source_key=?')
+      .run(JSON.stringify(state), this.now() + LEASE_MS, this.lease, this.sourceKey);
+    if (!result.changes) throw new Error('Enrich discovery ownership changed; start the run again.');
+  }
+  acquire() {
+    this.repo.transaction(() => {
+      const row = this.db.prepare('SELECT * FROM enrich_discovery WHERE id=1').get();
+      if (row?.lease && row.lease_until > this.now()) throw new Error('Another library discovery is running; try again shortly.');
+      if (!row || row.source_key !== this.sourceKey) {
+        this.db.exec('DELETE FROM enrich_inventory; DELETE FROM enrich_inventory_stage; DELETE FROM enrich_discovery;');
+        this.db.prepare('INSERT INTO enrich_discovery(id,source_key,state_json) VALUES(1,?,?)')
+          .run(this.sourceKey, JSON.stringify({ ready: false, watermark: null, fullAt: null, scan: null }));
+      }
+      this.db.prepare('UPDATE enrich_discovery SET lease=?,lease_until=? WHERE id=1').run(this.lease, this.now() + LEASE_MS);
+    });
+    this.owned = true;
+    // A provider may take longer than the lease. Refresh while this run owns it;
+    // crashes stop this heartbeat, allowing a later process to resume.
+    this.heartbeat = setInterval(() => {
+      try { this.db.prepare('UPDATE enrich_discovery SET lease_until=? WHERE id=1 AND lease=?')
+        .run(this.now() + LEASE_MS, this.lease); } catch { /* next checkpoint verifies ownership */ }
+    }, 30000);
+    this.heartbeat.unref();
+  }
+  close() {
+    clearInterval(this.heartbeat);
+    if (this.owned) this.db.prepare('UPDATE enrich_discovery SET lease=NULL,lease_until=0 WHERE id=1 AND lease=?').run(this.lease);
+    this.owned = false;
+  }
+  begin(kind) {
+    const state = this.state();
+    state.scan = { kind, partition: 0, page: 1, maxUpdated: null,
+      // Strict progress avoids replaying an arbitrarily large equal-timestamp
+      // boundary on every run. Late same-millisecond updates are reconciled by
+      // the daily full pass; local time is NEVER an incremental watermark.
+      after: kind === 'delta' && state.watermark !== null ? state.watermark + 1 : null };
+    this.repo.transaction(() => { this.db.exec('DELETE FROM enrich_inventory_stage'); this.save(state); });
+  }
+  async prepare() {
+    this.acquire();
+    const state = this.state();
+    const resumed = !!state.scan;
+    if (!state.scan) this.begin(!state.ready || state.fullAt === null || this.now() - state.fullAt >= RECONCILE_MS ? 'full' : 'delta');
+    const full = this.state().scan.kind === 'full';
+    await this.refresh();
+    // A resumed pass may be old. Follow it with a new incremental pass so
+    // uploads arriving before its saved offset are not delayed another run.
+    if (!this.shouldStop() && (resumed || full)) { this.begin('delta'); await this.refresh(); }
+  }
+  async refresh() {
+    const started = this.now(); let pages = 0;
+    while (this.state().scan && !this.shouldStop()) {
+      if (pages >= this.maxPages || this.now() - started >= this.maxRefreshMs) throw new DiscoveryIncompleteError();
+      const state = this.state(), scan = state.scan;
+      const response = await this.immich.searchMetadata({ page: scan.page, size: PAGE_SIZE,
+        visibility: VISIBILITIES[scan.partition], ...(scan.kind === 'full' ? { type: 'IMAGE' } : { withDeleted: true }),
+        ...(scan.after === null ? {} : { updatedAfter: new Date(scan.after).toISOString() }),
+        order: 'desc', withExif: false });
+      if (this.shouldStop()) return;
+      const items = response?.assets?.items;
+      if (!Array.isArray(items) || items.length > PAGE_SIZE || !Object.hasOwn(response.assets, 'nextPage')) {
+        throw new Error('Immich returned an invalid discovery page.');
+      }
+      const next = parseProgressingPage(response.assets.nextPage, scan.page, { label: 'Immich discovery', maxPage: Number.MAX_SAFE_INTEGER });
+      if (next !== null && (!items.length || next !== scan.page + 1)) throw new Error('Immich returned an incomplete discovery page sequence.');
+      const rows = items.map(normalize);
+      this.repo.transaction(() => {
+        const insert = this.db.prepare(`INSERT INTO enrich_inventory_stage VALUES(?,?,?,?) ON CONFLICT(asset_id)
+          DO UPDATE SET taken_at=excluded.taken_at,updated_at=excluded.updated_at,eligible=excluded.eligible
+          WHERE excluded.updated_at >= enrich_inventory_stage.updated_at`);
+        for (const row of rows) {
+          insert.run(row.id, row.taken, row.updated, row.eligible);
+          scan.maxUpdated = Math.max(scan.maxUpdated ?? row.updated, row.updated);
+        }
+        if (next !== null) scan.page = next;
+        else if (scan.kind === 'delta' && scan.partition < VISIBILITIES.length - 1) { scan.partition++; scan.page = 1; }
+        else {
+          if (scan.kind === 'full') this.db.exec('DELETE FROM enrich_inventory');
+          this.db.exec(`INSERT INTO enrich_inventory SELECT * FROM enrich_inventory_stage WHERE true
+            ON CONFLICT(asset_id) DO UPDATE SET taken_at=excluded.taken_at,updated_at=excluded.updated_at,eligible=excluded.eligible
+            WHERE excluded.updated_at > enrich_inventory.updated_at`);
+          if (scan.kind === 'full') state.fullAt = this.now();
+          // Full scans contain only timeline images. Keep a later watermark
+          // already observed in another visibility partition, including when
+          // the entire timeline has since been emptied.
+          if (scan.maxUpdated !== null) state.watermark = Math.max(state.watermark ?? scan.maxUpdated, scan.maxUpdated);
+          state.ready = true; state.scan = null;
+          this.db.exec('DELETE FROM enrich_inventory_stage');
+        }
+        this.save(state);
+      });
+      pages++; this.diagnostics.pages++; this.diagnostics.scanned += rows.length;
+      if (pages === 1 || pages % 20 === 0) this.log(`Library discovery: ${this.diagnostics.scanned} metadata records scanned; progress saved.`);
+      await yieldToLoop();
+    }
+  }
+  candidates(options) {
+    const predicate = workEligibility(options);
+    const cursor = this.after ? 'AND (i.taken_at < ? OR (i.taken_at = ? AND i.asset_id < ?))' : '';
+    const params = this.after ? [this.after.taken_at, this.after.taken_at, this.after.asset_id] : [];
+    return this.db.prepare(`SELECT i.asset_id,i.taken_at FROM enrich_inventory i LEFT JOIN assets a ON a.asset_id=i.asset_id
+      WHERE i.eligible=1 AND ${predicate.sql} ${cursor} ORDER BY i.taken_at DESC,i.asset_id DESC LIMIT 100`)
+      .all(...predicate.params, ...params);
+  }
+  async next(options) {
+    let rejected = 0;
+    while (!this.shouldStop()) {
+      if (this.diagnostics.validated >= this.maxValidations) throw new DiscoveryIncompleteError();
+      if (!this.buffer.length) this.buffer = this.candidates(options);
+      const row = this.buffer.shift();
+      if (!row) return null;
+      this.after = row;
+      if (this.seen.has(row.asset_id)) continue;
+      this.seen.add(row.asset_id); this.diagnostics.candidates++;
+      let asset;
+      try { asset = await this.immich.getAsset(row.asset_id); }
+      catch (error) {
+        if (error instanceof ImmichApiError && (error.status === 404
+          || (error.status === 400 && /not found/i.test(error.message)))) asset = null;
+        else throw error;
+      }
+      if (this.shouldStop()) return null;
+      this.diagnostics.validated++;
+      const current = asset ? normalize(asset) : null;
+      if (current && current.id !== row.asset_id) throw new Error('Immich returned the wrong discovery asset.');
+      if (current?.eligible) {
+        this.save(this.state());
+        return asset;
+      }
+      this.repo.transaction(() => {
+        // Also verifies that a different process has not acquired the lease.
+        this.save(this.state());
+        this.db.prepare('UPDATE enrich_inventory SET eligible=0 WHERE asset_id=?').run(row.asset_id);
+        if (!current) this.repo.markAssetsMissing([row.asset_id]);
+      });
+      rejected++; this.diagnostics.rejected++;
+      if (rejected >= this.rejectionBurst && !this.reconciled) {
+        this.log('Library changed during discovery; refreshing the inventory before continuing.');
+        this.begin('full'); await this.refresh();
+        if (this.shouldStop()) return null;
+        this.reconciled = true; this.buffer = []; this.after = null;
+      }
+    }
+    return null;
+  }
+  summary() {
+    const d = this.diagnostics;
+    return `Library discovery: ${d.pages} metadata pages, ${d.scanned} scanned, ${d.candidates} candidates, ${d.validated} validated, ${d.rejected} rejected.`;
+  }
+}

--- a/src/enrich/discovery.mjs
+++ b/src/enrich/discovery.mjs
@@ -34,17 +34,22 @@ export class DiscoveryIncompleteError extends Error {
   }
 }
 
-function normalize(asset) {
+function normalize(asset, partition) {
   const updated = typeof asset?.updatedAt === 'string' ? Date.parse(asset.updatedAt) : NaN;
   const takenMs = asset?.fileCreatedAt == null ? null
     : typeof asset.fileCreatedAt === 'string' ? Date.parse(asset.fileCreatedAt) : NaN;
   if (typeof asset?.id !== 'string' || !asset.id || asset.id.length > 200 || !Number.isFinite(updated)
-      || (takenMs !== null && !Number.isFinite(takenMs))
-      || !['IMAGE', 'VIDEO', 'AUDIO', 'OTHER'].includes(asset.type)
-      || !['timeline', 'archive', 'hidden', 'locked'].includes(asset.visibility)
-      || typeof asset.isTrashed !== 'boolean') throw new Error('Immich returned incomplete discovery metadata.');
+      || (takenMs !== null && !Number.isFinite(takenMs))) throw new Error('Immich returned incomplete discovery metadata.');
+  // Search is explicitly partitioned. Only an absent visibility can inherit
+  // that filter; live getAsset validation never receives this fallback.
+  const inferredVisibility = asset.visibility == null && partition !== undefined;
+  const visibility = inferredVisibility ? partition : asset.visibility;
+  const uncertain = !['IMAGE', 'VIDEO', 'AUDIO', 'OTHER'].includes(asset.type)
+    || !['timeline', 'archive', 'hidden', 'locked'].includes(visibility)
+    || typeof asset.isTrashed !== 'boolean';
   const taken = takenMs === null ? '' : new Date(takenMs).toISOString();
-  return { id: asset.id, taken, updated, eligible: asset.type === 'IMAGE' && asset.visibility === 'timeline' && !asset.isTrashed ? 1 : 0 };
+  return { id: asset.id, taken, updated, uncertain, inferredVisibility,
+    eligible: !uncertain && asset.type === 'IMAGE' && visibility === 'timeline' && asset.isTrashed === false ? 1 : 0 };
 }
 
 // Owns only a rebuildable inventory. Never deletes processing history or human
@@ -52,14 +57,15 @@ function normalize(asset) {
 // prevents a second process from interleaving refresh transactions.
 export class EnrichDiscovery {
   constructor(repo, immich, { shouldStop = () => false, log = () => {}, now = Date.now,
+    monotonicNow = () => performance.now(),
     maxPages = MAX_PAGES, maxRefreshMs = MAX_REFRESH_MS, maxValidations = MAX_VALIDATIONS,
     rejectionBurst = REJECTION_BURST } = {}) {
-    Object.assign(this, { repo, immich, shouldStop, log, now, maxPages, maxRefreshMs, maxValidations, rejectionBurst });
+    Object.assign(this, { repo, immich, shouldStop, log, now, monotonicNow, maxPages, maxRefreshMs, maxValidations, rejectionBurst });
     this.db = repo.db;
     this.sourceKey = createHash('sha256').update(JSON.stringify([immich.baseUrl, immich.apiKey])).digest('hex');
     this.lease = randomUUID(); this.owned = false;
     this.after = null; this.buffer = []; this.seen = new Set(); this.reconciled = false;
-    this.diagnostics = { pages: 0, scanned: 0, candidates: 0, validated: 0, rejected: 0 };
+    this.diagnostics = { pages: 0, scanned: 0, candidates: 0, validated: 0, rejected: 0, refreshMs: 0 };
   }
   state() { return JSON.parse(this.db.prepare('SELECT state_json FROM enrich_discovery WHERE id=1').get().state_json); }
   save(state) {
@@ -113,7 +119,12 @@ export class EnrichDiscovery {
     if (!this.shouldStop() && (resumed || full)) { this.begin('delta'); await this.refresh(); }
   }
   async refresh() {
-    const started = this.now(); let pages = 0;
+    const started = this.monotonicNow();
+    try { await this.refreshPages(); }
+    finally { this.diagnostics.refreshMs += this.monotonicNow() - started; }
+  }
+  async refreshPages() {
+    const started = this.now(); let pages = 0, warnedMetadata = false;
     while (this.state().scan && !this.shouldStop()) {
       if (pages >= this.maxPages || this.now() - started >= this.maxRefreshMs) throw new DiscoveryIncompleteError();
       const state = this.state(), scan = state.scan;
@@ -128,7 +139,11 @@ export class EnrichDiscovery {
       }
       const next = parseProgressingPage(response.assets.nextPage, scan.page, { label: 'Immich discovery', maxPage: Number.MAX_SAFE_INTEGER });
       if (next !== null && (!items.length || next !== scan.page + 1)) throw new Error('Immich returned an incomplete discovery page sequence.');
-      const rows = items.map(normalize);
+      const rows = items.map(asset => normalize(asset, VISIBILITIES[scan.partition]));
+      if (!warnedMetadata && rows.some(row => row.uncertain || row.inferredVisibility)) {
+        this.log('Library discovery: incomplete eligibility metadata; missing visibility uses the search partition, and uncertain photos are excluded.');
+        warnedMetadata = true;
+      }
       this.repo.transaction(() => {
         const insert = this.db.prepare(`INSERT INTO enrich_inventory_stage VALUES(?,?,?,?) ON CONFLICT(asset_id)
           DO UPDATE SET taken_at=excluded.taken_at,updated_at=excluded.updated_at,eligible=excluded.eligible
@@ -188,6 +203,10 @@ export class EnrichDiscovery {
       this.diagnostics.validated++;
       const current = asset ? normalize(asset) : null;
       if (current && current.id !== row.asset_id) throw new Error('Immich returned the wrong discovery asset.');
+      if (current?.uncertain && !this.warnedValidationMetadata) {
+        this.log('Library discovery: excluding photos with uncertain eligibility during live validation.');
+        this.warnedValidationMetadata = true;
+      }
       if (current?.eligible) {
         this.save(this.state());
         return asset;
@@ -210,6 +229,6 @@ export class EnrichDiscovery {
   }
   summary() {
     const d = this.diagnostics;
-    return `Library discovery: ${d.pages} metadata pages, ${d.scanned} scanned, ${d.candidates} candidates, ${d.validated} validated, ${d.rejected} rejected.`;
+    return `Library discovery: ${d.pages} metadata pages, ${d.scanned} scanned, ${d.candidates} candidates, ${d.validated} validated, ${d.rejected} rejected. Metadata refresh time: ${(d.refreshMs / 1000).toFixed(1)} s.`;
   }
 }

--- a/src/enrich/eligibility.mjs
+++ b/src/enrich/eligibility.mjs
@@ -1,0 +1,28 @@
+// Identity and eligibility shared by targeted selection and library discovery.
+// Modern inference IDs never match NULL legacy identity; label matching is
+// reserved for historical queries and imports.
+export function matchingRun(runKey, prefix = '') {
+  if (runKey.inferenceId) return { sql: `${prefix}inference_id = ?`, params: [runKey.inferenceId] };
+  return {
+    sql: `${prefix}provider = ? AND ${prefix}model = ? AND ${prefix}prompt_version = ? AND ${prefix}taxonomy_version = ?`,
+    params: [runKey.provider, runKey.model, runKey.promptVersion, runKey.taxonomyVersion],
+  };
+}
+
+// Callers join candidate alias i(asset_id) to assets alias a.
+export function workEligibility({ runKey, skipAnySuccessful = true, reprocess = false, maxFailuresPerAsset = 0 }) {
+  const match = matchingRun(runKey, 'p.');
+  const parts = ['a.enrich_discarded_at IS NULL'];
+  const params = [];
+  if (skipAnySuccessful || !reprocess) {
+    parts.push(`NOT EXISTS (SELECT 1 FROM processing_runs p WHERE p.asset_id=i.asset_id
+      AND p.status='succeeded'${skipAnySuccessful ? '' : ` AND ${match.sql}`})`);
+    if (!skipAnySuccessful) params.push(...match.params);
+  }
+  if (!reprocess && maxFailuresPerAsset > 0) {
+    parts.push(`(SELECT COUNT(*) FROM processing_runs p WHERE p.asset_id=i.asset_id
+      AND p.status='failed' AND ${match.sql}) < ?`);
+    params.push(...match.params, maxFailuresPerAsset);
+  }
+  return { sql: parts.join(' AND '), params };
+}

--- a/src/enrich/jobRunner.mjs
+++ b/src/enrich/jobRunner.mjs
@@ -541,7 +541,7 @@ export class EnrichJobRunner {
         return;
       }
       // "Send results to Curate": photos join the review list as they are
-      // enriched (or were already enriched) during the run — never on
+      // enriched during the run (or explicitly targeted with existing results) — never on
       // failure, so Curate holds no un-enriched mystery rows. Failed photos
       // stay with the queue item and re-enter when a later run enriches
       // them. Decided photos stay decided — membership never resets

--- a/src/enrich/repository.mjs
+++ b/src/enrich/repository.mjs
@@ -8,6 +8,8 @@ import { preparePrivateDatabasePath, restrictPrivateDatabaseModes } from '../pri
 import { sanitizeDiagnostic } from '../diagnostics.mjs';
 import { validateAssetBatch } from './assetBatch.mjs';
 import { EnrichTimingStore, TIMING_SCHEMA } from './timing.mjs';
+import { DISCOVERY_SCHEMA } from './discovery.mjs';
+import { matchingRun, workEligibility } from './eligibility.mjs';
 import { ACTION_RULES } from './reviewActions.mjs';
 import { canonicalJson, MAX_RUN_CONFIGURATION_BYTES } from './runConfiguration.mjs';
 
@@ -505,6 +507,7 @@ const ENRICH_MIGRATIONS = [
       db.exec('CREATE INDEX IF NOT EXISTS idx_job_runs_timing ON job_runs(timing_run_id)');
     },
   },
+  { version: 11, up(db) { db.exec(DISCOVERY_SCHEMA); } },
 ];
 
 // The review projection of a normalized output: exactly the fields the
@@ -600,7 +603,7 @@ export class Repository {
   }
 
   initSchema() {
-    const schemaSql = readFileSync(SCHEMA_PATH, 'utf8') + TIMING_SCHEMA;
+    const schemaSql = readFileSync(SCHEMA_PATH, 'utf8') + TIMING_SCHEMA + DISCOVERY_SCHEMA;
     const result = migrateDatabase(this.db, {
       schema: schemaSql,
       migrations: ENRICH_MIGRATIONS,
@@ -900,11 +903,15 @@ export class Repository {
   // successful, matching the runner's check order.
   assetIdsNeedingWork(assetIds, { runKey, skipAnySuccessful = true, maxFailuresPerAsset = 0 }) {
     const match = matchingRun(runKey);
-    const needy = new Set(assetIds.filter((id) => typeof id === 'string' && id));
+    const needy = new Set();
+    const eligibility = workEligibility({ runKey, skipAnySuccessful, maxFailuresPerAsset });
     const successful = new Set();
     const failureLimited = new Set();
     const discarded = new Set();
     for (const chunk of idChunks(assetIds)) {
+      for (const row of this.db.prepare(`WITH candidates AS (SELECT value AS asset_id FROM json_each(?))
+        SELECT i.asset_id FROM candidates i LEFT JOIN assets a ON a.asset_id=i.asset_id
+        WHERE ${eligibility.sql}`).all(JSON.stringify(chunk), ...eligibility.params)) needy.add(row.asset_id);
       const marks = chunk.map(() => '?').join(', ');
       // Human-discarded photos are dropped first and never run, but a
       // successful classification still wins below, matching the runner's
@@ -2644,17 +2651,4 @@ function sortKeysDeep(value) {
     );
   }
   return value;
-}
-
-// Modern executions always supply a content identity, so NULL legacy rows
-// never match them. The label path supports historical repository queries
-// and import tooling; it does not invent identity for old records.
-function matchingRun(runKey, prefix = '') {
-  if (runKey.inferenceId) {
-    return { sql: `${prefix}inference_id = ?`, params: [runKey.inferenceId] };
-  }
-  return {
-    sql: `${prefix}provider = ? AND ${prefix}model = ? AND ${prefix}prompt_version = ? AND ${prefix}taxonomy_version = ?`,
-    params: [runKey.provider, runKey.model, runKey.promptVersion, runKey.taxonomyVersion],
-  };
 }

--- a/src/enrich/runner.mjs
+++ b/src/enrich/runner.mjs
@@ -1,4 +1,5 @@
 import { timingErrorKind } from './timing.mjs';
+import { EnrichDiscovery } from './discovery.mjs';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
@@ -6,7 +7,7 @@ import { OutputValidationError, validateAiOutput } from './schema.mjs';
 import { captureClient, captureRunConfiguration } from './runConfiguration.mjs';
 export { buildUserPrompt } from './runConfiguration.mjs';
 import { mapOutputToTags } from './mapTags.mjs';
-import { ImmichApiError, tagId, tagValue } from '../immich.mjs';
+import { ImmichClient, ImmichApiError, tagId, tagValue } from '../immich.mjs';
 import { configuredSecrets, sanitizeDiagnostic } from '../diagnostics.mjs';
 import { createTraversalBudget } from '../pagination.mjs';
 
@@ -175,13 +176,17 @@ export async function analyzeWithValidationRetry(provider, image, {
 }
 
 export async function runBatch(options) {
-  const timingSession = { id: options.timingRunId ?? null };
+  const timingSession = { id: options.timingRunId ?? null, discovery: null };
   let outcome = 'failed';
   try {
     const result = await executeBatch({ ...options, timingSession });
     outcome = options.shouldStop?.() || options.signal?.aborted ? 'cancelled' : 'finished';
     return result;
   } finally {
+    if (timingSession.discovery) {
+      options.log?.(timingSession.discovery.summary());
+      timingSession.discovery.close();
+    }
     if (timingSession.id !== null && options.timingRunId == null) {
       options.repo.timings.finishRun(timingSession.id, outcome);
     }
@@ -259,6 +264,14 @@ async function executeBatch({
     timingSession.id ??= repo.timings?.startRun(configuration) ?? null;
   }
 
+  // A budgeted whole-library sweep uses a durable inventory. Explicit offsets,
+  // metadata-only CLI scans, and custom list-only adapters retain their bounded
+  // window semantics; targeted queue/retry runs keep their existing path.
+  const discovery = !assetIds && !skipAi && offset === 0 && maxAnalyzed !== null && immich instanceof ImmichClient
+    ? new EnrichDiscovery(repo, immich, { shouldStop, log, maxValidations: Math.max(10000, maxAnalyzed + 1000) }) : null;
+  timingSession.discovery = discovery;
+  if (discovery) await discovery.prepare();
+
   // Only Immich traversal time belongs to this deadline. Provider inference
   // can legitimately take minutes per photo and must not make the next
   // otherwise-healthy metadata window look like a stalled traversal.
@@ -282,7 +295,10 @@ async function executeBatch({
 
   const fetchWindow = async (windowOffset) => {
     let fetched;
-    if (assetIds) {
+    if (discovery) {
+      const asset = await discovery.next({ runKey: configuration.runKey, skipAnySuccessful, reprocess, maxFailuresPerAsset });
+      fetched = asset ? [asset] : [];
+    } else if (assetIds) {
       const targeted = await fetchAssetsChunked(immich, assetIds, {
         shouldStop,
         traversal,
@@ -351,7 +367,7 @@ async function executeBatch({
   };
 
   while (true) {
-    const scanTotal = scanned + assets.length;
+    const scanTotal = discovery ? maxAnalyzed : scanned + assets.length;
     for (const [index, asset] of assets.entries()) {
       if (shouldStop()) {
         log('stopping early: cancellation requested');
@@ -364,14 +380,14 @@ async function executeBatch({
       if (skipAnySuccessful && repo.hasAnySuccessfulRun(assetId)) {
         counters.skippedSuccessful += 1;
         recordSkip('already_succeeded');
-        // Already enriched, so it belongs in Curate just like a fresh success.
-        if (listForReview) listedForReview += repo.reviewListAdd([assetId], 'enrich');
+        // Explicit targeted selections may still send existing results to Curate.
+        if (assetIds && listForReview) listedForReview += repo.reviewListAdd([assetId], 'enrich');
         continue;
       }
       if (!reprocess && repo.hasSuccessfulRun({ assetId, ...runKey })) {
         counters.skippedSuccessful += 1;
         recordSkip('already_succeeded');
-        if (listForReview) listedForReview += repo.reviewListAdd([assetId], 'enrich');
+        if (assetIds && listForReview) listedForReview += repo.reviewListAdd([assetId], 'enrich');
         continue;
       }
       // A human discard is unconditional — it holds even for retry runs
@@ -551,7 +567,7 @@ async function executeBatch({
     if (stopped || window.stopped || assetIds || maxAnalyzed === null || analyzed >= maxAnalyzed) {
       break;
     }
-    if (window.fetchedCount < limit) {
+    if (!discovery && window.fetchedCount < limit) {
       log(`no more assets to scan; analyzed ${analyzed} of ${maxAnalyzed} requested`);
       break;
     }
@@ -565,7 +581,7 @@ async function executeBatch({
   }
 
   if (!stopped && !window.stopped && analyzed === 0 && !counters.skippedFailureLimit && !counters.skippedDiscarded) {
-    log('No photos needed enrichment in the scanned selection.');
+    log(discovery ? 'No eligible photos found in the current inventory; periodic reconciliation checks for changes.' : 'No photos needed enrichment in the scanned selection.');
   }
 
   if (applyTags && !dryRun) {

--- a/src/upgradeSafety.mjs
+++ b/src/upgradeSafety.mjs
@@ -4,7 +4,7 @@ import { backupTargets, readSnapshotStatus, runBackup } from './backup.mjs';
 
 // Bump only when a release changes a persisted contract and therefore needs
 // a pre-migration recovery point. Ordinary server releases keep this value.
-export const PERSISTENT_STATE_VERSION = 12;
+export const PERSISTENT_STATE_VERSION = 13;
 
 export class UpgradeSafetyError extends Error {
   constructor(message, { code = 'upgrade_safety_error' } = {}) {

--- a/test/enrich/discovery.test.mjs
+++ b/test/enrich/discovery.test.mjs
@@ -125,6 +125,77 @@ test('a changed inference reuses the inventory but Only unenriched still prevent
   assert.equal(h.calls.downloads.length, 2);
 });
 
+test('uncertain eligibility across metadata pages is excluded without blocking valid work or repeating warnings per photo', async t => {
+  const rows = Array.from({ length: 1501 }, (_, n) => photo(n)); const h = fixture(t, rows);
+  const patches = [{ type: 'FUTURE' }, { type: null }, { visibility: 'future' }, { visibility: '' },
+    { isTrashed: 'false' }, { isTrashed: null }, { isTrashed: 0 }];
+  h.hooks.search = body => {
+    if (body.updatedAfter) return;
+    const items = rows.slice((body.page - 1) * body.size, body.page * body.size)
+      .map(row => row.id === rows[1500].id ? row : { ...row, ...patches[Number(row.id.slice(6)) % patches.length] });
+    return Response.json({ assets: { items, nextPage: body.page === 1 ? '2' : null } });
+  };
+  const log = []; const result = await runBatch({ ...h.options, log: m => log.push(m) });
+  assert.equal(result.counters.succeeded, 1);
+  assert.deepEqual(h.calls.gets, [rows[1500].id]); assert.deepEqual(h.calls.downloads, [rows[1500].id]);
+  assert.equal(log.filter(m => m.includes('incomplete eligibility metadata')).length, 1);
+  assert.equal(h.repo.db.prepare('SELECT COUNT(*) n FROM enrich_inventory WHERE eligible=0').get().n, 1500);
+  assert.equal((await runBatch(h.options)).counters.analyzed, 0);
+  // A later source correction makes a quarantined row eligible again.
+  h.change(rows[0].id, { updatedAt: '2026-02-01T00:00:00.000Z' });
+  assert.equal((await runBatch(h.options)).counters.succeeded, 1);
+  assert.deepEqual(h.calls.downloads, [rows[1500].id, rows[0].id]);
+});
+
+test('missing search visibility inherits only its partition; live validation must independently confirm eligibility', async t => {
+  const h = fixture(t, [photo(0), photo(1), photo(2)]);
+  h.hooks.search = body => Response.json({ assets: {
+    items: body.updatedAfter ? (body.visibility === 'timeline' ? []
+      : [photo(body.visibility === 'archive' ? 10 : 11, { visibility: undefined })])
+      : [photo(0, { visibility: undefined }), photo(1, { visibility: undefined }), photo(2, { visibility: undefined })],
+    nextPage: null,
+  } });
+  h.hooks.get = id => id === photo(1).id ? Response.json(photo(1, { visibility: undefined }))
+    : id === photo(2).id ? Response.json(photo(2, { isTrashed: 'false' })) : undefined;
+  const log = []; const result = await runBatch({ ...h.options, log: m => log.push(m) });
+  assert.equal(result.counters.succeeded, 1);
+  assert.deepEqual(h.calls.gets, [photo(0).id, photo(1).id, photo(2).id]);
+  assert.deepEqual(h.calls.downloads, [photo(0).id]);
+  assert.equal(h.repo.db.prepare('SELECT eligible FROM enrich_inventory WHERE asset_id=?').get(photo(10).id).eligible, 0);
+  assert.equal(h.repo.db.prepare('SELECT eligible FROM enrich_inventory WHERE asset_id=?').get(photo(11).id).eligible, 0);
+  assert.equal(log.filter(m => m.includes('uncertain eligibility during live validation')).length, 1);
+});
+
+test('missing row identity or update timestamp still stops at the unpublished checkpoint', async t => {
+  for (const patch of [{ id: undefined }, { updatedAt: undefined }, { updatedAt: 'invalid' }]) {
+    const h = fixture(t, [photo(0)]);
+    h.hooks.search = () => Response.json({ assets: { items: [photo(0, patch)], nextPage: null } });
+    const d = new EnrichDiscovery(h.repo, h.immich);
+    try {
+      await assert.rejects(d.prepare(), /incomplete discovery metadata/);
+      assert.equal(d.state().ready, false); assert.equal(d.state().scan.page, 1);
+      assert.equal(d.state().watermark, null);
+      assert.equal(h.repo.db.prepare('SELECT COUNT(*) n FROM enrich_inventory_stage').get().n, 0);
+    } finally { d.close(); }
+  }
+});
+
+test('metadata refresh timing includes interrupted refreshes and excludes time between discovery calls', async t => {
+  const h = fixture(t, [photo(0)]); let clock = 0;
+  h.hooks.search = () => { clock += 250; };
+  const d = new EnrichDiscovery(h.repo, h.immich, { monotonicNow: () => clock });
+  try {
+    await d.prepare(); assert.equal(d.diagnostics.refreshMs, 1000); // full + three partitions
+    clock += 60000; // provider/other run work does not count as metadata refresh
+    assert.equal((await d.next({ runKey: h.runKey })).id, photo(0).id);
+    assert.match(d.summary(), /Metadata refresh time: 1\.0 s/);
+    d.begin('delta');
+    h.hooks.search = () => { clock += 500; return Response.json({ assets: { items: null, nextPage: null } }); };
+    await assert.rejects(d.refresh(), /invalid discovery page/);
+    assert.equal(d.diagnostics.refreshMs, 1500);
+  } finally { d.close(); }
+});
+
 test('permanent cleanup triggers bounded full catch-up within this run, rather than empty daily attempts', async t => {
   const rows = Array.from({ length: 6050 }, (_, n) => photo(n)); const h = fixture(t, rows);
   const d = new EnrichDiscovery(h.repo, h.immich); await d.prepare(); d.close();

--- a/test/enrich/discovery.test.mjs
+++ b/test/enrich/discovery.test.mjs
@@ -1,0 +1,240 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createServer } from 'node:http';
+import { Repository } from '../../src/enrich/repository.mjs';
+import { ImmichClient } from '../../src/immich.mjs';
+import { EnrichDiscovery, DiscoveryIncompleteError } from '../../src/enrich/discovery.mjs';
+import { runBatch } from '../../src/enrich/runner.mjs';
+import { captureRunConfiguration } from '../../src/enrich/runConfiguration.mjs';
+import { EnrichJobRunner } from '../../src/enrich/jobRunner.mjs';
+import { EnrichScheduler } from '../../src/enrich/scheduler.mjs';
+import { loadV1Taxonomy, sampleOutput, REPO_ROOT } from './helpers.mjs';
+
+function photo(n, changes = {}) {
+  return { id: `photo-${String(n).padStart(7, '0')}`, type: 'IMAGE', visibility: 'timeline', isTrashed: false,
+    fileCreatedAt: new Date(Date.UTC(2020, 0, 1) - n * 1000).toISOString(),
+    updatedAt: '2026-01-01T00:00:00.000Z', originalFileName: `${n}.jpg`, ...changes };
+}
+function fixture(t, rows) {
+  const dir = mkdtempSync(join(tmpdir(), 'pictaria-discovery-')), path = join(dir, 'enrich.sqlite');
+  let repo = new Repository(path); repo.initSchema();
+  const data = new Map(rows.map(r => [r.id, { ...r }])); let cache = new Map();
+  const calls = { pages: [], gets: [], downloads: [] };
+  const hooks = {};
+  const immich = new ImmichClient({ baseUrl: 'http://fixture.invalid/api', apiKey: 'synthetic-key', fetchImpl: async (input, init) => {
+    const url = new URL(input);
+    if (url.pathname.endsWith('/search/metadata')) {
+      const body = JSON.parse(init.body); calls.pages.push(body);
+      const override = await hooks.search?.(body); if (override) return override;
+      // Models the v2 default as well: no visibility means timeline, never broad.
+      const visibility = body.visibility ?? 'timeline';
+      const cacheKey = JSON.stringify([visibility, body.updatedAfter, body.type, body.withDeleted]);
+      if (!cache.has(cacheKey)) cache.set(cacheKey, [...data.values()].filter(r => r.visibility === visibility
+        && (!body.type || r.type === body.type) && (body.withDeleted || !r.isTrashed)
+        && (!body.updatedAfter || Date.parse(r.updatedAt) >= Date.parse(body.updatedAfter)))
+        .sort((a, b) => (b.fileCreatedAt ?? '').localeCompare(a.fileCreatedAt ?? '') || b.id.localeCompare(a.id)));
+      const found = cache.get(cacheKey);
+      return Response.json({ assets: { items: found.slice((body.page - 1) * body.size, body.page * body.size),
+        nextPage: body.page * body.size < found.length ? String(body.page + 1) : null } });
+    }
+    const id = decodeURIComponent(url.pathname.split('/')[3]);
+    if (url.pathname.endsWith('/thumbnail')) {
+      calls.downloads.push(id); return new Response('image', { headers: { 'content-type': 'image/jpeg' } });
+    }
+    calls.gets.push(id);
+    const override = await hooks.get?.(id); if (override) return override;
+    return data.has(id) ? Response.json(data.get(id)) : Response.json({ message: 'not found' }, { status: 404 });
+  } });
+  const provider = { providerName: 'cloud_openai', modelName: 'fixture', calls: [], async analyzeImage(image) {
+    this.calls.push(image.assetId); return { normalizedOutput: sampleOutput() };
+  } };
+  const options = { repo, immich, provider, taxonomy: loadV1Taxonomy(), systemPrompt: 'fixture',
+    userTemplate: '{approved_tags}', skipAnySuccessful: true, maxAnalyzed: 50, limit: 1000, listForReview: true };
+  const configuration = captureRunConfiguration(options); repo.saveRunConfiguration(configuration);
+  const runKey = configuration.runKey;
+  t.after(() => { repo.close(); rmSync(dir, { recursive: true, force: true }); });
+  return { get repo() { return repo; }, options, immich, calls, provider, hooks, runKey,
+    change(id, patch) { Object.assign(data.get(id), patch); cache.clear(); },
+    add(row) { data.set(row.id, row); cache.clear(); },
+    remove(id) { data.delete(id); cache.clear(); },
+    reopen() { repo.close(); repo = new Repository(path); repo.initSchema(); options.repo = repo; return repo; },
+    seed(rows, status = 'succeeded', key = runKey) {
+      repo.transaction(() => { for (const row of rows) {
+        repo.upsertAsset(row); repo.recordProcessingRun({ assetId: row.id, ...key, status });
+      } });
+    }, dir };
+}
+
+test('real budgeted runner finds 50 behind a 100k prefix; warm sweeps query only changes and never resend success', async t => {
+  const rows = Array.from({ length: 100050 }, (_, n) => photo(n)); const h = fixture(t, rows);
+  h.seed(rows.slice(0, 100000)); const log = [];
+  const result = await runBatch({ ...h.options, log: m => log.push(m) });
+  assert.equal(result.counters.succeeded, 50); assert.equal(result.counters.skippedSuccessful, 0);
+  assert.equal(h.calls.gets.length, 50); assert.equal(h.calls.downloads.length, 50);
+  assert.equal(h.repo.reviewListRows().length, 50); // historical successes are not swept into Curate
+  assert.equal(h.calls.pages.length, 104); // 101 full pages plus three delta partitions
+  assert.match(log.join('\n'), /50 candidates, 50 validated, 0 rejected/);
+  h.calls.pages.length = 0; h.calls.gets.length = 0;
+  const repeat = await runBatch(h.options);
+  assert.equal(repeat.counters.analyzed, 0); assert.equal(h.calls.pages.length, 3); assert.equal(h.calls.gets.length, 0);
+  assert.ok(h.calls.pages.every(p => p.updatedAfter === '2026-01-01T00:00:00.001Z'));
+});
+
+test('checkpoint survives a bounded incomplete run, backup and reopen; cancellation cannot publish a late page', async t => {
+  const h = fixture(t, Array.from({ length: 2001 }, (_, n) => photo(n)));
+  const d = new EnrichDiscovery(h.repo, h.immich, { maxPages: 1 });
+  await assert.rejects(d.prepare(), DiscoveryIncompleteError);
+  assert.equal(d.state().ready, false); assert.equal(d.state().scan.page, 2); d.close();
+  const backup = join(h.dir, 'backup.sqlite'); h.repo.backupTo(backup);
+  const restored = new Repository(backup); restored.initSchema();
+  const copy = new EnrichDiscovery(restored, h.immich); await copy.prepare();
+  assert.equal(copy.state().ready, true); assert.equal(copy.db.prepare('SELECT COUNT(*) n FROM enrich_inventory').get().n, 2001);
+  copy.close(); restored.close();
+  let stop = false;
+  const resumed = new EnrichDiscovery(h.reopen(), h.immich, { shouldStop: () => stop });
+  h.hooks.search = () => { stop = true; };
+  await resumed.prepare(); assert.equal(resumed.state().scan.page, 2); assert.equal(resumed.state().ready, false); resumed.close();
+  delete h.hooks.search;
+  const complete = new EnrichDiscovery(h.repo, h.immich); await complete.prepare();
+  assert.equal(complete.state().ready, true); complete.close();
+});
+
+test('broad partitions invalidate hidden/archive/trash and old-capture uploads appear promptly', async t => {
+  const rows = Array.from({ length: 5 }, (_, n) => photo(n)); const h = fixture(t, rows);
+  const d = new EnrichDiscovery(h.repo, h.immich); await d.prepare(); d.close();
+  const updatedAt = '2026-02-01T00:00:00.000Z';
+  h.change(rows[0].id, { visibility: 'hidden', updatedAt }); h.change(rows[1].id, { visibility: 'archive', updatedAt });
+  h.change(rows[2].id, { isTrashed: true, updatedAt });
+  h.add(photo(20, { updatedAt, fileCreatedAt: '1990-01-01T00:00:00.000Z' }));
+  const next = new EnrichDiscovery(h.repo, h.immich); await next.prepare();
+  const ids = next.candidates({ runKey: h.runKey }).map(r => r.asset_id);
+  assert.deepEqual(ids, [rows[3].id, rows[4].id, photo(20).id]); next.close();
+  await runBatch(h.options); assert.deepEqual(h.calls.gets, ids);
+});
+
+test('a changed inference reuses the inventory but Only unenriched still prevents paid reprocessing', async t => {
+  const h = fixture(t, [photo(0)]);
+  assert.equal((await runBatch(h.options)).counters.succeeded, 1);
+  h.provider.modelName = 'another-model';
+  assert.equal((await runBatch(h.options)).counters.analyzed, 0);
+  assert.equal((await runBatch({ ...h.options, skipAnySuccessful: false })).counters.succeeded, 1);
+  assert.equal((await runBatch({ ...h.options, skipAnySuccessful: false })).counters.analyzed, 0);
+  assert.equal(h.calls.downloads.length, 2);
+});
+
+test('permanent cleanup triggers bounded full catch-up within this run, rather than empty daily attempts', async t => {
+  const rows = Array.from({ length: 6050 }, (_, n) => photo(n)); const h = fixture(t, rows);
+  const d = new EnrichDiscovery(h.repo, h.immich); await d.prepare(); d.close();
+  for (const row of rows.slice(0, 6000)) h.remove(row.id);
+  const log = []; const result = await runBatch({ ...h.options, log: m => log.push(m) });
+  assert.equal(result.counters.succeeded, 50); assert.equal(h.calls.gets.length, 150);
+  assert.match(log.join('\n'), /refreshing the inventory/);
+  assert.match(log.join('\n'), /150 candidates, 150 validated, 100 rejected/);
+});
+
+test('eligibility SQL matches queue rules for configuration changes, infra/content failures and human discard', async t => {
+  const rows = Array.from({ length: 250 }, (_, n) => photo(n)); const h = fixture(t, rows);
+  h.seed(rows.slice(0, 50)); h.seed(rows.slice(50, 100), 'failed'); h.seed(rows.slice(50, 100), 'failed');
+  h.seed(rows.slice(100, 150), 'failed_infra');
+  h.repo.upsertAsset(rows[150]); h.repo.db.prepare('UPDATE assets SET enrich_discarded_at=? WHERE asset_id=?').run('2026-01-01', rows[150].id);
+  const d = new EnrichDiscovery(h.repo, h.immich); await d.prepare();
+  for (const runKey of [h.runKey, { ...h.runKey, inferenceId: 'b'.repeat(64) }, { ...h.runKey, inferenceId: null }]) {
+    for (const skipAnySuccessful of [true, false]) {
+      const opts = { runKey, skipAnySuccessful, maxFailuresPerAsset: 2 };
+      const expected = h.repo.assetIdsNeedingWork(rows.map(r => r.id), opts).needy;
+      assert.deepEqual(d.candidates(opts).map(r => r.asset_id), rows.filter(r => expected.has(r.id)).slice(0, 100).map(r => r.id));
+    }
+  }
+  d.close();
+});
+
+test('outages and malformed pages preserve inventory; a second owner cannot interleave; credential changes reset only inventory', async t => {
+  const h = fixture(t, [photo(0), photo(1)]); h.seed([photo(0)]);
+  const d = new EnrichDiscovery(h.repo, h.immich); await d.prepare();
+  const other = new EnrichDiscovery(h.repo, h.immich);
+  await assert.rejects(other.prepare(), /Another library discovery/);
+  const before = d.state(); d.close();
+  h.hooks.search = () => Response.json({ assets: { items: [{ id: 'broken' }], nextPage: null } });
+  const bad = new EnrichDiscovery(h.repo, h.immich);
+  await assert.rejects(bad.prepare(), /incomplete discovery metadata/);
+  assert.equal(bad.state().watermark, before.watermark); assert.equal(bad.state().ready, true); bad.close();
+  h.hooks.search = () => Response.json({ message: 'offline' }, { status: 503 });
+  const offline = new EnrichDiscovery(h.repo, h.immich); await assert.rejects(offline.prepare(), e => e.status === 503); offline.close();
+  delete h.hooks.search; h.immich.apiKey = 'different-synthetic-key'; h.remove(photo(1).id);
+  const changed = new EnrichDiscovery(h.repo, h.immich); await changed.prepare();
+  assert.equal(changed.db.prepare('SELECT COUNT(*) n FROM enrich_inventory').get().n, 1);
+  assert.equal(h.repo.hasAnySuccessfulRun(photo(0).id), true); changed.close();
+});
+
+test('late equal-timestamp arrivals and silent access changes reconcile after 24 hours without replaying the timestamp boundary', async t => {
+  const h = fixture(t, [photo(0)]); let now = 100000;
+  const make = () => new EnrichDiscovery(h.repo, h.immich, { now: () => now });
+  let d = make(); await d.prepare(); d.close(); h.add(photo(1));
+  d = make(); await d.prepare(); assert.equal(d.candidates({ runKey: h.runKey }).length, 1); d.close();
+  now += 24 * 60 * 60 * 1000;
+  d = make(); await d.prepare(); assert.equal(d.candidates({ runKey: h.runKey }).length, 2); d.close();
+});
+
+test('empty full reconciliation retains the completed broad watermark instead of repeatedly scanning hidden history', async t => {
+  const h = fixture(t, [photo(0)]); let now = 100000;
+  const make = () => new EnrichDiscovery(h.repo, h.immich, { now: () => now });
+  let d = make(); await d.prepare(); d.close();
+  const updatedAt = '2026-02-01T00:00:00.000Z'; h.change(photo(0).id, { visibility: 'hidden', updatedAt });
+  d = make(); await d.prepare(); d.close(); now += 24 * 60 * 60 * 1000;
+  h.calls.pages.length = 0;
+  d = make(); await d.prepare();
+  assert.equal(d.state().watermark, Date.parse(updatedAt));
+  assert.equal(d.db.prepare('SELECT COUNT(*) n FROM enrich_inventory').get().n, 0);
+  assert.equal(h.calls.pages.length, 4);
+  assert.ok(h.calls.pages.slice(1).every(p => p.updatedAfter === '2026-02-01T00:00:00.001Z'));
+  d.close();
+});
+
+test('validation exhaustion is explicitly incomplete and permission errors never become confirmed missing', async t => {
+  const h = fixture(t, [photo(0), photo(1)]);
+  const d = new EnrichDiscovery(h.repo, h.immich, { maxValidations: 1, rejectionBurst: 5 }); await d.prepare();
+  h.remove(photo(0).id);
+  await assert.rejects(d.next({ runKey: h.runKey }), DiscoveryIncompleteError); d.close();
+  h.hooks.get = () => Response.json({ message: 'forbidden' }, { status: 403 });
+  const denied = new EnrichDiscovery(h.repo, h.immich); await denied.prepare();
+  await assert.rejects(denied.next({ runKey: h.runKey }), e => e.status === 403);
+  assert.equal(denied.db.prepare('SELECT eligible FROM enrich_inventory WHERE asset_id=?').get(photo(1).id).eligible, 1);
+  denied.close();
+});
+
+test('Daily Enrich uses inventory discovery and manual discovery failures are visible in run history', async t => {
+  const h = fixture(t, [photo(0), photo(1)]);
+  const providerServer = createServer((req, res) => {
+    req.resume();
+    req.on('end', () => { res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({ choices: [{ message: { content: JSON.stringify(sampleOutput()) } }] })); });
+  });
+  await new Promise(resolve => providerServer.listen(0, '127.0.0.1', resolve));
+  t.after(() => new Promise(resolve => { providerServer.closeAllConnections(); providerServer.close(resolve); }));
+  const config = { promptsDir: join(REPO_ROOT, 'prompts'), promptVersion: 'v1', promptOverrides: {},
+    defaultProvider: 'local_lmstudio', imageSource: 'preview', maxFailuresPerAsset: 2,
+    enrichEnabled: true, enrichSchedule: { enabled: true, timeZone: 'UTC', time: '00:00', photoBudget: 1 },
+    providers: { local_lmstudio: { modelName: 'fixture', baseUrl: `http://127.0.0.1:${providerServer.address().port}/v1` } } };
+  const runner = new EnrichJobRunner({ repo: h.repo, immich: h.immich, taxonomy: h.options.taxonomy, config });
+  const scheduler = new EnrichScheduler({ runner, repo: h.repo, config, log: () => {} });
+  assert.equal(scheduler.tick(new Date()), true); await runner.runPromise;
+  assert.equal(runner.status().counters.succeeded, 1); assert.equal(runner.status().error, null);
+  assert.equal(h.calls.gets.length, 1); assert.equal(h.repo.reviewListRows().length, 1);
+  assert.equal(scheduler.tick(new Date()), false);
+  h.hooks.search = () => Response.json({ assets: { items: [photo(0)], nextPage: '1' } });
+  runner.start({ maxAnalyzed: 1 }); await runner.runPromise;
+  assert.match(runner.status().error, /invalid or non-progressing next page/);
+  const row = h.repo.db.prepare('SELECT status,error FROM job_runs ORDER BY id DESC LIMIT 1').get();
+  assert.equal(row.status, 'failed'); assert.match(row.error, /next page/);
+  assert.equal(h.calls.downloads.length, 1);
+  // Source changes cancel discovery before an old-client response can publish.
+  const previous = h.repo.db.prepare('SELECT state_json FROM enrich_discovery').get().state_json;
+  h.hooks.search = () => { runner.sourceChanged(); h.immich.apiKey = 'replacement-key'; };
+  runner.start({ maxAnalyzed: 1 }); await runner.runPromise;
+  assert.equal(runner.status().cancelled, true);
+  assert.equal(h.repo.db.prepare('SELECT state_json FROM enrich_discovery').get().state_json, previous);
+  assert.equal(h.calls.downloads.length, 1); await runner.stop();
+});

--- a/test/enrich/discoveryPrototype.test.mjs
+++ b/test/enrich/discoveryPrototype.test.mjs
@@ -1,0 +1,172 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { DiscoveryPrototype } from '../../scripts/prototypes/enrich-discovery.mjs';
+import { SyntheticSource, sandbox, history, finish, key, photo, library } from '../../scripts/prototypes/discovery-fixture.mjs';
+
+const options = { runKey: key, limit: 50 };
+test('prototype checkpoints a 150k inventory across reopen and publishes only a complete generation', async () => {
+  const box = sandbox();
+  try {
+    const rows = library(150000, false), source = new SyntheticSource(rows);
+    let index = new DiscoveryPrototype(box.repo); index.begin();
+    assert.deepEqual(await index.step(source), { pages: 2, complete: false });
+    assert.throws(() => index.candidates(options), /incomplete/);
+    assert.equal(index.state().watermark, 0);
+    index = box.reopen();
+    assert.equal(index.state().scan.page, 3);
+    await assert.rejects(index.step(source, { pageSize: 500 }), /same page size/);
+    assert.equal(await finish(index, source), 74);
+    assert.equal(source.calls.pages, 150);
+    assert.equal(box.repo.db.prepare('SELECT COUNT(*) AS n FROM prototype_inventory').get().n, 150000);
+    assert.equal(index.state().watermark, rows[0].updatedAt);
+    box.repo.transaction(() => { for (const row of rows.slice(0, -50)) history(box.repo, row); });
+    const selected = await index.select(source, options);
+    assert.deepEqual(selected.selected.map(r => r.id), rows.slice(-50).map(r => r.id));
+    assert.equal(selected.validated, 50);
+  } finally { box.close(); }
+});
+
+test('SQL eligibility matches production rules before LIMIT, including changed inference, failure limits and discard', async () => {
+  const box = sandbox();
+  try {
+    const rows = library(1100, false), index = new DiscoveryPrototype(box.repo);
+    box.repo.transaction(() => {
+      for (const [i, row] of rows.entries()) {
+        if (i < 400) history(box.repo, row);
+        else if (i < 800) { history(box.repo, row, { status: 'failed' }); history(box.repo, row, { status: 'failed' }); }
+        else if (i < 1000) history(box.repo, row, { status: null, discarded: true });
+        else if (i < 1050) history(box.repo, row, { status: 'failed_infra' });
+      }
+      history(box.repo, rows[1090], { runKey: { ...key, inferenceId: null } });
+    });
+    index.begin(); await finish(index, new SyntheticSource(rows));
+    for (const runKey of [key, { ...key, inferenceId: 'b'.repeat(64) }, { ...key, inferenceId: null }]) {
+      for (const onlyUnenriched of [true, false]) {
+        for (const maxFailures of [0, 2]) {
+          const expected = box.repo.assetIdsNeedingWork(rows.map(r => r.id), { runKey, skipAnySuccessful: onlyUnenriched, maxFailuresPerAsset: maxFailures }).needy;
+          const actual = index.candidates({ runKey, onlyUnenriched, maxFailures, limit: 50 });
+          assert.deepEqual(actual.map(r => r.asset_id), rows.filter(r => expected.has(r.id)).slice(0, 50).map(r => r.id));
+        }
+      }
+    }
+  } finally { box.close(); }
+});
+
+test('same fixtures produce the same eligible selections for Enrich and strengthened Insights inventories', async () => {
+  const rows = library(10000);
+  const outputs = [];
+  for (const mode of ['enrich', 'insights-with-eligibility-columns']) {
+    const box = sandbox();
+    try {
+      const index = box.index(mode), source = new SyntheticSource(rows, mode);
+      box.repo.transaction(() => { for (const row of rows.slice(0, 9950)) history(box.repo, row); });
+      index.begin(); await finish(index, source);
+      outputs.push((await index.select(source, options)).selected.map(r => r.id));
+      assert.equal(source.calls.gets, 50); // hidden/stack/video records never reach validation
+    } finally { box.close(); }
+  }
+  assert.deepEqual(outputs[0], outputs[1]);
+});
+
+test('validation excludes deletion, hiding and stack changes without consuming the photo budget; restore/new upload refresh', async () => {
+  const box = sandbox();
+  try {
+    const rows = library(12, false), source = new SyntheticSource(rows), index = new DiscoveryPrototype(box.repo);
+    index.begin(); await finish(index, source);
+    source.remove(rows[0].id); source.change(rows[1].id, { visibility: 'hidden', updatedAt: 100000 });
+    source.change(rows[2].id, { stackChild: true, updatedAt: 100000 });
+    const selected = await index.select(source, { ...options, limit: 4 });
+    assert.deepEqual(selected.selected.map(r => r.id), rows.slice(3, 7).map(r => r.id));
+    assert.equal(selected.validated, 7);
+    const again = await index.select(source, { ...options, limit: 4 }); assert.equal(again.validated, 4);
+    source.add(photo('old-upload', { takenAt: '1990-01-01T00:00:00.000Z', updatedAt: 110000 }));
+    source.add({ ...rows[0], updatedAt: 110000 }); // restored asset re-enters the filtered source
+    index.begin('delta'); await finish(index, source);
+    const all = index.candidates(options).map(r => r.asset_id);
+    assert.ok(all.includes('old-upload')); assert.ok(all.includes(rows[0].id));
+    assert.ok(!all.includes(rows[1].id)); assert.ok(!all.includes(rows[2].id));
+    const watermark = index.state().watermark;
+    index.begin('delta'); await finish(index, source); assert.equal(index.state().watermark, watermark);
+  } finally { box.close(); }
+});
+
+test('failed and malformed refresh pages preserve committed inventory, checkpoint, and watermark', async () => {
+  const box = sandbox();
+  try {
+    const index = new DiscoveryPrototype(box.repo), source = new SyntheticSource(library(20, false));
+    index.begin(); await finish(index, source);
+    const committed = index.candidates(options), watermark = index.state().watermark;
+    source.add(photo('new', { updatedAt: watermark + 5000 }));
+    index.begin('full'); await index.step(source, { pageSize: 5, maxPages: 1 });
+    const saved = index.state();
+    await assert.rejects(index.step({ scan: async () => { throw Error('offline'); } }, { pageSize: 5 }), /offline/);
+    assert.deepEqual(index.state(), saved); assert.deepEqual(index.candidates(options), committed);
+    await assert.rejects(index.step({ scan: async () => ({ items: [], nextPage: 1 }) }, { pageSize: 5 }), /Invalid upstream/);
+    assert.deepEqual(index.state(), saved);
+    await finish(index, source, { pageSize: 5 });
+    assert.equal(index.state().watermark, watermark + 5000);
+    assert.ok(index.candidates(options).some(r => r.asset_id === 'new'));
+  } finally { box.close(); }
+});
+
+test('periodic full reconciliation recovers access changes with no updatedAt change and null-date ordering is stable', async () => {
+  const box = sandbox();
+  try {
+    const source = new SyntheticSource([photo('null-a', { takenAt: null }), photo('null-z', { takenAt: null }), photo('dated')]);
+    const index = new DiscoveryPrototype(box.repo); index.begin(); await finish(index, source);
+    assert.deepEqual(index.candidates(options).map(r => r.asset_id), ['dated', 'null-z', 'null-a']);
+    source.remove('dated'); await index.select(source, options);
+    source.add(photo('dated', { updatedAt: 10000 }));
+    index.begin('delta'); await finish(index, source);
+    assert.ok(!index.candidates(options).some(r => r.asset_id === 'dated')); // negative cache stays until reconciliation
+    index.begin('full'); await finish(index, source);
+    assert.equal(index.candidates(options)[0].asset_id, 'dated');
+    const cursor = index.candidates({ ...options, limit: 2 }).at(-1);
+    assert.deepEqual(index.candidates({ ...options, after: cursor }).map(r => r.asset_id), ['null-a']);
+  } finally { box.close(); }
+});
+
+test('prototype exposes the large equal-timestamp overlap limitation rather than claiming a cheap warm refresh', async () => {
+  const box = sandbox();
+  try {
+    const source = new SyntheticSource(library(10000, false).map(r => ({ ...r, updatedAt: 10000 })));
+    const index = new DiscoveryPrototype(box.repo); index.begin(); await finish(index, source);
+    const before = source.calls.pages;
+    index.begin('delta'); await finish(index, source);
+    assert.equal(source.calls.pages - before, 10);
+    assert.equal(index.state().watermark, 10000);
+  } finally { box.close(); }
+});
+
+
+test('prototype sweep sends only its newly successful work to Curate', async () => {
+  const box = sandbox();
+  try {
+    const rows = [photo('already-enriched'), photo('new-success'), photo('new-failure')];
+    history(box.repo, rows[0]);
+    const index = new DiscoveryPrototype(box.repo); index.begin(); await finish(index, new SyntheticSource(rows));
+    const called = [];
+    const result = await index.run(new SyntheticSource(rows), options, { sendToCurate: true, process: async asset => {
+      called.push(asset.id); const status = asset.id === 'new-success' ? 'succeeded' : 'failed';
+      history(box.repo, asset, { status }); return status;
+    } });
+    assert.deepEqual(called.sort(), ['new-failure', 'new-success']);
+    assert.equal(result.succeeded, 1); assert.equal(result.failed, 1); assert.equal(result.listed, 1);
+    assert.deepEqual(box.repo.db.prepare('SELECT asset_id FROM review_list').all().map(r => r.asset_id), ['new-success']);
+  } finally { box.close(); }
+});
+
+
+test('mutable offset pagination requires reconciliation even when a pass reaches the end', async () => {
+  const box = sandbox();
+  try {
+    const rows = library(4, false), source = new SyntheticSource(rows), index = new DiscoveryPrototype(box.repo);
+    index.begin(); await index.step(source, { pageSize: 2, maxPages: 1 });
+    source.remove(rows[0].id); // page two shifts left; the next offset misses row 2
+    await finish(index, source, { pageSize: 2 });
+    assert.ok(!index.candidates(options).some(r => r.asset_id === rows[2].id));
+    index.begin('full'); await finish(index, source, { pageSize: 2 });
+    assert.ok(index.candidates(options).some(r => r.asset_id === rows[2].id));
+    assert.ok(!index.candidates(options).some(r => r.asset_id === rows[0].id));
+  } finally { box.close(); }
+});

--- a/test/enrich/discoveryPrototype.test.mjs
+++ b/test/enrich/discoveryPrototype.test.mjs
@@ -170,3 +170,63 @@ test('mutable offset pagination requires reconciliation even when a pass reaches
     assert.ok(!index.candidates(options).some(r => r.asset_id === rows[0].id));
   } finally { box.close(); }
 });
+
+test('filtered deltas miss a large cleanup and exhaust six validation budgets before reaching eligible work', async () => {
+  const box = sandbox();
+  try {
+    const rows = library(150000, false), source = new SyntheticSource(rows), index = box.index();
+    box.repo.transaction(() => { for (const row of rows.slice(6050)) history(box.repo, row); });
+    index.begin(); await finish(index, source);
+    const changedAt = index.state().watermark + 5000;
+    for (const row of rows.slice(0, 3000)) source.change(row.id, { visibility: 'hidden', updatedAt: changedAt });
+    for (const row of rows.slice(3000, 6000)) source.remove(row.id);
+    const before = { ...source.calls };
+    index.begin('delta'); await finish(index, source);
+    assert.equal(source.calls.pages - before.pages, 1);
+    assert.equal(source.calls.rows - before.rows, 0); // none of the transitions reached the inventory
+    for (let attempt = 0; attempt < 6; attempt++) {
+      const result = await index.select(source, options);
+      assert.equal(result.selected.length, 0);
+      assert.equal(result.validated, 1000);
+      assert.equal(result.limited, true); // MUST NOT become "library caught up" in production
+    }
+    const result = await index.select(source, options);
+    assert.deepEqual(result.selected.map(r => r.id), rows.slice(6000, 6050).map(r => r.id));
+    assert.equal(result.validated, 50);
+    assert.equal(result.limited, false);
+  } finally { box.close(); }
+});
+
+test('broad delta contract sees hidden, stack and trash transitions but permanent deletion still needs reconciliation', async () => {
+  const box = sandbox();
+  try {
+    const rows = library(4050, false), source = new SyntheticSource(rows, 'enrich-with-broad-delta'), index = box.index();
+    index.begin(); await finish(index, source);
+    const changedAt = index.state().watermark + 5000;
+    for (const row of rows.slice(0, 1000)) source.change(row.id, { visibility: 'hidden', updatedAt: changedAt });
+    for (const row of rows.slice(1000, 2000)) source.change(row.id, { stackChild: true, updatedAt: changedAt });
+    for (const row of rows.slice(2000, 3000)) source.change(row.id, { deleted: true, updatedAt: changedAt });
+    for (const row of rows.slice(3000, 4000)) source.remove(row.id);
+    const before = { ...source.calls };
+    index.begin('delta'); await finish(index, source);
+    assert.equal(source.calls.rows - before.rows, 3000);
+    assert.equal(source.calls.pages - before.pages, 3);
+    const first = await index.select(source, options);
+    assert.equal(first.selected.length, 0);
+    assert.equal(first.validated, 1000); // permanent deletions are not a searchable change feed
+    assert.equal(first.limited, true);
+    // Model the required response to a rejection burst: bounded full catch-up,
+    // rather than waiting for tomorrow's selection. No automatic scheduler exists here.
+    index.begin('full');
+    const step = await index.step(source, { maxPages: 1, pageSize: 25 });
+    assert.deepEqual(step, { pages: 1, complete: false });
+    const resumed = box.reopen();
+    assert.equal(resumed.state().scan.page, 2);
+    assert.deepEqual(await resumed.step(source, { maxPages: 1, pageSize: 25 }), { pages: 1, complete: true });
+    assert.equal(resumed.db.prepare('SELECT COUNT(*) AS n FROM prototype_inventory').get().n, 50);
+    const result = await resumed.select(source, options);
+    assert.deepEqual(result.selected.map(r => r.id), rows.slice(4000).map(r => r.id));
+    assert.equal(result.validated, 50);
+    assert.equal(result.limited, false);
+  } finally { box.close(); }
+});

--- a/test/enrich/profiles.test.mjs
+++ b/test/enrich/profiles.test.mjs
@@ -186,7 +186,7 @@ test('schema-8 fixture migrates to profiles without inventing old run attributio
   db.close();
   const repo = new Repository(path);
   try {
-    assert.deepEqual(repo.initSchema().applied, [9, 10]);
+    assert.deepEqual(repo.initSchema().applied, [9, 10, 11]);
     const config = { promptsDir: join(REPO_ROOT, 'prompts'), promptVersion: 'v1', taxonomyPath: join(REPO_ROOT, 'taxonomy/v1.json'),
       promptOverrides: { systemPrompt: 'Migrated customization' } };
     const profiles = new EnrichmentProfiles({ repo, config }); profiles.initialize();

--- a/test/enrich/runConfiguration.test.mjs
+++ b/test/enrich/runConfiguration.test.mjs
@@ -329,7 +329,7 @@ test('v7 upgrade preserves successes as unknown identity, with no invented snaps
   db.close();
   const repo = new Repository(path);
   try {
-    assert.deepEqual(repo.initSchema().applied, [8, 9, 10]);
+    assert.deepEqual(repo.initSchema().applied, [8, 9, 10, 11]);
     const config = snapshot();
     assert.equal(repo.hasAnySuccessfulRun('a1'), true);
     assert.equal(repo.hasSuccessfulRun({ assetId: 'a1', ...config.runKey }), false);

--- a/test/enrich/scale.test.mjs
+++ b/test/enrich/scale.test.mjs
@@ -160,7 +160,7 @@ test('a pre-v3 database backfills latest_success from the latest succeeded runs'
     // Simulate a pre-v3 database, then re-init as an upgraded server would.
     repo.db.exec('DROP TABLE latest_success');
     repo.db.exec('PRAGMA user_version = 2');
-    assert.deepEqual(repo.initSchema().applied, [3, 4, 5, 6, 7, 8, 9, 10]);
+    assert.deepEqual(repo.initSchema().applied, [3, 4, 5, 6, 7, 8, 9, 10, 11]);
 
     const rows = repo.db.prepare('SELECT * FROM latest_success ORDER BY asset_id').all();
     assert.equal(rows.length, 1, 'only assets with a succeeded run are projected');

--- a/test/enrich/timing.test.mjs
+++ b/test/enrich/timing.test.mjs
@@ -248,7 +248,7 @@ test('schema 9 upgrades without inventing old timing, and the migration is resta
   db.exec("PRAGMA user_version = 9; INSERT INTO job_runs(title, provider, status, started_at, finished_at) VALUES ('Old', 'venice', 'finished', '2026-09-01', '2026-09-01');"); db.close();
   const repo = new Repository(path);
   try {
-    assert.deepEqual(repo.initSchema().applied, [10]);
+    assert.deepEqual(repo.initSchema().applied, [10, 11]);
     assert.equal(repo.listJobRuns()[0].timingRunId, null); assert.deepEqual(repo.timings.runs().items, []);
     assert.deepEqual(repo.initSchema().applied, []);
   } finally { repo.close(); }

--- a/test/migrations.test.mjs
+++ b/test/migrations.test.mjs
@@ -129,7 +129,7 @@ test('a fresh enrichment database is stamped and fully shaped', () => {
     const repo = new Repository(join(dir, 'enrichment.sqlite'));
     const result = repo.initSchema();
     assert.equal(result.fresh, true);
-    assert.equal(getUserVersion(repo.db), 10);
+    assert.equal(getUserVersion(repo.db), 11);
     for (const column of ['subject_group']) {
       const names = repo.db.prepare("SELECT name FROM pragma_table_info('referee_picks')").all().map((row) => row.name);
       assert.ok(names.includes(column));
@@ -178,8 +178,8 @@ test('a legacy enrichment database lands in the current shape via migration 1', 
     const repo = new Repository(path);
     const result = repo.initSchema();
     assert.equal(result.fresh, false);
-    assert.deepEqual(result.applied, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-    assert.equal(getUserVersion(repo.db), 10);
+    assert.deepEqual(result.applied, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+    assert.equal(getUserVersion(repo.db), 11);
 
     // manual_overrides rebuilt append-only with data preserved.
     const overrideColumns = repo.db.prepare("SELECT name FROM pragma_table_info('manual_overrides')").all().map((row) => row.name);
@@ -227,7 +227,7 @@ test('provider-payload migration removes raw envelopes and superseded normalized
       .run(JSON.stringify({ caption: 'old', short_caption: 'old' }), rows[0].id);
     repo.db.exec('PRAGMA user_version = 5');
 
-    assert.deepEqual(repo.initSchema().applied, [6, 7, 8, 9, 10]);
+    assert.deepEqual(repo.initSchema().applied, [6, 7, 8, 9, 10, 11]);
     const migrated = repo.db.prepare(`
       SELECT raw_output_json, normalized_output_json
       FROM processing_runs ORDER BY id

--- a/test/upgrade/upgrade-safety.test.mjs
+++ b/test/upgrade/upgrade-safety.test.mjs
@@ -79,7 +79,7 @@ test('the activity schema contract creates a recovery point before changing an e
       currentServerVersion: '0.1.0-with-activity',
       now: new Date('2026-08-08T02:00:00Z'),
     });
-    assert.equal(PERSISTENT_STATE_VERSION, 12);
+    assert.equal(PERSISTENT_STATE_VERSION, 13);
     assert.equal(prepared.action, 'create');
 
     const snapshot = new DatabaseSync(join(config.backup.dir, prepared.snapshotName, 'enrichment.sqlite'), {
@@ -96,7 +96,7 @@ test('the activity schema contract creates a recovery point before changing an e
       successfulStateVersion: PERSISTENT_STATE_VERSION,
       successfulServerVersion: '0.1.0-with-activity',
     });
-    assert.equal(sealed.upgrade.stateVersion, 12);
+    assert.equal(sealed.upgrade.stateVersion, 13);
     assert.equal(sealed.upgrade.recoveryPoint.snapshotName, prepared.snapshotName);
   });
 });
@@ -116,7 +116,7 @@ test('a zero-model v2 installation creates a complete schedule-confirmation reco
       now: new Date('2026-08-08T02:00:00Z'),
     });
 
-    assert.equal(PERSISTENT_STATE_VERSION, 12);
+    assert.equal(PERSISTENT_STATE_VERSION, 13);
     assert.deepEqual({
       action: prepared.action,
       fromStateVersion: prepared.fromStateVersion,
@@ -124,7 +124,7 @@ test('a zero-model v2 installation creates a complete schedule-confirmation reco
     }, {
       action: 'create',
       fromStateVersion: 2,
-      toStateVersion: 12,
+      toStateVersion: 13,
     });
     assert.equal(
       readFileSync(join(config.backup.dir, prepared.snapshotName, 'smart-albums.json'), 'utf8'),
@@ -146,7 +146,7 @@ test('a zero-model v2 installation creates a complete schedule-confirmation reco
       purpose: {
         type: 'pre-migration',
         fromStateVersion: 2,
-        toStateVersion: 12,
+        toStateVersion: 13,
         fromServerVersion: '0.1.0-before-schedule-confirmation',
         toServerVersion: '0.1.0-with-schedule-confirmation',
       },

--- a/test/upgrade/whole-install.test.mjs
+++ b/test/upgrade/whole-install.test.mjs
@@ -47,7 +47,7 @@ test('a complete legacy installation upgrades, restarts, backs up, and restores 
     const sourceConfig = fixtureConfig(sourceRoot);
 
     const first = await openInstallation(sourceConfig, 'initialize');
-    assert.deepEqual(first.enrichmentMigration.applied, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    assert.deepEqual(first.enrichmentMigration.applied, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
     await assertRepresentativeState(first, sourceConfig);
 
     const migratedDefault = first.profiles.activeProfile();
@@ -134,7 +134,7 @@ test('contract 10 upgrade snapshots queue pins before clearing them and retains 
     writeFileSync(config.persistentState.inventoryPath, JSON.stringify(inventory));
 
     const upgraded = await openInstallation(config, 'verify');
-    assert.equal(upgraded.inventory.upgrade.stateVersion, 12);
+    assert.equal(upgraded.inventory.upgrade.stateVersion, 13);
     assert.deepEqual(semanticSnapshot(upgraded), before);
     assert.equal(upgraded.profiles.activeProfile().id, travel.id);
     assert.equal(upgraded.enrichment.db.prepare('SELECT COUNT(*) AS n FROM enrich_queue WHERE profile_revision_id IS NOT NULL').get().n, 0);
@@ -191,6 +191,30 @@ function createDatabaseFromSql(databasePath, fixturePath) {
   }
 }
 
+test('contract 12 upgrade saves schema-10 history before introducing discovery', async () => {
+  const workspace = mkdtempSync(join(tmpdir(), 'pictaria-discovery-recovery-'));
+  try {
+    const config = fixtureConfig(join(workspace, 'source')); materializeLegacyInstallation(join(workspace, 'source'));
+    const installed = await openInstallation(config, 'initialize');
+    installed.enrichment.db.exec(`DROP TABLE enrich_inventory; DROP TABLE enrich_inventory_stage; DROP TABLE enrich_discovery;
+      PRAGMA user_version = 10;
+      INSERT INTO job_runs(title,provider,status,started_at,finished_at) VALUES('Before discovery','venice','finished','2026-09-01','2026-09-01');`);
+    closeInstallation(installed);
+    const inventory = JSON.parse(readFileSync(config.persistentState.inventoryPath, 'utf8'));
+    inventory.upgrade.stateVersion = 12; writeFileSync(config.persistentState.inventoryPath, JSON.stringify(inventory));
+    const upgraded = await openInstallation(config, 'verify');
+    assert.deepEqual(upgraded.enrichmentMigration.applied, [11]);
+    assert.equal(upgraded.enrichment.listJobRuns()[0].title, 'Before discovery');
+    assert.equal(upgraded.enrichment.db.prepare('SELECT COUNT(*) n FROM enrich_inventory').get().n, 0);
+    const snapshotPath = join(config.backup.dir, upgraded.inventory.upgrade.recoveryPoint.snapshotName, 'enrichment.sqlite');
+    const snapshot = new DatabaseSync(snapshotPath, { readOnly: true });
+    assert.equal(getUserVersion(snapshot), 10);
+    assert.equal(snapshot.prepare("SELECT name FROM sqlite_master WHERE name='enrich_inventory'").get(), undefined);
+    assert.equal(snapshot.prepare('SELECT title FROM job_runs ORDER BY id DESC LIMIT 1').get().title, 'Before discovery');
+    snapshot.close(); closeInstallation(upgraded);
+  } finally { rmSync(workspace, { recursive: true, force: true }); }
+});
+
 test('contract 11 upgrade saves a schema-9 recovery point before introducing timings', async () => {
   const workspace = mkdtempSync(join(tmpdir(), 'pictaria-timing-recovery-'));
   try {
@@ -206,7 +230,7 @@ test('contract 11 upgrade saves a schema-9 recovery point before introducing tim
     const inventory = JSON.parse(readFileSync(config.persistentState.inventoryPath, 'utf8'));
     inventory.upgrade.stateVersion = 11; writeFileSync(config.persistentState.inventoryPath, JSON.stringify(inventory));
     const upgraded = await openInstallation(config, 'verify');
-    assert.deepEqual(upgraded.enrichmentMigration.applied, [10]);
+    assert.deepEqual(upgraded.enrichmentMigration.applied, [10, 11]);
     assert.equal(upgraded.enrichment.listJobRuns()[0].timingRunId, null);
     const snapshotDir = join(config.backup.dir, upgraded.inventory.upgrade.recoveryPoint.snapshotName);
     closeInstallation(upgraded);


### PR DESCRIPTION
Related to PIC-311

Budgeted library sweeps and Daily Enrich now select work from an Enrich-owned SQLite inventory. A 100,000-photo enriched prefix no longer prevents reaching the next 50 photos, and completed photos do not need repeated metadata upserts or provider calls. Library-sweep Send to Curate adds only successes from that execution; explicitly targeted selections retain their existing behavior.

The inventory builds in checkpointed 1,000-record pages, refreshes timeline/archive/hidden changes across the inspected Immich v2/v3 APIs, and validates selected photos immediately before processing. SQL eligibility is shared with queue selection and preserves inference identity, failure limits, and human discard. Rejection bursts trigger bounded reconciliation within the run. Cancellation/source changes prevent late-page publication, and a durable lease guards concurrent refreshes. Malformed page structure and missing identity/update timestamps retain their checkpoint and appear as failures in run history rather than implying the library is caught up. Unknown eligibility metadata instead excludes the affected photos and logs a bounded diagnostic. Search rows may inherit missing visibility from their explicit partition, but live validation must independently confirm eligibility. The discovery summary reports metadata refresh time separately from AI processing.

Freshness limits: remote offset pagination is not a snapshot. Incremental refresh advances one millisecond beyond the largest completed source timestamp to avoid repeatedly reading equal-timestamp imports. Late boundary arrivals, silent access changes, and pagination misses reconcile on the next sweep after 24 hours. Refresh/validation budgets can require another run; Daily Enrich retains its once-per-day attempt policy. Timeline-image eligibility is preserved; the prototype's synthetic stack-child exclusion is not introduced. Explicit offsets and unbudgeted CLI scans retain the legacy window path.

Schema 11 / persistent-state contract 13 creates the normal pre-migration recovery point. Inventory and checkpoints participate in existing backups without replacing history or decisions. Rollback requires that snapshot and its corresponding older build; a stale lease can delay restart by up to five minutes.

Validation: all 1,120 tests pass locally on Node 22 (matching CI), including the real-client 100k-prefix regression, warm queries, cleanup/reconciliation, configuration changes, Daily Enrich, cancellation, malformed/outage/permission handling, checkpoint/backup/reopen, and schema-10 recovery-point preservation. New regressions cover 1,500 uncertain records across pages, partition fallback versus live validation, corrected metadata, structural failure checkpoints, and refresh timing. Publication, DCO, and diff checks pass. A local Node 25 run completed all assertions but hung during browser-test cleanup; the Node 22 run completed normally. CI supplies container build/boot and upgrade validation. Live Immich test-instance acceptance remains outstanding; no live provider calls or user-library mutations were performed.

Authored by Codex. Claude reviewed the earlier prototype and its transition findings are incorporated. Claude independently reviewed production commit `10d00a1`, including real-client/server A/B checks and upgrade/restore rehearsals. Claude also independently reviewed follow-up commit `1546889` and approved it with no new findings, verifying metadata tolerance, live validation, recovery, and timing through real HTTP/client/server fixtures. David approved the merge. Historical prototype scripts and findings remain available, separate from production imports.
