### PR TITLE
PIC-347: Sync AI tags after every successful enrichment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to Pictaria Server are documented here. This project follows
 - Every successfully enriched photo now queues its AI tags for Immich,
   regardless of Send to Curate. Tag-based albums/searches can include photos
   before review; human `frame/*` decisions and unrelated tags remain intact.
-  Enrich shows pending/failed tag sync and retry. A separate durable backlog
+  Enrich shows pending/failed tag sync and retry, with errors labeled Immich. A separate durable backlog
   preserves results through outages without filling Curate's decision queue;
   coordinated tag writes prioritize human actions. Pictaria reconciles its
   `ai/*` namespace, including replacing manual tags within that prefix.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to Pictaria Server are documented here. This project follows
 
 ### Changed
 
+- Every successfully enriched photo now queues its AI tags for Immich,
+  regardless of Send to Curate. Tag-based albums/searches can include photos
+  before review; human `frame/*` decisions and unrelated tags remain intact.
+  Enrich shows pending/failed tag sync and retry. A separate durable backlog
+  preserves results through outages without filling Curate's decision queue;
+  coordinated tag writes prioritize human actions. Pictaria reconciles its
+  `ai/*` namespace, including replacing manual tags within that prefix.
+  Upgrade snapshots schema 11 / state contract 14 before moving to schema 12 /
+  contract 15. Older enriched photos are not automatically backfilled.
+
 - Enrich run history is configurable in Settings: keep 100–1,000 run summaries
   and Performance history entries, with diagnostic logs separately limited to
   the newest 0–100 runs. Defaults remain 100 each. Lowering a limit prunes older

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -214,6 +214,14 @@ data/               all persistent state (gitignored): enrichment.sqlite,
   links. Enrich and Settings link to this page; Enrich no longer fetches
   comparison aggregates. `public/enrich-format.js` shares readable provider,
   status, date, duration, and rate formatting between these views. No persistent schema or settings contract changes are needed.
+- **Automatic AI tag sync**: `enrich/aiTagSyncStore.mjs` owns the schema-12
+  asset-keyed outbox and persistent lane backoff. The runner enqueues in the
+  successful-photo transaction. `aiTagSync.mjs` reuses the review service's
+  reconciliation/verification in bounded slices, with generation-checked
+  acknowledgement. `tagWriteCoordinator.mjs` serializes AI, Curate and direct
+  favorite/never-show tag work, prioritizing human requests; AI retries have
+  separate storage and do not fill or sleep inside the decision queue. Enrich
+  exposes status and retry. See [Enrich](ENRICH.md#the-pipeline).
 - **Enrich timing**: `enrich/timing.mjs` owns compact execution/request records
   and their schema, appended to the base enrichment schema by the repository.
   Schema 10 / persistent-state contract 12 adds timing tables and a nullable

--- a/docs/ENRICH.md
+++ b/docs/ENRICH.md
@@ -62,8 +62,9 @@ bounded AI slices (at most 10 photos). It does not interrupt a network request
 already in flight. AI backoff never holds the coordinator or consumes the
 Curate backlog allowance. Shared verification checks both additions and stale
 AI-tag removals, with one settle delay per slice rather than per photo.
-Systemic failures pause the AI lane for 30 seconds; photo-specific failures
-are parked after five attempts and can be retried from Enrich.
+Any failed sync slice pauses the AI lane for 30 seconds. Systemic failures
+do not consume individual photo attempts; photo-specific failures are parked
+after five attempts and can be retried from Enrich.
 
 New saved run configurations record `processing.syncAiTags: true`. The older
 `applyTags`/`dryRun` fields describe only the separate legacy batch-end write

--- a/docs/ENRICH.md
+++ b/docs/ENRICH.md
@@ -1,7 +1,8 @@
 # Enrich
 
 AI models look at your photos and propose tags from a controlled taxonomy,
-plus a one-sentence caption. Proposed tags land in **Curate** for human review.
+plus a one-sentence caption. AI tags sync to Immich after every successfully
+enriched photo. **Send to Curate** optionally adds those photos to human review.
 Results are stored in `data/enrichment.sqlite`; if optional caption writeback
 is enabled, successful captions are also copied automatically into Immich
 descriptions under the rules documented below.
@@ -31,12 +32,50 @@ For each photo, one *processing run*:
    (latest normalized output, provider/model, and a reference to the saved
    configuration) locally. Raw provider envelopes are not retained.
 
-Enrichment runs are always dry runs against Immich. Tags reach Immich only
-through Curate decisions, via a durable background sync worker that verifies
-and repairs both required additions and required removals after writing. For
-that sync, enable **Tags** under **Immich Account Settings → Features** for the
-account whose API key Pictaria uses, and grant that key `tag.read`,
-`tag.create`, and `tag.asset`.
+Every successful dashboard enrichment durably queues its `ai/*` tags for
+Immich, whether or not **Send to Curate** is checked. Sync starts while the run
+continues; it does not wait for the whole batch. **Send to Curate** controls
+review-list membership only. Curate retains authority over human decisions
+such as `frame/eligible`, `frame/favorite`, and `frame/never-show`.
+
+Pictaria manages the `ai/*` namespace: re-enrichment adds missing tags and
+removes stale ones, including manually added Immich tags inside that prefix.
+Tags outside `ai/*` are preserved. The AI-derived `frame/review` marker stays
+local and is not published by automatic tag sync. An album/search filtering
+on AI tags can now include photos before review; use Curate decision tags
+when approval is required.
+
+**Immich tag sync** in Enrich's Status card shows pending/failed photos, the
+latest error, and **Retry sync** when intervention is needed. A remote sync
+failure does not fail enrichment or repeat an AI call. Enable **Tags** under
+**Immich Account Settings → Features** for the API-key account, and grant
+`tag.read`, `tag.create`, and `tag.asset`. Fix connection/permission problems
+and retry there. Deleted photos are skipped. Turning Enrich off pauses this
+queue while preserving pending work; it does not block Curate sync.
+
+AI sync has a separate durable queue with one row per photo and no historical
+tag payload. Repeated enrichment coalesces to the newest local result. A
+processing-run generation prevents an older in-flight completion or failure
+from clearing newer queued work. The same tag-write coordinator serves
+Curate and favorite/never-show routes, with human work taking priority between
+bounded AI slices (at most 10 photos). It does not interrupt a network request
+already in flight. AI backoff never holds the coordinator or consumes the
+Curate backlog allowance. Shared verification checks both additions and stale
+AI-tag removals, with one settle delay per slice rather than per photo.
+Systemic failures pause the AI lane for 30 seconds; photo-specific failures
+are parked after five attempts and can be retried from Enrich.
+
+New saved run configurations record `processing.syncAiTags: true`. The older
+`applyTags`/`dryRun` fields describe only the separate legacy batch-end write
+path, which stays disabled for dashboard runs. Historical configurations are
+not rewritten. Background sync time is not part of photo inference timing.
+
+This change uses Enrich schema 12 and persistent-state contract 15. Startup
+creates the required pre-migration recovery snapshot; rollback restores that
+snapshot. Queue state is included in normal database backup/restore and
+resumes idempotently. Upgrade does **not** backfill tags for older enriched
+photos. Those photos sync on a subsequent successful enrichment or Curate
+decision; a bulk historical-sync action is not included.
 
 ## Providers
 

--- a/public/enrich.html
+++ b/public/enrich.html
@@ -454,7 +454,8 @@
         el('tagSyncStatus').textContent = !sync ? 'Sync status unavailable.'
           : `${sync.paused ? 'Paused — Enrich is turned off. ' : ''}${sync.pending} pending · ${sync.failed} failed`;
         el('tagSyncError').hidden = !sync?.lastError;
-        el('tagSyncError').textContent = sync?.lastError || '';
+        el('tagSyncError').textContent = sync?.lastError
+          ? (/^Immich\b/i.test(sync.lastError) ? sync.lastError : `Immich: ${sync.lastError}`) : '';
         el('tagSyncRetry').hidden = !sync || (!sync.failed && !sync.lastError);
         el('tagSyncRetry').disabled = !!sync?.paused;
         el('connStatus').hidden = false;

--- a/public/enrich.html
+++ b/public/enrich.html
@@ -142,8 +142,8 @@
 
   <main>
     <h1><span class="glyph">✦</span> Enrich</h1>
-    <p class="intro">AI models analyze your photos and propose tags from the taxonomy. Proposed tags land in
-      <a href="/curate.html" style="color: var(--p-accent)">Curate</a> for your review. If caption writeback is enabled,
+    <p class="intro">AI models analyze your photos and sync AI tags to Immich. Send photos to
+      <a href="/curate.html" style="color: var(--p-accent)">Curate</a> when you want to review them. If caption writeback is enabled,
       successful captions are copied automatically into Immich descriptions. You add photo groups to the Enrich queue from
       <a href="/insights.html" style="color: var(--p-accent)">Insights</a>.</p>
 
@@ -193,6 +193,12 @@
         <span class="p-score-track"><span id="enrichBar" class="p-score-fill" style="width: 0%"></span></span>
         <span id="enrichBarText" class="p-muted"></span>
       </div>
+      <div class="es-main" style="margin-top: 12px">
+        <strong>Immich tag sync</strong><span id="tagSyncStatus" class="p-muted" role="status">Loading…</span>
+        <div class="p-grow"></div><button id="tagSyncRetry" class="p-btn quiet" hidden>Retry sync</button>
+      </div>
+      <p class="p-muted" style="margin-bottom: 0">AI tags sync after each photo is enriched. Curate decisions stay separate.</p>
+      <p id="tagSyncError" class="p-muted" hidden></p>
     </section>
 
     <section id="runPanel" class="p-panel panel">
@@ -210,7 +216,7 @@
         <div class="qline opts">
           <label>Photos <input id="enrichMax" class="p-input" type="number" min="1" value="100" style="width: 74px"></label>
           <label title="Checked: skips photos any model has already enriched. Unchecked: re-enriches photos your current model + prompt + taxonomy hasn't processed yet — exact-duplicate re-runs are always skipped either way."><input id="enrichSkip" type="checkbox" checked> Only unenriched</label>
-          <label title="When the run finishes, the analyzed photos join the Curate review queue. Uncheck to enrich for tags/albums only."><input id="enrichCurate" type="checkbox" checked> Send to Curate</label>
+          <label title="Adds each successfully enriched photo to Curate. AI tags sync to Immich either way."><input id="enrichCurate" type="checkbox" checked> Send to Curate</label>
         </div>
       </div>
       <!-- Photos stuck at the content-failure limit under the selected
@@ -431,11 +437,26 @@
       el('runAllBtn').disabled = off || busy || providerUnavailable;
     }
 
+    el('tagSyncRetry').addEventListener('click', async () => {
+      el('tagSyncRetry').disabled = true;
+      try { await api('/api/enrich/tag-sync/retry', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({}) }); }
+      catch (error) { toast(error.message, true); }
+      finally { el('tagSyncRetry').disabled = false; }
+      await refresh();
+    });
+
     async function refresh() {
       try {
         const profileEpoch = profileUI.epoch();
         const status = await api('/api/enrich/status');
         profileUI.sync(status.activeProfile, profileEpoch);
+        const sync = status.tagSync;
+        el('tagSyncStatus').textContent = !sync ? 'Sync status unavailable.'
+          : `${sync.paused ? 'Paused — Enrich is turned off. ' : ''}${sync.pending} pending · ${sync.failed} failed`;
+        el('tagSyncError').hidden = !sync?.lastError;
+        el('tagSyncError').textContent = sync?.lastError || '';
+        el('tagSyncRetry').hidden = !sync || (!sync.failed && !sync.lastError);
+        el('tagSyncRetry').disabled = !!sync?.paused;
         el('connStatus').hidden = false;
         renderProviders(status);
         applyEnabled(status);
@@ -519,7 +540,8 @@
         // polling through that gap — an item retired as fully covered
         // would otherwise sit stale on screen, with its history row
         // missing, until a manual reload.
-        const busy = status.running || status.resolvingSlice;
+        const busy = status.running || status.resolvingSlice
+          || (sync?.pending > 0 && !sync.paused && sync.retryAfter <= Date.now());
         if (busy && !state.polling) state.polling = setInterval(refresh, 2000);
         if (!busy && state.polling) {
           clearInterval(state.polling);

--- a/src/enrich/aiTagSync.mjs
+++ b/src/enrich/aiTagSync.mjs
@@ -1,0 +1,121 @@
+import { ImmichApiError } from '../immich.mjs';
+import { awaitDrain } from '../lifecycle.mjs';
+import { configuredSecrets, sanitizeDiagnostic } from '../diagnostics.mjs';
+
+// Independent durable backlog, shared write boundary. Backoff never holds
+// the coordinator, and a large AI backlog cannot fill the decision queue.
+const BACKOFF_MS = 30000;
+const IDLE_MS = 5000;
+
+export class AiTagSyncService {
+  constructor({ repo, immich, review, tagWrites, config, log = () => {} }) {
+    Object.assign(this, { repo, immich, review, tagWrites, config, log });
+    this.store = repo.aiTagSync;
+    this.stopped = true;
+    this.done = null;
+    this.waker = null;
+  }
+
+  status() { return { ...this.store.status(), paused: !this.config.enrichEnabled }; }
+  retry() { const n = this.store.retry(); this.wake(); return n; }
+  wake() { this.waker?.(); }
+  start() {
+    if (this.done) return;
+    this.stopped = false;
+    this.done = this.loop().finally(() => { this.done = null; });
+  }
+  async stop(timeoutMs = 3000) {
+    this.stopped = true;
+    this.wake();
+    return this.done ? awaitDrain(this.done, timeoutMs) : true;
+  }
+
+  async loop() {
+    while (!this.stopped) {
+      let worked = false;
+      try { worked = await this.tick(); }
+      catch (error) {
+        // Database/read failures also must not create an unhandled rejection.
+        this.log(`AI tag sync will retry: ${this.diagnostic(error)}`);
+      }
+      if (!worked) await this.sleep(IDLE_MS);
+    }
+  }
+
+  diagnostic(error) {
+    return sanitizeDiagnostic(error instanceof Error ? error.message : error, {
+      secrets: configuredSecrets(this.config, this.immich),
+    });
+  }
+
+  async tick() {
+    if (!this.config.enrichEnabled || this.store.status().retryAfter > Date.now()) return false;
+    if (!this.store.next(1).length) return false;
+    return this.tagWrites.run(async () => {
+      if (!this.config.enrichEnabled || this.stopped) return false;
+      // Choose and snapshot only AFTER acquiring the write boundary.
+      const batch = this.store.next();
+      if (!batch.length) return false;
+      const active = [];
+      const remoteAssets = new Map();
+      let attempted = null;
+      let stage = 'read';
+      try {
+        for (const item of batch) {
+          if (!this.store.current(item)) continue;
+          attempted = item;
+          try {
+            const asset = await this.immich.getAsset(item.assetId);
+            if (!Array.isArray(asset?.tags)) {
+              throw new ImmichApiError('Immich did not expose asset tags. Enable Tags for the API-key account and grant tag.read, tag.create, and tag.asset.', 403);
+            }
+            remoteAssets.set(item.assetId, asset);
+            active.push(item);
+          } catch (error) {
+            if (error instanceof ImmichApiError && error.status === 404) {
+              this.store.mark(item, 'skipped', 'Photo no longer exists in Immich.');
+              continue;
+            }
+            throw error;
+          }
+        }
+        if (!active.length) { this.store.defer(null, 0); return true; }
+        stage = 'write';
+        const assetIds = active.map(item => item.assetId);
+        const localTagsByAsset = this.repo.loadAssetTagsFor(assetIds, { prefix: 'ai/' });
+        await this.review.syncAiTagsForAssets(assetIds, undefined, { localTagsByAsset, remoteAssets });
+        await this.review.verifyAndRepairTags({ assetIds, add: [], remove: [] }, { localTagsByAsset, verifyAiRemovals: true });
+        for (const item of active) this.store.mark(item, 'written');
+        this.store.defer(null, 0);
+      } catch (error) {
+        const message = this.diagnostic(error);
+        // Permission, connectivity, overload and server errors pause the lane
+        // without burning retries on thousands of individual photos.
+        const systemic = error.code !== 'immich_tag_inconsistent' && (
+          !(error instanceof ImmichApiError) || error.status == null
+          || [401, 403, 408, 429].includes(error.status) || error.status >= 500);
+        if (!systemic) {
+          for (const item of stage === 'read' ? (attempted ? [attempted] : []) : active) {
+            if (error.code === 'immich_tag_inconsistent' && !error.assetIds.includes(item.assetId)) {
+              this.store.mark(item, 'written');
+            } else {
+              this.store.failure(item, message);
+            }
+          }
+        }
+        this.store.defer(message, Date.now() + BACKOFF_MS);
+      }
+      return true;
+    }, { priority: 0 });
+  }
+
+  sleep(ms) {
+    return new Promise(resolve => {
+      const finish = () => { clearTimeout(timer); this.waker = null; resolve(); };
+      const timer = setTimeout(finish, ms);
+      timer.unref?.();
+      this.waker = finish;
+      if (this.stopped) finish();
+    });
+  }
+}

--- a/src/enrich/aiTagSyncStore.mjs
+++ b/src/enrich/aiTagSyncStore.mjs
@@ -1,0 +1,77 @@
+import { sanitizeDiagnostic } from '../diagnostics.mjs';
+
+export const AI_TAG_SYNC_SCHEMA = `
+CREATE TABLE IF NOT EXISTS ai_tag_sync (
+  asset_id TEXT PRIMARY KEY REFERENCES assets(asset_id) ON DELETE CASCADE,
+  generation INTEGER NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('pending','written','skipped','failed')),
+  attempts INTEGER NOT NULL DEFAULT 0,
+  last_error TEXT,
+  updated_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_ai_tag_sync_pending ON ai_tag_sync(status, updated_at, asset_id);
+CREATE TABLE IF NOT EXISTS ai_tag_sync_state (
+  id INTEGER PRIMARY KEY CHECK(id = 1),
+  retry_after INTEGER NOT NULL DEFAULT 0,
+  last_error TEXT
+);
+`;
+
+// One row per photo, no copied tag payload. The processing-run id protects
+// newer work from completion/failure of a stale HTTP request.
+export class AiTagSyncStore {
+  constructor(db) { this.db = db; }
+
+  enqueue(assetId, runId) {
+    this.db.prepare(`INSERT INTO ai_tag_sync(asset_id,generation,status,updated_at)
+      VALUES (?,?,'pending',?) ON CONFLICT(asset_id) DO UPDATE SET
+      generation=excluded.generation,status='pending',attempts=0,last_error=NULL,updated_at=excluded.updated_at
+    `).run(assetId, runId, Date.now());
+  }
+
+  next(limit = 10) {
+    return this.db.prepare(`SELECT asset_id AS assetId,generation,attempts FROM ai_tag_sync
+      WHERE status='pending' ORDER BY updated_at,asset_id LIMIT ?`).all(Math.max(1, Math.min(10, limit)));
+  }
+
+  current(item) {
+    return this.db.prepare(`SELECT 1 FROM ai_tag_sync WHERE asset_id=? AND generation=? AND status='pending'`)
+      .get(item.assetId, item.generation) !== undefined;
+  }
+
+  mark(item, status, error = null) {
+    return Number(this.db.prepare(`UPDATE ai_tag_sync SET status=?,last_error=?,updated_at=?
+      WHERE asset_id=? AND generation=? AND status='pending'`)
+      .run(status, error ? sanitizeDiagnostic(error) : null, Date.now(), item.assetId, item.generation).changes);
+  }
+
+  failure(item, error) {
+    this.db.prepare(`UPDATE ai_tag_sync SET attempts=attempts+1,last_error=?,updated_at=?,
+      status=CASE WHEN attempts+1>=5 THEN 'failed' ELSE 'pending' END
+      WHERE asset_id=? AND generation=? AND status='pending'`)
+      .run(sanitizeDiagnostic(error), Date.now(), item.assetId, item.generation);
+  }
+
+  defer(error, retryAfter) {
+    this.db.prepare(`INSERT INTO ai_tag_sync_state(id,retry_after,last_error) VALUES(1,?,?)
+      ON CONFLICT(id) DO UPDATE SET retry_after=excluded.retry_after,last_error=excluded.last_error`)
+      .run(retryAfter, error ? sanitizeDiagnostic(error) : null);
+  }
+
+  retry() {
+    const result = this.db.prepare(`UPDATE ai_tag_sync SET status='pending',attempts=0,last_error=NULL
+      WHERE status='failed'`).run();
+    this.defer(null, 0);
+    return Number(result.changes);
+  }
+
+  status() {
+    const counts = { pending: 0, written: 0, skipped: 0, failed: 0 };
+    for (const row of this.db.prepare('SELECT status,COUNT(*) AS n FROM ai_tag_sync GROUP BY status').all()) {
+      if (Object.hasOwn(counts, row.status)) counts[row.status] = Number(row.n);
+    }
+    const state = this.db.prepare('SELECT retry_after,last_error FROM ai_tag_sync_state WHERE id=1').get();
+    const failure = this.db.prepare(`SELECT last_error FROM ai_tag_sync WHERE status='failed' ORDER BY updated_at DESC LIMIT 1`).get();
+    return { ...counts, retryAfter: state?.retry_after ?? 0, lastError: state?.last_error ?? failure?.last_error ?? null };
+  }
+}

--- a/src/enrich/jobRunner.mjs
+++ b/src/enrich/jobRunner.mjs
@@ -11,12 +11,13 @@ import { configuredSecrets, sanitizeDiagnostic } from '../diagnostics.mjs';
 const LOG_TAIL_LIMIT = 500;
 
 export class EnrichJobRunner {
-  constructor({ repo, immich, taxonomy, config, profiles = null }) {
+  constructor({ repo, immich, taxonomy, config, profiles = null, onTagsQueued = () => {} }) {
     this.repo = repo;
     this.immich = immich;
     this.taxonomy = taxonomy;
     this.config = config;
     this.profiles = profiles;
+    this.onTagsQueued = onTagsQueued;
     this.state = idleState();
     this.runPromise = null;
     this.runLifecycle = null;
@@ -230,6 +231,7 @@ export class EnrichJobRunner {
         ...fixedOptions,
         maxFailuresPerAsset: fixedOptions.retryFailureLimited ? 0 : this.config.maxFailuresPerAsset,
         listForReview: fixedOptions.sendToCurate,
+        syncAiTags: true,
         captionWriteback: Boolean(this.config.captionWriteback),
       },
     });
@@ -495,6 +497,8 @@ export class EnrichJobRunner {
         retryFailureLimited: this.state.options.retryFailureLimited,
         imageSource: this.state.options.imageSource,
         promptVersion: this.state.promptVersion,
+        syncAiTags: configuration.snapshot.processing.syncAiTags === true,
+        onTagsQueued: this.onTagsQueued,
         applyTags: false,
         dryRun: true,
         listForReview: this.state.options.sendToCurate,

--- a/src/enrich/repository.mjs
+++ b/src/enrich/repository.mjs
@@ -9,6 +9,7 @@ import { sanitizeDiagnostic } from '../diagnostics.mjs';
 import { validateAssetBatch } from './assetBatch.mjs';
 import { EnrichTimingStore, TIMING_SCHEMA } from './timing.mjs';
 import { historyRetention } from './historyRetention.mjs';
+import { AiTagSyncStore, AI_TAG_SYNC_SCHEMA } from './aiTagSyncStore.mjs';
 import { DISCOVERY_SCHEMA } from './discovery.mjs';
 import { matchingRun, workEligibility } from './eligibility.mjs';
 import { ACTION_RULES } from './reviewActions.mjs';
@@ -509,6 +510,7 @@ const ENRICH_MIGRATIONS = [
     },
   },
   { version: 11, up(db) { db.exec(DISCOVERY_SCHEMA); } },
+  { version: 12, up(db) { db.exec(AI_TAG_SYNC_SCHEMA); } },
 ];
 
 // The review projection of a normalized output: exactly the fields the
@@ -592,6 +594,7 @@ export class Repository {
     preparePrivateDatabasePath(this.databasePath);
     this.db = new DatabaseSync(this.databasePath);
     this.timings = new EnrichTimingStore(this.db);
+    this.aiTagSync = new AiTagSyncStore(this.db);
     this.historyRetention = historyRetention();
     this.db.exec('PRAGMA journal_mode = WAL');
     // Decisions, tags, and captions are personal data: keep the DB (and its
@@ -605,7 +608,7 @@ export class Repository {
   }
 
   initSchema() {
-    const schemaSql = readFileSync(SCHEMA_PATH, 'utf8') + TIMING_SCHEMA + DISCOVERY_SCHEMA;
+    const schemaSql = readFileSync(SCHEMA_PATH, 'utf8') + TIMING_SCHEMA + DISCOVERY_SCHEMA + AI_TAG_SYNC_SCHEMA;
     const result = migrateDatabase(this.db, {
       schema: schemaSql,
       migrations: ENRICH_MIGRATIONS,

--- a/src/enrich/reviewService.mjs
+++ b/src/enrich/reviewService.mjs
@@ -26,13 +26,14 @@ const REMOTE_FETCH_CONCURRENCY = 8;
 const SYNC_ASSET_BATCH_SIZE = 50;
 
 export class ReviewService {
-  constructor({ repo, immich, taxonomy, config = null, log = () => {}, verifyDelayMs = 1500 }) {
+  constructor({ repo, immich, taxonomy, config = null, log = () => {}, verifyDelayMs = 1500, tagWrites = null }) {
     this.repo = repo;
     this.immich = immich;
     this.taxonomy = taxonomy;
     this.config = config;
     this.log = log;
     this.verifyDelayMs = verifyDelayMs;
+    this.tagWrites = tagWrites;
     this._syncWake = null;
     this._syncLastCompletedAt = null;
     this._syncWorkerRunning = false;
@@ -414,6 +415,11 @@ export class ReviewService {
   }
 
   async pushDecisionToImmich(job) {
+    if (this.tagWrites) return this.tagWrites.run(() => this.#pushDecisionToImmich(job), { priority: 2 });
+    return this.#pushDecisionToImmich(job);
+  }
+
+  async #pushDecisionToImmich(job) {
     if (job.assetIds.length > SYNC_ASSET_BATCH_SIZE) {
       throw new Error(`Review sync work exceeded the ${SYNC_ASSET_BATCH_SIZE}-asset worker slice.`);
     }
@@ -444,8 +450,7 @@ export class ReviewService {
   // a short settle and repair once; if it is still inconsistent, throw so the
   // durable queue retries the whole (idempotent) job. A never-show decision
   // must not complete while the remote photo is still eligible.
-  async verifyAndRepairTags(job) {
-    const localTagsByAsset = this.repo.loadAssetTagsFor(job.assetIds, { prefix: 'ai/' });
+  async verifyAndRepairTags(job, { localTagsByAsset = this.repo.loadAssetTagsFor(job.assetIds, { prefix: 'ai/' }), verifyAiRemovals = false } = {}) {
     const expectedByAsset = new Map(
       job.assetIds.map((assetId) => [assetId, [...(localTagsByAsset[assetId] ?? []), ...job.add]]),
     );
@@ -468,7 +473,10 @@ export class ReviewService {
         if (missing.length > 0) {
           missingByAsset.set(assetId, missing);
         }
-        const retained = job.remove.filter((tag) => remoteTags.has(tag));
+        const retained = [...new Set([
+          ...job.remove.filter((tag) => remoteTags.has(tag)),
+          ...(verifyAiRemovals ? [...remoteTags].filter(tag => tag.startsWith('ai/') && !(localTagsByAsset[assetId] ?? []).includes(tag)) : []),
+        ])];
         if (retained.length > 0) {
           retainedByAsset.set(assetId, retained);
           retainedTagIdsByAsset.set(
@@ -492,9 +500,12 @@ export class ReviewService {
             .map(([assetId, tags]) => `${assetId}: ${tags.join(', ')}`)
             .join(' | ')}`);
         }
-        throw new Error(
+        const error = new Error(
           `Immich did not retain all requested tags after a repair attempt. Confirm Tags is enabled for the API-key account and that the affected photos are owned by or writable to that account, then retry. ${problems.join(' | ')}`,
         );
+        error.code = 'immich_tag_inconsistent';
+        error.assetIds = [...new Set([...missingByAsset.keys(), ...retainedByAsset.keys()])];
+        throw error;
       }
       const inconsistentAssets = new Set([...missingByAsset.keys(), ...retainedByAsset.keys()]);
       this.log(`immich tag state is still inconsistent on ${inconsistentAssets.size} asset(s); repairing`);
@@ -524,8 +535,7 @@ export class ReviewService {
 
   // Reconcile ai/* tags in Immich with the local source of truth for the
   // decided assets: parallel reads, then one grouped write per tag.
-  async syncAiTagsForAssets(assetIds, knownTagIds) {
-    const localTagsByAsset = this.repo.loadAssetTagsFor(assetIds, { prefix: 'ai/' });
+  async syncAiTagsForAssets(assetIds, knownTagIds, { localTagsByAsset = this.repo.loadAssetTagsFor(assetIds, { prefix: 'ai/' }), remoteAssets = null } = {}) {
     const allLocalTags = [...new Set(assetIds.flatMap((assetId) => localTagsByAsset[assetId] ?? []))].sort();
     const tagIds = { ...knownTagIds };
     if (allLocalTags.length > 0) {
@@ -533,7 +543,7 @@ export class ReviewService {
     }
 
     const remoteMaps = await mapWithConcurrency(assetIds, REMOTE_FETCH_CONCURRENCY, async (assetId) => {
-      const remoteAsset = await this.immich.getAsset(assetId);
+      const remoteAsset = remoteAssets?.get(assetId) ?? await this.immich.getAsset(assetId);
       return tagMap(Array.isArray(remoteAsset?.tags) ? remoteAsset.tags : []);
     });
 

--- a/src/enrich/runConfiguration.mjs
+++ b/src/enrich/runConfiguration.mjs
@@ -83,6 +83,7 @@ export function captureRunConfiguration({
       reprocess: processing.reprocess === true,
       maxFailuresPerAsset: processing.maxFailuresPerAsset ?? 2,
       retryFailureLimited: processing.retryFailureLimited === true,
+      syncAiTags: processing.syncAiTags === true,
       applyTags: processing.applyTags === true,
       dryRun: processing.dryRun !== false,
       listForReview: processing.listForReview === true,

--- a/src/enrich/runner.mjs
+++ b/src/enrich/runner.mjs
@@ -214,6 +214,8 @@ async function executeBatch({
   applyTags = false,
   dryRun = true,
   listForReview = false,
+  syncAiTags = false,
+  onTagsQueued = () => {},
   captionWriteback = false,
   shouldStop = () => false,
   log = () => {},
@@ -482,6 +484,7 @@ async function executeBatch({
             model: provider.modelName,
             taxonomyVersion: taxonomy.version,
           });
+          if (syncAiTags) repo.aiTagSync.enqueue(assetId, processingRunId);
           let listed = 0;
           if (listForReview) {
             // "Send to Curate" on: each photo joins the review queue as it
@@ -495,6 +498,11 @@ async function executeBatch({
           }
           return listed;
         });
+        if (syncAiTags) {
+          // Waking is best effort; the durable worker also polls after restart.
+          try { onTagsQueued(); } catch {}
+          log('  AI tags queued for Immich');
+        }
         photoOutcome = 'succeeded';
         assetDecisions[assetId] = decisions;
         counters.succeeded += 1;
@@ -587,6 +595,8 @@ async function executeBatch({
   if (applyTags && !dryRun) {
     await syncTagDecisions(immich, assetDecisions);
     log('applied mapped tags to Immich');
+  } else if (syncAiTags) {
+    log('AI tag sync continues in the background; see Immich tag sync on Enrich.');
   } else {
     log('dry run complete; no Immich tags were written');
   }

--- a/src/enrich/tagWriteCoordinator.mjs
+++ b/src/enrich/tagWriteCoordinator.mjs
@@ -1,0 +1,22 @@
+// One in-process tag mutation boundary. Human actions jump ahead of queued
+// background slices; network work already in flight is never interrupted.
+export class TagWriteCoordinator {
+  #busy = false;
+  #waiting = [];
+
+  async run(work, { priority = 1 } = {}) {
+    await new Promise(resolve => {
+      this.#waiting.push({ priority, resolve });
+      this.#next();
+    });
+    try { return await work(); }
+    finally { this.#busy = false; this.#next(); }
+  }
+
+  #next() {
+    if (this.#busy || !this.#waiting.length) return;
+    this.#waiting.sort((a, b) => b.priority - a.priority);
+    this.#busy = true;
+    this.#waiting.shift().resolve();
+  }
+}

--- a/src/routes/enrich.mjs
+++ b/src/routes/enrich.mjs
@@ -89,7 +89,7 @@ function runPageLimit(value) {
   return limit;
 }
 
-export function createEnrichRoutes({ review, enrichRunner, taxonomy, profiles = null, repo, requireImmich, config, immich, captionWriteback, referee, activityLog = null }) {
+export function createEnrichRoutes({ review, aiTagSync = null, enrichRunner, taxonomy, profiles = null, repo, requireImmich, config, immich, captionWriteback, referee, activityLog = null }) {
   const diagnostic = (value) => sanitizeDiagnostic(value instanceof Error ? value.message : value, {
     secrets: configuredSecrets(config, immich),
   });
@@ -466,11 +466,18 @@ export function createEnrichRoutes({ review, enrichRunner, taxonomy, profiles = 
       return true;
     }
 
+    if (request.method === 'POST' && url.pathname === '/api/enrich/tag-sync/retry' && aiTagSync) {
+      await readJsonBody(request);
+      sendJson(response, 200, { requeued: aiTagSync.retry(), sync: aiTagSync.status() });
+      return true;
+    }
+
     if (request.method === 'GET' && url.pathname === '/api/enrich/status') {
       sendJson(response, 200, {
         ...enrichRunner.status(),
         enabled: config.enrichEnabled,
         resolvingSlice: sliceResolutions > 0,
+        tagSync: aiTagSync?.status() ?? null,
         library: repo.libraryStats(),
       });
       return true;

--- a/src/routes/voice.mjs
+++ b/src/routes/voice.mjs
@@ -50,7 +50,8 @@ function voiceProseBudgetMs(config) {
   return Math.min(Number.isFinite(configured) && configured > 0 ? configured : 25000, MAX_VOICE_PROSE_BUDGET_MS);
 }
 
-export function createVoiceRoutes({ immich, config, requireImmich, voiceMetrics = null, activityLog = null }) {
+export function createVoiceRoutes({ immich, config, requireImmich, voiceMetrics = null, activityLog = null, tagWrites = null }) {
+  const withTagWrite = work => tagWrites ? tagWrites.run(work, { priority: 2 }) : work();
   const voiceConfig = config.voice;
   const ambientConfig = config.ambient;
   const promptsConfig = config.prompts ?? {};
@@ -281,16 +282,18 @@ export function createVoiceRoutes({ immich, config, requireImmich, voiceMetrics 
       }
       const assetId = decodeURIComponent(favoriteMatch[1]);
       try {
-        const tags = await immich.upsertTags([FRAME_FAVORITE_TAG]);
-        const favoriteTag = findFrameTag(tags, FRAME_FAVORITE_TAG);
-        if (!favoriteTag?.id) {
-          activityLog?.assetFavorited({ assetId, outcome: 'failed' });
-          sendError(response, 502, 'favorite_tag_missing', 'Immich did not return the favorite tag ID.');
-          return true;
-        }
-        await immich.tagAssetsBulk({ tagIds: [favoriteTag.id], assetIds: [assetId] });
-        activityLog?.assetFavorited({ assetId });
-        sendJson(response, 200, { assetId, tag: favoriteTag });
+        await withTagWrite(async () => {
+          const tags = await immich.upsertTags([FRAME_FAVORITE_TAG]);
+          const favoriteTag = findFrameTag(tags, FRAME_FAVORITE_TAG);
+          if (!favoriteTag?.id) {
+            activityLog?.assetFavorited({ assetId, outcome: 'failed' });
+            sendError(response, 502, 'favorite_tag_missing', 'Immich did not return the favorite tag ID.');
+            return true;
+          }
+          await immich.tagAssetsBulk({ tagIds: [favoriteTag.id], assetIds: [assetId] });
+          activityLog?.assetFavorited({ assetId });
+          sendJson(response, 200, { assetId, tag: favoriteTag });
+        });
       } catch (error) {
         activityLog?.assetFavorited({ assetId, outcome: 'failed' });
         throw error;
@@ -305,26 +308,28 @@ export function createVoiceRoutes({ immich, config, requireImmich, voiceMetrics 
       }
       const assetId = decodeURIComponent(neverShowMatch[1]);
       try {
-        const tags = await immich.upsertTags([FRAME_NEVER_SHOW_TAG]);
-        const neverShowTag = findFrameTag(tags, FRAME_NEVER_SHOW_TAG);
-        if (!neverShowTag?.id) {
-          activityLog?.assetHidden({ assetId, outcome: 'failed' });
-          sendError(response, 502, 'never_show_tag_missing', 'Immich did not return the never-show tag ID.');
-          return true;
-        }
-        await immich.tagAssetsBulk({ tagIds: [neverShowTag.id], assetIds: [assetId] });
+        await withTagWrite(async () => {
+          const tags = await immich.upsertTags([FRAME_NEVER_SHOW_TAG]);
+          const neverShowTag = findFrameTag(tags, FRAME_NEVER_SHOW_TAG);
+          if (!neverShowTag?.id) {
+            activityLog?.assetHidden({ assetId, outcome: 'failed' });
+            sendError(response, 502, 'never_show_tag_missing', 'Immich did not return the never-show tag ID.');
+            return true;
+          }
+          await immich.tagAssetsBulk({ tagIds: [neverShowTag.id], assetIds: [assetId] });
 
-        const allTags = await immich.listTags();
-        const eligibleTag = findFrameTag(allTags, FRAME_ELIGIBLE_TAG);
-        if (eligibleTag?.id) {
-          await immich.untagAssets({ tagId: eligibleTag.id, assetIds: [assetId] });
-        }
+          const allTags = await immich.listTags();
+          const eligibleTag = findFrameTag(allTags, FRAME_ELIGIBLE_TAG);
+          if (eligibleTag?.id) {
+            await immich.untagAssets({ tagId: eligibleTag.id, assetIds: [assetId] });
+          }
 
-        activityLog?.assetHidden({ assetId });
-        sendJson(response, 200, {
-          addedTag: neverShowTag,
-          assetId,
-          removedTag: eligibleTag ?? null,
+          activityLog?.assetHidden({ assetId });
+          sendJson(response, 200, {
+            addedTag: neverShowTag,
+            assetId,
+            removedTag: eligibleTag ?? null,
+          });
         });
       } catch (error) {
         activityLog?.assetHidden({ assetId, outcome: 'failed' });

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -13,6 +13,8 @@ import { isImmichVersionSupported, parseImmichVersion } from './immichCompatibil
 import { Repository } from './enrich/repository.mjs';
 import { ReviewService } from './enrich/reviewService.mjs';
 import { backfillAssetVisuals } from './enrich/visualBackfill.mjs';
+import { TagWriteCoordinator } from './enrich/tagWriteCoordinator.mjs';
+import { AiTagSyncService } from './enrich/aiTagSync.mjs';
 import { CaptionWritebackService } from './enrich/captionWriteback.mjs';
 import { RefereeService } from './enrich/refereeService.mjs';
 import { EnrichJobRunner } from './enrich/jobRunner.mjs';
@@ -133,6 +135,7 @@ settingsStore.onApplied = () => {
   immichPing = emptyImmichStatus();
   enrichScheduler.settingsChanged();
   captionWriteback.wake();
+  aiTagSync.wake();
   // First-time setup: the moment Immich becomes reachable, populate
   // Insights instead of waiting for the hourly staleness check. A no-op
   // whenever the snapshot is fresh or Immich is still unconfigured.
@@ -177,9 +180,11 @@ const immich = new ImmichClient({
   apiKey: config.immichApiKey,
   timeoutMs: config.requestTimeoutMs,
 });
-const review = new ReviewService({ repo, immich, taxonomy, config, log: (message) => console.log(`[Pictaria] ${message}`) });
+const tagWrites = new TagWriteCoordinator();
+const review = new ReviewService({ repo, immich, taxonomy, config, tagWrites, log: (message) => console.log(`[Pictaria] ${message}`) });
 const captionWriteback = new CaptionWritebackService({ repo, immich, config, log: (message) => console.log(`[Pictaria] ${message}`) });
-const enrichRunner = new EnrichJobRunner({ repo, immich, taxonomy, config, profiles });
+const aiTagSync = new AiTagSyncService({ repo, immich, review, tagWrites, config, log: message => console.log(`[Pictaria] ${message}`) });
+const enrichRunner = new EnrichJobRunner({ repo, immich, taxonomy, config, profiles, onTagsQueued: () => aiTagSync.wake() });
 const enrichScheduler = new EnrichScheduler({ runner: enrichRunner, repo, config });
 const referee = new RefereeService({ repo, immich, review, enrichRunner, config, log: (message) => console.log(`[Pictaria] ${message}`) });
 const albumStore = new SmartAlbumStore(config.albums.dataFile, { installationSecret });
@@ -204,6 +209,7 @@ const insightsCollector = new InsightsCollector({
 
 review.startSyncWorker();
 captionWriteback.start();
+aiTagSync.start();
 referee.start();
 // Near-dup grouping needs thumbhashes; fill rows that predate the columns
 // once Immich is reachable. No-op after the first complete pass. The pass
@@ -281,6 +287,7 @@ lifecycle.setTimeout(scheduleBackupTick, 60000);
 // the 5s force-exit guard in shutdown(). stop(timeoutMs) resolves within its
 // budget; false means "gave up waiting" and gets warned by name.
 lifecycle.register('review-sync', 3000, (timeoutMs) => review.stopSyncWorker(timeoutMs));
+lifecycle.register('ai-tag-sync', 3000, timeoutMs => aiTagSync.stop(timeoutMs));
 lifecycle.register('caption-writeback', 3000, (timeoutMs) => captionWriteback.stop(timeoutMs));
 lifecycle.register('enrich-runner', 3000, (timeoutMs) => enrichRunner.stop(timeoutMs));
 lifecycle.register('enrich-scheduler', 3000, () => enrichScheduler.stop());
@@ -297,11 +304,11 @@ lifecycle.register('thumbhash-backfill', 3000, (timeoutMs) => awaitDrain(thumbha
 
 const features = [
   createActivityRoutes({ activityHistory }),
-  createEnrichRoutes({ review, enrichRunner, taxonomy, profiles, repo, requireImmich, config, immich, captionWriteback, referee, activityLog }),
+  createEnrichRoutes({ review, aiTagSync, enrichRunner, taxonomy, profiles, repo, requireImmich, config, immich, captionWriteback, referee, activityLog }),
   createAlbumsRoutes({ immich, store: albumStore, config, requireImmich, enrichRepo: repo }),
   createWakeWordRoutes({ store: wakeWordModels }),
   createFrameRoutes({ immich, frameHub, frameLedger, requireImmich, voiceMetrics, activityLog }),
-  createVoiceRoutes({ immich, config, requireImmich, voiceMetrics, activityLog }),
+  createVoiceRoutes({ immich, config, tagWrites, requireImmich, voiceMetrics, activityLog }),
   createAmbientRoutes({ config }),
   createInsightsRoutes({ collector: insightsCollector, repo: insightsRepo, immich, config, settingsStore, requireImmich }),
   createSettingsRoutes({ settingsStore, profiles }),

--- a/src/upgradeSafety.mjs
+++ b/src/upgradeSafety.mjs
@@ -4,7 +4,7 @@ import { backupTargets, readSnapshotStatus, runBackup } from './backup.mjs';
 
 // Bump only when a release changes a persisted contract and therefore needs
 // a pre-migration recovery point. Ordinary server releases keep this value.
-export const PERSISTENT_STATE_VERSION = 14;
+export const PERSISTENT_STATE_VERSION = 15;
 
 export class UpgradeSafetyError extends Error {
   constructor(message, { code = 'upgrade_safety_error' } = {}) {

--- a/test/browser/aiTagSync.test.mjs
+++ b/test/browser/aiTagSync.test.mjs
@@ -1,0 +1,70 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { sampleOutput } from '../enrich/helpers.mjs';
+import { bootServer, findChrome, launchChrome } from './harness.mjs';
+
+// Real dashboard -> production routes/job runner -> provider -> durable
+// worker -> fake Immich. No private library or provider credentials used.
+test('Enrich-only success survives tag outage and the Enrich retry button syncs without another AI call', { timeout: 60000 }, async t => {
+  if (!findChrome()) return t.skip('Chrome required');
+  const dir = mkdtempSync(join(tmpdir(), 'pic347-browser-'));
+  const assetId = '00000000-0000-0000-0000-000000000001';
+  let server, browser, allowTags = false, inferenceCalls = 0;
+  const tags = new Set(); const photoTags = new Set(['frame/never-show', 'holiday']);
+  const fake = createServer(async (request, response) => {
+    const path = new URL(request.url, 'http://fake').pathname;
+    let body = ''; for await (const chunk of request) body += chunk;
+    const input = body ? JSON.parse(body) : {};
+    const json = (value, status = 200) => { response.writeHead(status, { 'Content-Type': 'application/json' }); response.end(JSON.stringify(value)); };
+    if (path.endsWith('/chat/completions')) { inferenceCalls++; return json({ choices: [{ message: { content: JSON.stringify(sampleOutput()) } }] }); }
+    if (path.includes('/thumbnail')) { response.writeHead(200, { 'Content-Type': 'image/jpeg' }); return response.end(Buffer.from('synthetic photo')); }
+    if (path === `/api/assets/${assetId}`) return json({ id: assetId, type: 'IMAGE', isArchived: false, isTrashed: false, tags: [...photoTags].map(value => ({ id: value, value })) });
+    if (path.startsWith('/api/tags')) {
+      if (!allowTags) return json({ message: 'Synthetic tag-service outage' }, 503);
+      if (path === '/api/tags' && request.method === 'GET') return json([...tags].map(value => ({ id: value, value })));
+      if (path === '/api/tags' && request.method === 'PUT') { input.tags.forEach(tag => tags.add(tag)); return json(input.tags.map(value => ({ id: value, value }))); }
+      if (path === '/api/tags/assets') { input.tagIds.forEach(tag => photoTags.add(tag)); return json({ count: 1 }); }
+    }
+    if (path === '/api/server/version') return json({ major: 3, minor: 1, patch: 0 });
+    if (path === '/api/server/ping') return json({ res: 'pong' });
+    return json([]);
+  });
+  await new Promise(resolve => fake.listen(0, '127.0.0.1', resolve));
+  t.after(async () => {
+    await Promise.allSettled([browser?.stop(), server?.stop()]);
+    fake.closeAllConnections(); await new Promise(resolve => fake.close(resolve));
+    rmSync(dir, { recursive: true, force: true });
+  });
+  const base = `http://127.0.0.1:${fake.address().port}`;
+  server = await bootServer(dir, { env: { ENRICH_ENABLED: 'true', IMMICH_BASE_URL: base, IMMICH_API_KEY: 'synthetic',
+    DEFAULT_PROVIDER: 'local_lmstudio', LMSTUDIO_BASE_URL: `${base}/v1`, LMSTUDIO_MODEL: 'synthetic-model' } });
+  browser = await launchChrome(); const page = await browser.newPage();
+  await page.navigate(`${server.base}/enrich.html`);
+  await page.waitFor('document.querySelector(".gate-backdrop input")');
+  await page.evaluate('document.querySelector(".gate-backdrop input").value="smoke-secret"; document.querySelector(".gate-backdrop button").click()');
+  await page.waitFor('!document.querySelector(".gate-backdrop")');
+  const result = await page.evaluate(`(async()=>{const r=await fetch('/api/enrich/run',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({provider:'local_lmstudio',assetIds:['${assetId}'],sendToCurate:false})});return {status:r.status,body:await r.json()}})()`);
+  assert.equal(result.status, 202, JSON.stringify(result));
+  await page.waitFor('document.getElementById("tagSyncStatus").textContent.includes("1 pending") && !document.getElementById("tagSyncRetry").hidden');
+  assert.equal(inferenceCalls, 1);
+  const succeeded = await page.evaluate("(async()=>{const s=await(await fetch('/api/enrich/status')).json();return s.liveCounters.succeeded})()");
+  assert.equal(succeeded, 1);
+  allowTags = true; await page.evaluate('document.getElementById("tagSyncRetry").click()');
+  try {
+  await page.waitFor('document.getElementById("tagSyncStatus").textContent.includes("0 pending") && document.getElementById("tagSyncRetry").hidden');
+  } catch (error) {
+    t.diagnostic(JSON.stringify(await page.evaluate("(async()=>({sync:(await(await fetch('/api/enrich/status')).json()).tagSync, text:document.getElementById('tagSyncError').textContent}))()")));
+    throw error;
+  }
+  assert.equal(inferenceCalls, 1);
+  assert.ok(photoTags.has('ai/scene/mountains')); assert.ok(photoTags.has('frame/never-show')); assert.ok(photoTags.has('holiday'));
+  assert.ok(!photoTags.has('frame/eligible'));
+  if (process.env.PICTARIA_SYNC_SCREENSHOT) {
+    const screenshot = await page.send('Page.captureScreenshot', { format: 'png' });
+    writeFileSync(process.env.PICTARIA_SYNC_SCREENSHOT, Buffer.from(screenshot.data, 'base64'));
+  }
+});

--- a/test/browser/aiTagSync.test.mjs
+++ b/test/browser/aiTagSync.test.mjs
@@ -50,6 +50,7 @@ test('Enrich-only success survives tag outage and the Enrich retry button syncs 
   const result = await page.evaluate(`(async()=>{const r=await fetch('/api/enrich/run',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({provider:'local_lmstudio',assetIds:['${assetId}'],sendToCurate:false})});return {status:r.status,body:await r.json()}})()`);
   assert.equal(result.status, 202, JSON.stringify(result));
   await page.waitFor('document.getElementById("tagSyncStatus").textContent.includes("1 pending") && !document.getElementById("tagSyncRetry").hidden');
+  assert.match(await page.evaluate('document.getElementById("tagSyncError").textContent'), /^Immich:/);
   assert.equal(inferenceCalls, 1);
   const succeeded = await page.evaluate("(async()=>{const s=await(await fetch('/api/enrich/status')).json();return s.liveCounters.succeeded})()");
   assert.equal(succeeded, 1);

--- a/test/browser/harness.mjs
+++ b/test/browser/harness.mjs
@@ -4,6 +4,7 @@ import { createServer } from 'node:http';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { terminateTestProcess } from './processCleanup.mjs';
 
 // Zero-dependency headless-browser harness: system Chrome/Chromium driven
 // over raw CDP with Node's builtin WebSocket client. No npm packages — the
@@ -155,24 +156,15 @@ export async function launchChrome() {
   let stopPromise;
   function stopChrome() {
     stopPromise ??= (async () => {
-      const parentRunning = child.exitCode === null && child.signalCode === null;
-      const parentExit = parentRunning
-        ? new Promise((resolveExit) => child.once('exit', resolveExit))
-        : null;
-      try {
-        if (hasProcessGroup) {
-          process.kill(-child.pid, 'SIGKILL');
-        } else if (parentRunning) {
-          child.kill('SIGKILL');
-        }
-      } catch (error) {
-        if (error?.code !== 'ESRCH') {
-          throw error;
-        }
-      }
-      if (parentExit) {
-        await parentExit;
-      }
+      await terminateTestProcess(child, {
+        kill() {
+          if (hasProcessGroup) {
+            process.kill(-child.pid, 'SIGKILL');
+          } else if (child.exitCode === null && child.signalCode === null) {
+            child.kill('SIGKILL');
+          }
+        },
+      });
       // Chrome's Linux subprocesses can finish touching profile files just
       // after the parent exits. Node's bounded ENOTEMPTY retry handles that
       // documented rimraf race without hiding a persistent cleanup failure.

--- a/test/browser/processCleanup.mjs
+++ b/test/browser/processCleanup.mjs
@@ -1,0 +1,31 @@
+import { awaitDrain } from '../../src/lifecycle.mjs';
+
+// Killing a detached Chrome group does not guarantee Node delivers the
+// parent's exit event. Never let a missed event hang browser-test teardown.
+export async function terminateTestProcess(child, {
+  kill,
+  timeoutMs = 3000,
+  warn = message => console.warn(message),
+}) {
+  const running = child.exitCode === null && child.signalCode === null;
+  let onExit;
+  const exited = running ? new Promise(resolve => {
+    onExit = resolve;
+    child.once('exit', onExit);
+  }) : null;
+  try {
+    // Still kill the group if the parent already exited: helpers can remain.
+    try { kill(); }
+    catch (error) { if (error?.code !== 'ESRCH') throw error; }
+    if (exited && !await awaitDrain(exited, timeoutMs)) {
+      warn('Browser test cleanup: Chrome exit was not observed within the shutdown deadline; continuing cleanup after SIGKILL.');
+    }
+    // Chrome helpers can retain stderr even AFTER the parent's exit event.
+    // Closing this test-owned pipe lets Node retire the ChildProcess handles
+    // rather than waiting for EOF from an orphaned helper.
+    child.stderr?.destroy();
+    child.unref();
+  } finally {
+    if (onExit) child.removeListener('exit', onExit);
+  }
+}

--- a/test/browser/processCleanup.test.mjs
+++ b/test/browser/processCleanup.test.mjs
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { terminateTestProcess } from './processCleanup.mjs';
+
+function fakeChild() {
+  const child = new EventEmitter();
+  Object.assign(child, { exitCode: null, signalCode: null, released: false, stderrClosed: false });
+  child.unref = () => { child.released = true; };
+  child.stderr = { destroy: () => { child.stderrClosed = true; } };
+  return child;
+}
+
+test('Chrome cleanup observes an exit delivered during the kill and removes its listener', async () => {
+  const child = fakeChild(); const warnings = [];
+  await terminateTestProcess(child, { kill: () => child.emit('exit', null, 'SIGKILL'), warn: message => warnings.push(message) });
+  assert.equal(child.listenerCount('exit'), 0);
+  assert.equal(child.released, true); assert.equal(child.stderrClosed, true);
+  assert.deepEqual(warnings, []);
+});
+
+test('a missing Chrome exit event has a bounded wait and releases only test-owned handles', { timeout: 1000 }, async () => {
+  const child = fakeChild(); const warnings = [];
+  await terminateTestProcess(child, { kill() {}, timeoutMs: 10, warn: message => warnings.push(message) });
+  assert.equal(child.released, true); assert.equal(child.stderrClosed, true);
+  assert.equal(child.listenerCount('exit'), 0);
+  assert.equal(warnings.length, 1); assert.match(warnings[0], /continuing cleanup after SIGKILL/);
+});
+
+test('Chrome group cleanup still runs after the parent exits; ESRCH is harmless', async () => {
+  const child = fakeChild(); child.exitCode = 0; let killed = false;
+  await terminateTestProcess(child, { kill() { killed = true; throw Object.assign(new Error('gone'), { code: 'ESRCH' }); } });
+  assert.equal(killed, true); assert.equal(child.listenerCount('exit'), 0); assert.equal(child.released, true);
+  assert.equal(child.stderrClosed, true);
+});
+
+test('Chrome cleanup does not conceal an actual kill failure', async () => {
+  const child = fakeChild(); const denied = Object.assign(new Error('denied'), { code: 'EPERM' });
+  await assert.rejects(terminateTestProcess(child, { kill() { throw denied; } }), error => error === denied);
+  assert.equal(child.released, false); assert.equal(child.listenerCount('exit'), 0);
+});

--- a/test/enrich/aiTagSync.test.mjs
+++ b/test/enrich/aiTagSync.test.mjs
@@ -1,0 +1,192 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Repository } from '../../src/enrich/repository.mjs';
+import { ReviewService } from '../../src/enrich/reviewService.mjs';
+import { AiTagSyncService } from '../../src/enrich/aiTagSync.mjs';
+import { TagWriteCoordinator } from '../../src/enrich/tagWriteCoordinator.mjs';
+import { ImmichApiError } from '../../src/immich.mjs';
+import { runBatch } from '../../src/enrich/runner.mjs';
+import { loadV1Taxonomy, sampleOutput } from './helpers.mjs';
+
+const id = n => `00000000-0000-0000-0000-${String(n).padStart(12, '0')}`;
+const taxonomy = loadV1Taxonomy();
+const deferred = () => { let resolve; const promise = new Promise(r => { resolve = r; }); return { promise, resolve }; };
+
+class Immich {
+  tags = new Map();
+  photos = new Map();
+  calls = [];
+  error = null;
+  onWrite = null;
+  dropRemoval = false;
+  async getAsset(assetId) {
+    this.calls.push(['get', assetId]);
+    if (this.error) throw this.error;
+    if (!this.photos.has(assetId)) throw new ImmichApiError('gone', 404);
+    return { id: assetId, type: 'IMAGE', tags: [...this.photos.get(assetId)].map(value => ({ id: value, value })) };
+  }
+  async getAssetThumbnail() { return { data: Buffer.from('photo'), contentType: 'image/jpeg' }; }
+  async listTags() { this.calls.push(['list']); return [...this.tags].map(([value]) => ({ id: value, value })); }
+  async upsertTags(tags) { for (const tag of tags) this.tags.set(tag, tag); return tags.map(value => ({ id: value, value })); }
+  async tagAssetsBulk({ assetIds, tagIds }) {
+    this.calls.push(['add', assetIds, tagIds]);
+    await this.onWrite?.();
+    for (const assetId of assetIds) for (const tag of tagIds) this.photos.get(assetId).add(tag);
+  }
+  async untagAssets({ assetIds, tagId }) {
+    this.calls.push(['remove', assetIds, tagId]);
+    if (!this.dropRemoval) for (const assetId of assetIds) this.photos.get(assetId).delete(tagId);
+  }
+}
+
+async function fixture(work) {
+  const dir = mkdtempSync(join(tmpdir(), 'pic347-'));
+  const repo = new Repository(join(dir, 'enrichment.sqlite')); repo.initSchema();
+  const immich = new Immich(); const config = { enrichEnabled: true };
+  const tagWrites = new TagWriteCoordinator();
+  const review = new ReviewService({ repo, immich, taxonomy, config, tagWrites, verifyDelayMs: 0 });
+  const sync = new AiTagSyncService({ repo, immich, review, config, tagWrites }); sync.stopped = false;
+  function seed(n, tags = ['ai/scene/mountains']) {
+    const assetId = id(n); repo.upsertAsset({ id: assetId });
+    if (!immich.photos.has(assetId)) immich.photos.set(assetId, new Set());
+    const runId = repo.recordProcessingRun({ assetId, provider: 'test', model: 'test', promptVersion: 'v1', taxonomyVersion: 'v1', status: 'succeeded', normalizedOutput: sampleOutput() });
+    repo.replaceAssetTags({ assetId, decisions: tags.map(tag => ({ tag, source: 'ai', confidence: 1, reason: 'test' })), model: 'test', taxonomyVersion: 'v1' });
+    repo.aiTagSync.enqueue(assetId, runId); return assetId;
+  }
+  try { await work({ repo, immich, sync, review, config, tagWrites, seed, dir }); }
+  finally { await sync.stop(); repo.close(); rmSync(dir, { recursive: true, force: true }); }
+}
+
+test('AI sync reconciles stale tags, preserves frame and user tags, and makes no Curate decision', async () => {
+  await fixture(async ({ repo, immich, sync, seed }) => {
+    const assetId = seed(1); immich.photos.get(assetId).add('ai/scene/old'); immich.photos.get(assetId).add('frame/never-show'); immich.photos.get(assetId).add('holiday');
+    await sync.tick();
+    assert.deepEqual([...immich.photos.get(assetId)].sort(), ['ai/scene/mountains', 'frame/never-show', 'holiday']);
+    assert.equal(repo.aiTagSync.status().written, 1);
+    assert.equal(repo.pendingSyncJobCount(), 0);
+    assert.equal(repo.db.prepare('SELECT COUNT(*) n FROM manual_overrides').get().n, 0);
+    assert.equal(repo.db.prepare('SELECT COUNT(*) n FROM review_list').get().n, 0);
+  });
+});
+
+test('new enrichment during an HTTP write survives stale completion and converges to latest tags', async () => {
+  await fixture(async ({ immich, sync, seed, repo }) => {
+    const assetId = seed(1); const entered = deferred(); const release = deferred();
+    immich.onWrite = async () => { entered.resolve(); await release.promise; };
+    const first = sync.tick(); await entered.promise;
+    seed(1, ['ai/scene/water']); release.resolve(); await first;
+    assert.equal(repo.aiTagSync.status().pending, 1);
+    immich.onWrite = null; await sync.tick();
+    assert.deepEqual([...immich.photos.get(assetId)], ['ai/scene/water']);
+    assert.equal(repo.aiTagSync.status().written, 1);
+  });
+});
+
+test('outage pauses only AI sync; Curate decisions can still be recorded and sent during backoff', async () => {
+  await fixture(async ({ seed, immich, repo, sync, review }) => {
+    for (let n = 1; n <= 30; n++) seed(n);
+    immich.error = new ImmichApiError('permission unavailable', 403);
+    await sync.tick();
+    assert.equal(repo.aiTagSync.status().pending, 30); assert.equal(repo.aiTagSync.status().failed, 0);
+    assert.equal(repo.pendingSyncJobCount(), 0);
+    assert.equal(repo.db.prepare('SELECT SUM(attempts) n FROM ai_tag_sync').get().n, 0);
+    repo.reviewListAdd([id(1)], 'test'); review.applyDecision({ action: 'favorite', assetIds: [id(1)] });
+    immich.error = null; await review.pushDecisionToImmich(repo.nextSyncJob());
+    assert.ok(immich.photos.get(id(1)).has('frame/favorite'));
+    assert.equal(await sync.tick(), false); // still in AI backoff
+    sync.retry(); await sync.tick(); assert.equal(repo.aiTagSync.status().written, 10);
+  });
+});
+
+test('human work has priority between AI slices and never overlaps tag writes', async () => {
+  const lock = new TagWriteCoordinator(); const entered = deferred(); const release = deferred(); const order = [];
+  const first = lock.run(async () => { order.push('ai1'); entered.resolve(); await release.promise; order.push('ai1 done'); }, { priority: 0 });
+  await entered.promise;
+  const second = lock.run(() => { order.push('ai2'); }, { priority: 0 });
+  const human = lock.run(() => { order.push('decision'); }, { priority: 2 });
+  release.resolve(); await Promise.all([first, second, human]);
+  assert.deepEqual(order, ['ai1', 'ai1 done', 'decision', 'ai2']);
+});
+
+test('deleted photo is skipped; disabled Enrich pauses and a slice is bounded', async () => {
+  await fixture(async ({ seed, immich, sync, repo, config }) => {
+    for (let n = 1; n <= 25; n++) seed(n);
+    immich.photos.delete(id(1)); config.enrichEnabled = false;
+    assert.equal(await sync.tick(), false); assert.equal(immich.calls.length, 0);
+    config.enrichEnabled = true; await sync.tick();
+    assert.equal(repo.aiTagSync.status().skipped, 1); assert.equal(repo.aiTagSync.status().written, 9); assert.equal(repo.aiTagSync.status().pending, 15);
+    assert.equal(immich.calls.filter(c => c[0] === 'list').length, 1);
+  });
+});
+
+test('a silently dropped removal is verified and never acknowledged as synced', async () => {
+  await fixture(async ({ seed, immich, repo, sync }) => {
+    const assetId = seed(1); immich.photos.get(assetId).add('ai/scene/old'); immich.dropRemoval = true;
+    await sync.tick(); assert.equal(repo.aiTagSync.status().written, 0); assert.equal(repo.aiTagSync.status().pending, 1);
+    assert.match(repo.aiTagSync.status().lastError, /Still present/);
+    immich.dropRemoval = false; sync.retry(); await sync.tick();
+    assert.equal(repo.aiTagSync.status().written, 1);
+  });
+});
+
+test('pending work and backoff survive database reopen; stale failure cannot fail a newer generation', async () => {
+  await fixture(async ({ seed, repo, dir }) => {
+    seed(1); const old = repo.aiTagSync.next()[0]; seed(1, ['ai/scene/water']);
+    repo.aiTagSync.failure(old, 'old failure'); repo.aiTagSync.mark(old, 'written');
+    repo.aiTagSync.defer('temporary outage', Date.now() + 30000);
+    const reopened = new Repository(join(dir, 'enrichment.sqlite')); reopened.initSchema();
+    try {
+      assert.equal(reopened.aiTagSync.status().pending, 1); assert.equal(reopened.aiTagSync.next()[0].attempts, 0);
+      assert.match(reopened.aiTagSync.status().lastError, /temporary outage/);
+    } finally { reopened.close(); }
+  });
+});
+
+for (const listForReview of [false, true]) test(`each successful photo queues tags before the batch ends (Send to Curate ${listForReview})`, async () => {
+  await fixture(async ({ repo, immich, sync }) => {
+    for (const n of [1, 2]) immich.photos.set(id(n), new Set());
+    const entered = deferred(); const release = deferred(); let calls = 0;
+    const provider = { providerName: 'local_lmstudio', modelName: 'test', async analyzeImage() {
+      if (++calls === 2) { entered.resolve(); await release.promise; }
+      return { normalizedOutput: sampleOutput() };
+    } };
+    const running = runBatch({ immich, repo, provider, taxonomy, systemPrompt: 'test', userTemplate: '{approved_tags}',
+      assetIds: [id(1), id(2)], limit: 2, syncAiTags: true, listForReview });
+    await entered.promise;
+    try {
+      assert.equal(repo.aiTagSync.status().pending, 1);
+      await sync.tick(); assert.ok(immich.photos.get(id(1)).has('ai/scene/mountains'));
+      assert.equal(repo.db.prepare('SELECT COUNT(*) n FROM review_list').get().n, listForReview ? 1 : 0);
+    } finally { release.resolve(); }
+    const result = await running; assert.equal(result.counters.succeeded, 2); assert.equal(repo.aiTagSync.status().pending, 1);
+  });
+});
+
+test('curating the same photo during AI write preserves the decision and completes both operations', async () => {
+  await fixture(async ({ seed, repo, immich, sync, review }) => {
+    const assetId = seed(1); repo.reviewListAdd([assetId], 'test');
+    const entered = deferred(); const release = deferred();
+    immich.onWrite = async () => { entered.resolve(); await release.promise; };
+    const ai = sync.tick(); await entered.promise;
+    review.applyDecision({ action: 'reject', assetIds: [assetId] });
+    const decision = review.pushDecisionToImmich(repo.nextSyncJob());
+    release.resolve(); await Promise.all([ai, decision]);
+    assert.ok(immich.photos.get(assetId).has('frame/never-show'));
+    assert.ok(!immich.photos.get(assetId).has('frame/eligible'));
+    assert.ok(immich.photos.get(assetId).has('ai/scene/mountains'));
+    assert.equal(repo.aiTagSync.status().written, 1);
+  });
+});
+
+test('a persistently inconsistent photo is parked without failing successfully verified neighbors', async () => {
+  await fixture(async ({ seed, repo, immich, sync }) => {
+    const bad = seed(1); seed(2); immich.photos.get(bad).add('ai/scene/old'); immich.dropRemoval = true;
+    for (let n = 0; n < 5; n++) { repo.aiTagSync.defer(null, 0); await sync.tick(); }
+    assert.equal(repo.aiTagSync.status().failed, 1); assert.equal(repo.aiTagSync.status().written, 1);
+    immich.dropRemoval = false; assert.equal(sync.retry(), 1); await sync.tick();
+    assert.equal(repo.aiTagSync.status().written, 2);
+  });
+});

--- a/test/enrich/profiles.test.mjs
+++ b/test/enrich/profiles.test.mjs
@@ -186,7 +186,7 @@ test('schema-8 fixture migrates to profiles without inventing old run attributio
   db.close();
   const repo = new Repository(path);
   try {
-    assert.deepEqual(repo.initSchema().applied, [9, 10, 11]);
+    assert.deepEqual(repo.initSchema().applied, [9, 10, 11, 12]);
     const config = { promptsDir: join(REPO_ROOT, 'prompts'), promptVersion: 'v1', taxonomyPath: join(REPO_ROOT, 'taxonomy/v1.json'),
       promptOverrides: { systemPrompt: 'Migrated customization' } };
     const profiles = new EnrichmentProfiles({ repo, config }); profiles.initialize();

--- a/test/enrich/runConfiguration.test.mjs
+++ b/test/enrich/runConfiguration.test.mjs
@@ -329,7 +329,7 @@ test('v7 upgrade preserves successes as unknown identity, with no invented snaps
   db.close();
   const repo = new Repository(path);
   try {
-    assert.deepEqual(repo.initSchema().applied, [8, 9, 10, 11]);
+    assert.deepEqual(repo.initSchema().applied, [8, 9, 10, 11, 12]);
     const config = snapshot();
     assert.equal(repo.hasAnySuccessfulRun('a1'), true);
     assert.equal(repo.hasSuccessfulRun({ assetId: 'a1', ...config.runKey }), false);

--- a/test/enrich/scale.test.mjs
+++ b/test/enrich/scale.test.mjs
@@ -160,7 +160,7 @@ test('a pre-v3 database backfills latest_success from the latest succeeded runs'
     // Simulate a pre-v3 database, then re-init as an upgraded server would.
     repo.db.exec('DROP TABLE latest_success');
     repo.db.exec('PRAGMA user_version = 2');
-    assert.deepEqual(repo.initSchema().applied, [3, 4, 5, 6, 7, 8, 9, 10, 11]);
+    assert.deepEqual(repo.initSchema().applied, [3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
 
     const rows = repo.db.prepare('SELECT * FROM latest_success ORDER BY asset_id').all();
     assert.equal(rows.length, 1, 'only assets with a succeeded run are projected');

--- a/test/enrich/timing.test.mjs
+++ b/test/enrich/timing.test.mjs
@@ -248,7 +248,7 @@ test('schema 9 upgrades without inventing old timing, and the migration is resta
   db.exec("PRAGMA user_version = 9; INSERT INTO job_runs(title, provider, status, started_at, finished_at) VALUES ('Old', 'venice', 'finished', '2026-09-01', '2026-09-01');"); db.close();
   const repo = new Repository(path);
   try {
-    assert.deepEqual(repo.initSchema().applied, [10, 11]);
+    assert.deepEqual(repo.initSchema().applied, [10, 11, 12]);
     assert.equal(repo.listJobRuns()[0].timingRunId, null); assert.deepEqual(repo.timings.runs().items, []);
     assert.deepEqual(repo.initSchema().applied, []);
   } finally { repo.close(); }

--- a/test/migrations.test.mjs
+++ b/test/migrations.test.mjs
@@ -129,7 +129,7 @@ test('a fresh enrichment database is stamped and fully shaped', () => {
     const repo = new Repository(join(dir, 'enrichment.sqlite'));
     const result = repo.initSchema();
     assert.equal(result.fresh, true);
-    assert.equal(getUserVersion(repo.db), 11);
+    assert.equal(getUserVersion(repo.db), 12);
     for (const column of ['subject_group']) {
       const names = repo.db.prepare("SELECT name FROM pragma_table_info('referee_picks')").all().map((row) => row.name);
       assert.ok(names.includes(column));
@@ -178,8 +178,8 @@ test('a legacy enrichment database lands in the current shape via migration 1', 
     const repo = new Repository(path);
     const result = repo.initSchema();
     assert.equal(result.fresh, false);
-    assert.deepEqual(result.applied, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
-    assert.equal(getUserVersion(repo.db), 11);
+    assert.deepEqual(result.applied, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+    assert.equal(getUserVersion(repo.db), 12);
 
     // manual_overrides rebuilt append-only with data preserved.
     const overrideColumns = repo.db.prepare("SELECT name FROM pragma_table_info('manual_overrides')").all().map((row) => row.name);
@@ -227,7 +227,7 @@ test('provider-payload migration removes raw envelopes and superseded normalized
       .run(JSON.stringify({ caption: 'old', short_caption: 'old' }), rows[0].id);
     repo.db.exec('PRAGMA user_version = 5');
 
-    assert.deepEqual(repo.initSchema().applied, [6, 7, 8, 9, 10, 11]);
+    assert.deepEqual(repo.initSchema().applied, [6, 7, 8, 9, 10, 11, 12]);
     const migrated = repo.db.prepare(`
       SELECT raw_output_json, normalized_output_json
       FROM processing_runs ORDER BY id

--- a/test/upgrade/upgrade-safety.test.mjs
+++ b/test/upgrade/upgrade-safety.test.mjs
@@ -79,7 +79,7 @@ test('the activity schema contract creates a recovery point before changing an e
       currentServerVersion: '0.1.0-with-activity',
       now: new Date('2026-08-08T02:00:00Z'),
     });
-    assert.equal(PERSISTENT_STATE_VERSION, 14);
+    assert.equal(PERSISTENT_STATE_VERSION, 15);
     assert.equal(prepared.action, 'create');
 
     const snapshot = new DatabaseSync(join(config.backup.dir, prepared.snapshotName, 'enrichment.sqlite'), {
@@ -96,7 +96,7 @@ test('the activity schema contract creates a recovery point before changing an e
       successfulStateVersion: PERSISTENT_STATE_VERSION,
       successfulServerVersion: '0.1.0-with-activity',
     });
-    assert.equal(sealed.upgrade.stateVersion, 14);
+    assert.equal(sealed.upgrade.stateVersion, 15);
     assert.equal(sealed.upgrade.recoveryPoint.snapshotName, prepared.snapshotName);
   });
 });
@@ -116,7 +116,7 @@ test('a zero-model v2 installation creates a complete schedule-confirmation reco
       now: new Date('2026-08-08T02:00:00Z'),
     });
 
-    assert.equal(PERSISTENT_STATE_VERSION, 14);
+    assert.equal(PERSISTENT_STATE_VERSION, 15);
     assert.deepEqual({
       action: prepared.action,
       fromStateVersion: prepared.fromStateVersion,
@@ -124,7 +124,7 @@ test('a zero-model v2 installation creates a complete schedule-confirmation reco
     }, {
       action: 'create',
       fromStateVersion: 2,
-      toStateVersion: 14,
+      toStateVersion: 15,
     });
     assert.equal(
       readFileSync(join(config.backup.dir, prepared.snapshotName, 'smart-albums.json'), 'utf8'),
@@ -146,7 +146,7 @@ test('a zero-model v2 installation creates a complete schedule-confirmation reco
       purpose: {
         type: 'pre-migration',
         fromStateVersion: 2,
-        toStateVersion: 14,
+        toStateVersion: 15,
         fromServerVersion: '0.1.0-before-schedule-confirmation',
         toServerVersion: '0.1.0-with-schedule-confirmation',
       },

--- a/test/upgrade/whole-install.test.mjs
+++ b/test/upgrade/whole-install.test.mjs
@@ -47,7 +47,7 @@ test('a complete legacy installation upgrades, restarts, backs up, and restores 
     const sourceConfig = fixtureConfig(sourceRoot);
 
     const first = await openInstallation(sourceConfig, 'initialize');
-    assert.deepEqual(first.enrichmentMigration.applied, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+    assert.deepEqual(first.enrichmentMigration.applied, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
     await assertRepresentativeState(first, sourceConfig);
 
     const migratedDefault = first.profiles.activeProfile();
@@ -69,6 +69,12 @@ test('a complete legacy installation upgrades, restarts, backs up, and restores 
     const photo = first.enrichment.timings.photos(timingRun.id).items[0];
     assert.equal(first.enrichment.timings.attempts(photo.id).items[0].outcome, 'accepted');
 
+
+    // New automatic tag-sync intent and its retry state survive restart and
+    // the real online-backup / clean-volume restore path below.
+    const syncRun = first.enrichment.db.prepare("SELECT MAX(id) id FROM processing_runs WHERE asset_id='timing-fixture' AND status='succeeded'").get();
+    first.enrichment.aiTagSync.enqueue('timing-fixture', syncRun.id);
+    first.enrichment.aiTagSync.defer('Synthetic Immich outage', 2000000000000);
 
     const migratedSettings = readFileSync(sourceConfig.settingsPath, 'utf8');
     const firstSnapshot = semanticSnapshot(first);
@@ -134,7 +140,7 @@ test('contract 10 upgrade snapshots queue pins before clearing them and retains 
     writeFileSync(config.persistentState.inventoryPath, JSON.stringify(inventory));
 
     const upgraded = await openInstallation(config, 'verify');
-    assert.equal(upgraded.inventory.upgrade.stateVersion, 14);
+    assert.equal(upgraded.inventory.upgrade.stateVersion, 15);
     assert.deepEqual(semanticSnapshot(upgraded), before);
     assert.equal(upgraded.profiles.activeProfile().id, travel.id);
     assert.equal(upgraded.enrichment.db.prepare('SELECT COUNT(*) AS n FROM enrich_queue WHERE profile_revision_id IS NOT NULL').get().n, 0);
@@ -191,6 +197,29 @@ function createDatabaseFromSql(databasePath, fixturePath) {
   }
 }
 
+test('contract 14 upgrade snapshots schema 11 before tag sync and does not backfill old photos', async () => {
+  const workspace = mkdtempSync(join(tmpdir(), 'pictaria-ai-sync-recovery-'));
+  try {
+    const root = join(workspace, 'source'); materializeLegacyInstallation(root);
+    const config = fixtureConfig(root); const installed = await openInstallation(config, 'initialize');
+    installed.enrichment.db.exec('DROP TABLE ai_tag_sync; DROP TABLE ai_tag_sync_state; PRAGMA user_version = 11;');
+    closeInstallation(installed);
+    const inventory = JSON.parse(readFileSync(config.persistentState.inventoryPath, 'utf8'));
+    inventory.upgrade.stateVersion = 14; writeFileSync(config.persistentState.inventoryPath, JSON.stringify(inventory));
+    const upgraded = await openInstallation(config, 'verify');
+    assert.deepEqual(upgraded.enrichmentMigration.applied, [12]);
+    assert.equal(upgraded.enrichment.aiTagSync.status().pending, 0);
+    const snapshotDir = join(config.backup.dir, upgraded.inventory.upgrade.recoveryPoint.snapshotName);
+    const snapshot = new DatabaseSync(join(snapshotDir, 'enrichment.sqlite'), { readOnly: true });
+    try {
+      assert.equal(getUserVersion(snapshot), 11);
+      assert.equal(snapshot.prepare("SELECT name FROM sqlite_master WHERE name='ai_tag_sync'").get(), undefined);
+    } finally { snapshot.close(); }
+    assert.equal(upgraded.inventory.upgrade.stateVersion, 15);
+    closeInstallation(upgraded);
+  } finally { rmSync(workspace, { recursive: true, force: true }); }
+});
+
 test('contract 13 upgrade snapshots version 6 settings and history before adopting retention settings', async () => {
   const workspace = mkdtempSync(join(tmpdir(), 'pictaria-retention-recovery-'));
   try {
@@ -205,7 +234,7 @@ test('contract 13 upgrade snapshots version 6 settings and history before adopti
     const inventory = JSON.parse(readFileSync(config.persistentState.inventoryPath, 'utf8'));
     inventory.upgrade.stateVersion = 13; writeFileSync(config.persistentState.inventoryPath, JSON.stringify(inventory));
     const upgraded = await openInstallation(config, 'verify');
-    assert.equal(upgraded.inventory.upgrade.stateVersion, 14);
+    assert.equal(upgraded.inventory.upgrade.stateVersion, 15);
     assert.equal(JSON.parse(readFileSync(config.settingsPath, 'utf8')).version, 7);
     assert.equal(config.enrichHistoryRuns, 100); assert.equal(config.enrichHistoryLogs, 100);
     const snapshotDir = join(config.backup.dir, upgraded.inventory.upgrade.recoveryPoint.snapshotName);
@@ -232,7 +261,7 @@ test('contract 12 upgrade saves schema-10 history before introducing discovery',
     const inventory = JSON.parse(readFileSync(config.persistentState.inventoryPath, 'utf8'));
     inventory.upgrade.stateVersion = 12; writeFileSync(config.persistentState.inventoryPath, JSON.stringify(inventory));
     const upgraded = await openInstallation(config, 'verify');
-    assert.deepEqual(upgraded.enrichmentMigration.applied, [11]);
+    assert.deepEqual(upgraded.enrichmentMigration.applied, [11, 12]);
     assert.equal(upgraded.enrichment.listJobRuns()[0].title, 'Before discovery');
     assert.equal(upgraded.enrichment.db.prepare('SELECT COUNT(*) n FROM enrich_inventory').get().n, 0);
     const snapshotPath = join(config.backup.dir, upgraded.inventory.upgrade.recoveryPoint.snapshotName, 'enrichment.sqlite');
@@ -259,7 +288,7 @@ test('contract 11 upgrade saves a schema-9 recovery point before introducing tim
     const inventory = JSON.parse(readFileSync(config.persistentState.inventoryPath, 'utf8'));
     inventory.upgrade.stateVersion = 11; writeFileSync(config.persistentState.inventoryPath, JSON.stringify(inventory));
     const upgraded = await openInstallation(config, 'verify');
-    assert.deepEqual(upgraded.enrichmentMigration.applied, [10, 11]);
+    assert.deepEqual(upgraded.enrichmentMigration.applied, [10, 11, 12]);
     assert.equal(upgraded.enrichment.listJobRuns()[0].timingRunId, null);
     const snapshotDir = join(config.backup.dir, upgraded.inventory.upgrade.recoveryPoint.snapshotName);
     closeInstallation(upgraded);
@@ -351,6 +380,8 @@ function semanticSnapshot(installation) {
     queue: installation.enrichment.queuePage().items,
     settingsVersion: JSON.parse(readFileSync(installation.settings.filePath, 'utf8')).version,
     enrichmentVersion: getUserVersion(installation.enrichment.db),
+    aiTagSync: installation.enrichment.db.prepare('SELECT * FROM ai_tag_sync ORDER BY asset_id').all(),
+    aiTagSyncState: installation.enrichment.aiTagSync.status(),
     assetCount: installation.enrichment.db.prepare('SELECT COUNT(*) AS n FROM assets').get().n,
     tagCount: installation.enrichment.db.prepare('SELECT COUNT(*) AS n FROM asset_tags').get().n,
     overrideCount: installation.enrichment.db.prepare('SELECT COUNT(*) AS n FROM manual_overrides').get().n,


### PR DESCRIPTION
Enriched photos now sync their AI tags to Immich as they finish, whether or not Send to Curate is selected. Previously an Enrich-only photo's tags stayed local indefinitely. Send to Curate now controls review-list membership only; automatic AI sync preserves human frame decisions and tags outside Pictaria's ai/* namespace.

Fixes PIC-347

PIC-327 merged in #41. This PR now targets main; rebasing preserved the exact file contents of the user-tested build `65fd3a3`. David tested that build and approved merging on September 10.

### Implementation

- A separate durable, asset-keyed queue is written in the successful-photo transaction. It coalesces newer results and checks the processing-run generation before acknowledging writes or recording failures, so in-flight work cannot clear a newer update.
- Reuses AI-tag reconciliation and verification, including stale-tag removal. Small slices share tag resolution and the verification delay. A priority coordinator serializes AI, Curate, and direct favorite/never-show tag operations, with human work ahead of waiting AI slices.
- AI failures neither repeat inference nor fill Curate's queue. Systemic failures pause the AI lane; persistent photo-specific failures are parked. Enrich's Status card exposes pending/failed counts, diagnostics, and retry, with polling through background completion.
- New run configurations record automatic sync explicitly. Changelog and Enrich documentation explain namespace ownership and earlier inclusion in AI-tag searches/albums.

### Validation

Automated coverage includes per-photo delivery before batch completion with Send to Curate both on and off, concurrent Curate decisions, stale generations, tag preservation/removal, bounded slices, permission/outage backoff, deleted photos, parked-job recovery, restart, and online backup/restore. The real-browser scenario drives production routes and the worker against synthetic provider/Immich endpoints: enrichment succeeds during a tag outage, and the Enrich retry button writes tags without another inference call. The resulting desktop UI was visually inspected.

All 1,146 tests passed on two consecutive normal Node 22 `node --test` runs (31 seconds each), without `--test-force-exit`, failures, cancellations, or skips. Publication hygiene and staged whitespace checks pass. The review follow-up bounds Chrome shutdown and closes its stderr pipe: a reproduced Mac hang retained that test-owned pipe after assertions finished. Focused regression tests cover normal/missing exit events, an already-exited parent, and real kill failures. The bounded cleanup path was exercised in the full suite. All four [CI checks](https://github.com/pictaria-ai/pictaria-server/actions/runs/34515060996) pass on `65fd3a3`: normal Server tests, Upgrade compatibility, Container build and boot smoke, and DCO sign-off.


### Upgrade and operational limits

Enrich schema 12 / persistent-state contract 15 require a pre-migration recovery snapshot. Rollback restores that snapshot; older binaries must not open upgraded state directly. No historical backfill is performed. Tag sync is asynchronous and a human write waits for the current bounded AI slice, not the entire AI backlog. Work outside this server can still modify Immich concurrently, so high-volume throughput remains an operational limit to monitor; automated tests are not a real-Immich load benchmark. David confirmed the installed build works and approved it. Codex used synthetic upstream services for its tests.

Implemented and tested by Codex. Claude independently reviewed `6d0b23b` and approved the product implementation after API/browser tests against synthetic Immich/provider services. This follow-up addresses the requested harness cleanup and the optional retry-backoff documentation and Immich error-label improvements. David subsequently tested the installed build and approved merging.

