### PR TITLE
PIC-349: Prepare Pictaria Server v1.2.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,8 +33,8 @@ ALLOW_INSECURE_OPEN=false
 # ---- Server ----
 # Container image selected by docker-compose.yml. Tagged release files default
 # to their matching versioned image tag; image tags omit the `v` used by Git
-# release refs (`1.1.0` versus `v1.1.0`). Set this only for deliberate testing.
-#PICTARIA_IMAGE_TAG=1.1.0
+# release refs (`1.2.0` versus `v1.2.0`). Set this only for deliberate testing.
+#PICTARIA_IMAGE_TAG=1.2.0
 #HOST=0.0.0.0
 #PORT=4080
 #REQUEST_TIMEOUT_MS=60000

--- a/.env.example
+++ b/.env.example
@@ -203,7 +203,9 @@ ALLOW_INSECURE_OPEN=false
 #INSIGHTS_FAVORITES_TAG_VALUE=
 
 # ---- Rarely needed (defaults are right for almost everyone) ----
-# Enrichment taxonomy and prompt files:
+# Template files seed the initial profile and New profile → Pictaria templates.
+# Edit saved profiles in Settings → Enrichment profiles; later file changes
+# do not overwrite their prompts or taxonomy. Custom Docker paths need mounts.
 #TAXONOMY_PATH=taxonomy/v1.json
 #PROMPTS_DIR=prompts
 #PROMPT_VERSION=v2

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
     attributes:
       label: Pictaria Server version
       description: Find this in Settings or the authenticated health response.
-      placeholder: "1.1.0"
+      placeholder: "1.2.0"
     validations:
       required: true
   - type: input

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ synchronization to Immich.
   routine already-enriched skips. Logs retain compact discovery diagnostics.
 - Lowering history limits prunes older records after confirmation. Raising
   limits cannot restore deleted history.
+- First-run, configuration, and backup guides now cover the profile workflow,
+  automatic AI-tag sync, performance page, and history controls.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,123 +5,87 @@ All notable changes to Pictaria Server are documented here. This project follows
 
 ## Unreleased
 
-### Changed
+## 1.2.0 - 2026-09-10
 
-- Every successfully enriched photo now queues its AI tags for Immich,
-  regardless of Send to Curate. Tag-based albums/searches can include photos
-  before review; human `frame/*` decisions and unrelated tags remain intact.
-  Enrich shows pending/failed tag sync and retry, with errors labeled Immich. A separate durable backlog
-  preserves results through outages without filling Curate's decision queue;
-  coordinated tag writes prioritize human actions. Pictaria reconciles its
-  `ai/*` namespace, including replacing manual tags within that prefix.
-  Upgrade snapshots schema 11 / state contract 14 before moving to schema 12 /
-  contract 15. Older enriched photos are not automatically backfilled.
-
-- Enrich run history is configurable in Settings: keep 100–1,000 run summaries
-  and Performance history entries, with diagnostic logs separately limited to
-  the newest 0–100 runs. Defaults remain 100 each. Lowering a limit prunes older
-  history after confirmation; photo/request detail retains its existing bounds.
-- Library sweeps and Daily Enrich select work from a resumable Enrich inventory,
-  avoiding repeated walks through already-enriched photos and the old 100k
-  discovery cliff. Refreshes track visibility/trash changes; stale candidate
-  bursts trigger reconciliation. Incomplete discovery keeps a checkpoint and
-  reports a failure rather than claiming the library is caught up.
-- Unexpected eligibility metadata excludes the affected photos instead of
-  blocking every library sweep at the same page. Discovery logs include
-  metadata refresh time and bounded diagnostics for uncertain eligibility.
-- Send to Curate on a library sweep adds only that run's successful photos.
-  Explicit targeted selections can still send previously enriched results.
-
-- Enrich performance labels median request times explicitly instead of using
-  “Typical,” with a short median/average explanation in run details.
-
-- Performance run dialogs offer Copy for displayed details, compact photo rows,
-  and a visible Immich link explanation. Successful single-request photos consistently show Enriched and total time;
-  retries, failures, and incomplete timings retain request details. The
-  introduction scrolls with the details and puts the Immich link note on its own line.
-
-- Enrich run summaries focus on photos processed, with explicit failure-limit
-  and discard exceptions. Routine already-enriched counts and future per-photo
-  skip log entries are omitted; diagnostic counters remain available. Discovery
-  and empty-selection messages explain what the run is doing without implying
-  the entire library has been checked.
+This release focuses on Enrich: reusable profiles, predictable run settings,
+faster library discovery, useful performance history, and automatic AI-tag
+synchronization to Immich.
 
 ### Added
 
-- A dedicated Enrich performance page, linked from Enrich and Settings, starts
-  with run history and offers a Compare setups view for successful-request
-  speed, outcomes, and throughput. Enrich keeps compact Recent runs with direct
-  View details links. Run details include summaries, photo processing times,
-  paginated requests/retries, and clear incomplete or expired timing states;
-  the dialog fills the screen on phones. Shared formatting, plain-language
-  request counts, prominent profile/host labels and last-used dates, and
-  throughput beneath run duration make comparisons easier to read. Run dialogs
-  show structured metrics and photo requests directly, support backdrop dismissal,
-  and link photos to Immich. Run settings use separate provider, profile, and image
-  rows; the View details link aligns with neighboring buttons.
+- **Enrichment profiles** pair reusable prompts and taxonomy. Create, copy,
+  edit, archive, and restore profiles in Settings; select one active profile
+  on Enrich for library sweeps, queued jobs, retries, and Daily Enrich.
+- **Saved run settings** preserve the exact prompts, taxonomy, provider/model,
+  and processing options used for each run. Running work and automatic retries
+  keep those inputs when Settings changes. Run all uses one saved profile
+  revision for the batch.
+- **Enrich performance**, linked from Enrich and Settings, shows run history
+  and compares setups by request speed, reliability, and throughput. Details
+  include photo/request times, retries, timeouts, median and average times,
+  Copy, and photo links to Immich. Missing or expired measurements remain
+  explicit; older runs do not acquire invented timing data.
+- **Configurable history retention** keeps 100–1,000 run summaries and
+  Performance entries, with logs independently limited to the newest 0–100
+  runs. Defaults remain 100 each; photo/request detail has separate bounds.
 
-- Enrich records per-photo processing time and each actual provider request's
-  duration and outcome, including retries, timeouts, invalid responses, and
-  cancellation. Completed requests survive interrupted runs; incomplete and
-  historical measurements remain explicitly unknown. Bounded timing APIs
-  provide the foundation for the upcoming native performance view.
+### Changed
 
-- Named Enrich profiles: manage reusable prompts and taxonomy in Settings.
-  One server-saved **Active profile** on Enrich controls new sweeps, queued
-  groups, retries, and Daily Enrich. Queueing saves photos only; execution
-  captures the active revision. Run all captures one revision for the batch.
-  Active selection synchronizes across tabs; stale start requests are rejected.
-  Settings provides a profile list, focused editors, readable tag summaries,
-  contextual help, and unsaved-edit protection. Create/edit dialogs save back
-  to the profile list; active selection belongs to Enrich. Running work and history retain their saved inputs.
-- Queued runs have an independent **Only unenriched** option, allowing a new
-  profile pass without reopening existing human Curate decisions.
-- Enrich runs and per-photo results now reference saved, deduplicated
-  configurations. A **View run settings** button shows the prompts, taxonomy, and
-  non-secret settings used by each modern run. The Status card distinguishes
-  current and last-run settings; technical identifiers stay collapsed in the viewer. Failed-photo retries record
-  their source run and use settings at retry start.
+- Library sweeps and Daily Enrich use a resumable local inventory and SQL
+  eligibility checks instead of repeatedly walking already-enriched photos.
+  Later runs fetch changed metadata; periodic full reconciliation catches
+  missed changes. Large or interrupted discovery saves progress and reports
+  incomplete work honestly.
+- Every newly successful enrichment queues its AI tags for Immich, whether
+  Send to Curate is on or off. Sync retries survive restart without repeating
+  inference. Enrich shows pending/failed sync and a retry action; a separate
+  backlog and coordinated writes preserve Curate responsiveness.
+- **Send to Curate** on library sweeps adds only photos successfully enriched
+  by that run. Explicit targeted selections can still send existing results.
+- Provider and active-profile controls share one Enrich card. Profile editing
+  lives in Settings, and Recent Runs focuses on processed photos rather than
+  routine already-enriched skips. Logs retain compact discovery diagnostics.
+- Lowering history limits prunes older records after confirmation. Raising
+  limits cannot restore deleted history.
 
 ### Fixed
 
-- Profile creation distinguishes **Pictaria templates** from **Copy of [name]**
-  under **Starting point**. The initial profile is named **My profile**; untouched
-  preview starters named Default receive that name once, preserving history.
-  Edited/user-named profiles keep their names.
-
-- The Enrich master switch also pauses caption writeback, preserving pending
-  captions and saved preferences. Daily Enrich and caption controls show their
-  paused state while Enrich is off. The Enrich page combines provider/profile
-  controls and removes redundant run-profile text.
-
-- Enrich captures its configuration before photo selection and keeps it fixed
-  through inference, retries, validation, tag mapping, and run history. A
-  settings edit can no longer mix taxonomies or prompts within one execution.
-- With **Only unenriched** off, skip checks and failure limits now use actual
-  inference inputs. Custom prompt/vocabulary edits work without new version
-  labels; label-only and review-policy edits do not force AI calls. Taxonomy
-  edits no longer require bumping their display version.
+- Settings changes cannot mix prompts or taxonomy within an enrichment run.
+  With Only unenriched off, reprocessing checks use actual inference inputs;
+  label-only or live review-policy changes do not force new AI calls.
 - An Immich connection change cancels active enrichment and invalidates queue
-  resolution; an execution cannot switch libraries midway through its work.
+  resolution instead of switching libraries midway through a run.
+- Unexpected eligibility metadata excludes affected photos with diagnostics
+  rather than blocking every sweep at the same page.
+- Turning Enrich off pauses Daily Enrich, caption writeback, and automatic
+  AI-tag sync while preserving pending work and saved preferences.
+- Profile creation clearly distinguishes Pictaria templates from copies of
+  saved profiles; new installations start with **My profile**.
+- Browser-test cleanup closes retained Chrome pipes and bounds shutdown waits.
 
 ### Upgrade notes
 
-- Enrichment schema 9 and persistent-state contract 11 add named profiles
-  and one saved active profile. Existing effective overrides seed My profile once;
-  that profile becomes the initial active choice. Earlier preview queue pins
-  are cleared while queued selections and historical snapshots are preserved.
-  Saved profiles then own inference content, while Settings taxonomy JSON remains the shared live Curate policy.
-  Old prompt settings remain preserved but are no longer edited through the
-  Settings API. Normal pre-migration backup and snapshot-restore rollback apply.
-- Enrichment schema 8 (included in this upgrade) adds configuration
-  snapshots without backfilling unknown historical inputs or replaying photos.
-  Legacy successes still skip with **Only unenriched** on; with it off they
-  cannot prove an input match and may be reprocessed. Startup creates the
-  normal pre-migration recovery point; rollback restores that snapshot.
-- Legacy failures no longer count toward the current configuration's failure
-  limit. Previously stuck photos leave the **Stuck photos** strip and can get
-  two fresh attempts (the default limit) on subsequent sweeps, using additional
-  provider calls.
+- This release uses **Enrich schema 12, settings version 7, and persistent-state
+  contract 15**. Startup creates a complete pre-migration recovery snapshot.
+  Keep that snapshot and the prior image/version; rollback requires restoring
+  the snapshot with the matching older build, not opening upgraded state with
+  older code. See [Upgrading](docs/UPGRADING.md#upgrading-to-v120).
+- Existing effective prompts/taxonomy seed the initial active profile once.
+  Check it in Settings after upgrading. Saved profiles then own inference
+  content; the live Curate review policy remains separate. Earlier v1.2 preview
+  queue pins are cleared while selections and historical snapshots remain.
+- **Only unenriched** still skips every prior success. With it off, historical
+  results lacking a known configuration may be reprocessed. Legacy failures
+  no longer count toward the current configuration's failure limit, so
+  subsequent sweeps may make fresh provider calls for previously stuck photos.
+- Automatic tag sync requires Immich tag permissions. Pictaria manages the
+  entire **ai/** namespace: re-enrichment can remove stale or manually added
+  tags within that namespace. Human **frame/** decisions and unrelated tags
+  remain intact. AI-tag searches/albums can include photos before curation.
+  Existing enriched photos are **not** automatically backfilled on upgrade.
+- The first budgeted library sweep builds the inventory. A full metadata
+  reconciliation is expected on the first sweep after 24 hours; ordinary new
+  uploads are discovered incrementally even with older capture dates.
 
 ## 1.1.0 - 2026-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,6 @@ synchronization to Immich.
   AI-tag sync while preserving pending work and saved preferences.
 - Profile creation clearly distinguishes Pictaria templates from copies of
   saved profiles; new installations start with **My profile**.
-- Browser-test cleanup closes retained Chrome pipes and bounds shutdown waits.
 
 ### Upgrade notes
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Production installs should select an explicit reviewed release. The source
 tag and matching versioned GHCR image keep the deployment inputs aligned.
 
 ```sh
-PICTARIA_RELEASE=v1.1.0 # replace with the release you are installing
+PICTARIA_RELEASE=v1.2.0 # replace with the release you are installing
 mkdir pictaria-server && cd pictaria-server
 curl -fsSLO \
   "https://raw.githubusercontent.com/pictaria-ai/pictaria-server/${PICTARIA_RELEASE}/docker-compose.yml"
@@ -82,7 +82,7 @@ and its online-backup API; earlier builds fail at boot — `engines` says
 newer supported versions work as well.
 
 ```sh
-PICTARIA_RELEASE=v1.1.0 # replace with the release you are installing
+PICTARIA_RELEASE=v1.2.0 # replace with the release you are installing
 git clone --branch "$PICTARIA_RELEASE" --depth 1 \
   https://github.com/pictaria-ai/pictaria-server.git
 cd pictaria-server

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Use it as a standalone Immich application or pair it with [Pictaria Frame](https
 Pictaria Server includes:
 
 - **Insights** — understand your collection (`/insights.html`): photos per year with a person/place/tag lens, a "where you were" timeline with auto-detected trips, a people constellation (faces linked by shared photos), records (busiest day, home base, furthest from home), and leaderboards for people, places, cameras, and tags. Every number is clickable — browse the photos behind it, open the same view in Immich, or turn it into an album. Everything is computed by Pictaria from a periodic Immich sweep; optional Geoapify place naming sends coordinates to the provider you configured.
-- **Enrich** — AI photo classification into a controlled taxonomy (`/enrich.html`). Works with operator-hosted Ollama, LM Studio, llama.cpp and other OpenAI-compatible endpoints, or through the cloud with OpenAI, OpenRouter, Venice, or Ollama's cloud models.
+- **Enrich** — AI photo classification into a controlled taxonomy (`/enrich.html`), with reusable prompt/taxonomy profiles and automatic AI-tag sync to Immich. Inspect run and photo timings and compare setups on **Enrich performance** (`/enrich-performance.html`). Works with operator-hosted Ollama, LM Studio, llama.cpp and other OpenAI-compatible endpoints, or through the cloud with OpenAI, OpenRouter, Venice, or Ollama's cloud models.
 - **Curate** — the human review workflow that decides what your frame shows (`/curate.html`). Same-moment photos collapse into **Stacks** with a suggested keeper: a silver ★ from frame-worthiness scores, or a gold ★ when the optional AI referee has compared the group side by side.
 - **Smart Albums** — saved Immich searches (people, tags, places, dates, cameras, or free-text ranked search) that keep real Immich albums up to date on a schedule (`/albums.html`). A free-text rule can run in **Best of** mode: each search hit is double-checked against your own enrichment data and the keepers are ranked by your Curate decisions and photo scores — a "Top 50" that is your best 50, not Immich's first 50. Each run re-syncs the album to its rule, and deleting a rule never deletes the Immich album itself. ([Rules, Best of, the sync.](docs/ALBUMS.md))
 - **Frame Remote** — see what each frame is showing and control it live from your phone (`/remote.html`). Multiple frames run off one server: each device reports under its own name, and a device picker appears when more than one is known so commands reach only the frame you chose. Retired or re-onboarded devices are cleaned up under Settings → Devices.
@@ -112,7 +112,9 @@ Either way, continue with the **[first-run checklist](docs/GETTING-STARTED.md)**
 
 ## Configuration
 
-Only a handful of values have to be environment variables: the listen address/port, the data paths, and `APP_PASSWORD`. Everything else — the Immich connection, AI providers and models, voice, weather, backups — can be set (and changed at any time, no restart) from the web UI. Provider connections and model identifiers live under **Settings → AI Providers**; choose the provider used for new enrichment runs on **Enrich**, where the selection is remembered across visits and restarts. Every UI-editable field also has an env-var form for infrastructure-as-code setups; a value saved in the UI overrides the environment until cleared.
+Only a handful of values have to be environment variables: the listen address/port, the data paths, and `APP_PASSWORD`. Everything else — the Immich connection, AI providers and models, voice, weather, backups — can be set (and changed at any time, no restart) from the web UI. Provider connections and model identifiers live under **Settings → AI Providers**. Manage reusable prompts and taxonomy under **Settings → Enrichment profiles**, then choose the active provider and profile on **Enrich**; those choices are remembered across visits and restarts.
+
+Configuration fields with environment equivalents use a saved UI override until cleared. Enrichment profiles are stored separately in the database: configured prompt/taxonomy files seed the initial profile, but later file changes do not overwrite saved profiles. See the [profile guide](docs/ENRICH.md#enrichment-profiles).
 
 See [docs/CONFIGURATION.md](docs/CONFIGURATION.md) for the complete reference and [.env.example](.env.example) for an annotated starter file. The short version:
 
@@ -220,7 +222,7 @@ The suite includes browser-level smoke tests (`test/browser/`) that drive the re
 ## Design rules
 
 - Zero npm dependencies; Node built-ins only.
-- The taxonomy file is configuration, not code: tags, thresholds, and review-bucket policy live in `taxonomy/v1.json` so users can tune behavior without touching source.
+- Taxonomy is configuration, not code: `taxonomy/v1.json` supplies the starting template, saved profiles own inference content, and shared live Curate policy stays separate. Users can tune behavior without touching source.
 - Human decisions always win over AI output.
 - SQLite is the local source of truth; Immich is synced to, never trusted as the record of review decisions.
 - One password, one data directory, one process: setup should never be the hard part.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     # Release files default to their matching versioned image tag. A tag is a
     # release name, not a cryptographic digest. Set PICTARIA_IMAGE_TAG only
     # when deliberately testing another published tag.
-    image: ghcr.io/pictaria-ai/pictaria-server:${PICTARIA_IMAGE_TAG:-1.1.0}
+    image: ghcr.io/pictaria-ai/pictaria-server:${PICTARIA_IMAGE_TAG:-1.2.0}
     build: .
     container_name: pictaria
     restart: unless-stopped

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,7 +10,8 @@ one config, one password, and one data directory.
 | Feature | What it does | API prefix | UI page |
 | --- | --- | --- | --- |
 | **Insights** | Local collection statistics: yearly histogram + lens, timeline with trips, people constellation, records, leaderboards; every stat opens a photo browser | `/api/insights` | `/insights.html` |
-| **Enrich** | AI tagging/captioning of the Immich library, review workflow | `/api/enrich`, `/api/review`, `/api/taxonomy` | `/curate.html` |
+| **Enrich** | AI tagging/captioning, reusable profiles, library discovery, automatic AI-tag sync, and performance history | `/api/enrich`, `/api/taxonomy` | `/enrich.html`, `/enrich-performance.html`; profiles in Settings |
+| **Curate** | Human review decisions, Stacks, and optional AI referee | `/api/review` | `/curate.html` |
 | **Albums** | Smart albums: saved Immich searches synced to real albums on a schedule; Best-of mode corroborates free-text hits against the enrichment DB and ranks by Curate signals | `/api/albums` | `/albums.html` |
 | **Frame** | Frame hub: device presence, live state per device, remote commands (SSE) routed by device name, display ledger/stats | `/api/frame` | `/remote.html` |
 | **Voice** | Voice pipeline for Pictaria Frame: intent parsing, photo search, photo Q&A, TTS, usage counters | `/api/voice`, `/api/photos` | testers in `/settings.html` (Voice section) |

--- a/docs/BACKUP.md
+++ b/docs/BACKUP.md
@@ -9,7 +9,7 @@ live in Immich and are covered by whatever backs Immich up.
 
 | File | Contents | Replaceable? |
 | --- | --- | --- |
-| `enrichment.sqlite` (`DATABASE_PATH`) | decisions, tags, captions, run history, review list | **No — the crown jewels** |
+| `enrichment.sqlite` (`DATABASE_PATH`) | decisions, tags, captions, profiles/revisions and active choice, saved run settings, run/timing history, review list, discovery checkpoints, pending AI-tag sync | **No — the crown jewels** |
 | `settings.json` (`SETTINGS_PATH`) | settings overrides, incl. location groups | No |
 | `smart-albums.json` (`ALBUMS_DATA_FILE`) | album rules and job state | No |
 | `frame.db` (`FRAME_DB_PATH`) | which photos the frame has shown, voice command usage counters | No (small) |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,8 +1,9 @@
 # Configuration reference
 
-Everything can be configured through environment variables (a `.env` file
-works for bare-Node runs; the Docker image reads normal container env), and
-most day-to-day values can also be changed at runtime from the Settings page —
+The configuration fields below can be set through environment variables (a
+`.env` file works for bare-Node runs; the Docker image reads normal container
+env), and most day-to-day values can also be changed at runtime from the
+Settings page —
 those are marked **UI**. A value saved in the UI overrides the environment
 until cleared and applies immediately, no restart. The listen address/port,
 data paths, and `APP_PASSWORD` are deliberately environment-only.
@@ -13,8 +14,13 @@ data paths, and `APP_PASSWORD` are deliberately environment-only.
 - **AI Providers** owns reusable provider credentials, endpoints, and
   provider-default model identifiers, separated into Local Models and Cloud
   Models.
-- The **Enrich page** chooses the provider for new enrichment runs;
-  **Settings → Enrich** owns enrichment behavior, prompts, and taxonomy.
+- The **Enrich page** chooses the active provider and profile for new runs.
+  **Settings → Enrich** owns processing behavior, Daily Enrich, history
+  retention, and the shared live Curate review policy.
+- **Settings → Enrichment profiles** manages saved prompts and inference
+  taxonomy. Profiles live in the database, not environment overrides;
+  configured template files seed the initial profile and can be imported
+  through **New profile → Pictaria templates**.
 - **Settings → Curate** owns the AI-referee provider/model override and
   other review behavior.
 - **Settings → Voice TTS** owns the voice-answer provider, Interesting and
@@ -139,10 +145,12 @@ files.
 
 | Variable | Default | Notes |
 | --- | --- | --- |
-| `ENRICH_ENABLED` | `false` | Master switch for AI enrichment — off by default because a run sends the selected image rendition to its chosen model. Voice Interesting is a separate, user-invoked model path and does not depend on this switch. Flip Enrich in Settings → Enrich (or here). **UI** |
-| `ENRICH_SCHEDULE_ENABLED` | `false` | Run one daily library sweep for photos that have never been enriched. Uses the provider currently selected on Enrich, sends successful results to Curate, and waits quietly when another enrich run is active. **UI** |
+| `ENRICH_ENABLED` | `false` | Master switch for AI enrichment — off by default because a run sends the selected image rendition to its chosen model. Turning it off pauses Daily Enrich, caption writeback, and automatic AI-tag sync while preserving their preferences and pending work. Curate decision sync remains available. Voice Interesting is a separate, user-invoked model path and does not depend on this switch. Flip Enrich in Settings → Enrich (or here). **UI** |
+| `ENRICH_SCHEDULE_ENABLED` | `false` | Run one daily library sweep for photos that have never been enriched. Uses the active provider and profile selected on Enrich when the run starts, sends successful results to Curate, and waits quietly when another enrich run is active. **UI** |
 | `ENRICH_SCHEDULE_TIME` / `ENRICH_SCHEDULE_TIME_ZONE` | `03:00` / server time zone (`UTC` in stock Compose) | Daily start time (`HH:MM`) and IANA time zone. Settings captures the browser's current time zone automatically, so the normal UI path does not require time-zone setup. **UI** |
 | `ENRICH_SCHEDULE_PHOTO_BUDGET` | `100` | Maximum new photos analyzed by each daily run (1–10,000). Already-enriched photos do not consume this budget. **UI** |
+| `ENRICH_HISTORY_RUNS` | `100` | Retain 100–1,000 run summaries and Performance entries. Photo/request detail has separate bounds and may expire sooner. Settings → Enrich → Run history. **UI** |
+| `ENRICH_HISTORY_LOGS` | `100` | Retain diagnostic logs for the newest 0–100 runs; `0` retains no logs. Older summaries can remain without logs. Lowering either history limit prunes records on save/startup; raising it cannot recover deleted history. Settings → Enrich → Run history. **UI** |
 | `CAPTION_WRITEBACK` | `false` | Copy enrichment captions into Immich's description field, making photos searchable in Immich by their content. Pictaria checks at the final safe point before writing and only fills an empty description or updates its own earlier text; Immich offers no atomic conditional update, so see the precisely documented residual race in [ENRICH.md](ENRICH.md). **UI** |
 | `DEFAULT_PROVIDER` | `cloud_openai` | Initial/infrastructure fallback when the Enrich page has no remembered provider. `cloud_openai` \| `local_lmstudio` \| `local_ollama` \| `openai_compatible` \| `openrouter` \| `cloud_ollama` \| `venice`. Choosing a provider on Enrich saves a UI override. **UI (Enrich page)** |
 | `INFERENCE_HOST_LABEL` | *(empty)* | Optional operator-entered label (maximum 120 characters) copied into each new run summary, such as `M4 Mac mini · LM Studio`. Useful for comparing providers/models hosted on different machines. Pictaria does not detect hardware or rewrite earlier runs when this changes. **UI** |
@@ -162,8 +170,8 @@ files.
 | `VENICE_API_KEY` / `VENICE_MODEL` / `VENICE_BASE_URL` | — / *(empty — no default)* / `https://api.venice.ai/api/v1` | Key and model live under Settings → AI Providers. **UI**. The model must support vision and structured output; the AI referee additionally needs multi-image input (e.g. `qwen3-vl-235b-a22b`). |
 | `IMAGE_SOURCE` | `preview` | Which Immich rendition is sent to the model (`preview`, `thumbnail`, or `original`). Immich previews are WebP. LM Studio cannot ingest them (Pictaria converts on macOS; use `original` in Docker), and current llama.cpp accepts stb_image formats rather than WebP, so use `original` with that endpoint too. **UI** |
 | `MAX_FAILURES_PER_ASSET` | `2` | Give up on an asset after this many content failures per inference configuration (effective prompts, allowed vocabulary/schema, provider/model/generation settings, and image policy). Profile names and revision labels do not create a new allowance when inference inputs are identical; infrastructure failures do not consume it. `0` disables the limit; raising it above an asset's recorded failures re-attempts it on the next run. Stuck photos can also be retried one run at a time from the Enrich page's **Stuck photos** strip. |
-| `TAXONOMY_PATH` | `taxonomy/v1.json` | Seeds the initial inference profile and New profile → Built-in setup. Saved profiles own their taxonomy after initialization; Settings → Enrich retains the separate shared live Curate policy. Version labels need not change after edits. A custom container path requires a matching bind mount and Compose override. |
-| `PROMPTS_DIR` / `PROMPT_VERSION` | `prompts` / `v2` | Prompt templates for enrichment. `PROMPT_VERSION` is forwarded by stock Compose; a custom `PROMPTS_DIR` requires a matching bind mount and Compose override. The templates seed the initial profile and New profile → Built-in setup. Edit saved text in Settings → Enrichment profiles; later file/environment changes do not overwrite saved profiles. |
+| `TAXONOMY_PATH` | `taxonomy/v1.json` | Seeds the initial inference profile and New profile → Pictaria templates. Saved profiles own their taxonomy after initialization; Settings → Enrich retains the separate shared live Curate policy. Version labels need not change after edits. A custom container path requires a matching bind mount and Compose override. |
+| `PROMPTS_DIR` / `PROMPT_VERSION` | `prompts` / `v2` | Prompt templates for enrichment. `PROMPT_VERSION` is forwarded by stock Compose; a custom `PROMPTS_DIR` requires a matching bind mount and Compose override. The templates seed the initial profile and New profile → Pictaria templates. Edit saved text in Settings → Enrichment profiles; later file/environment changes do not overwrite saved profiles. |
 | `CURATE_BURST_GROUPING` | `true` | Collapse same-moment photos (bursts, re-shoots, duplicates) into stacked cards in the Curate queue. Off = flat photo-by-photo queue. **UI** |
 | `CURATE_REFEREE_ENABLED` | `false` | The gold star: an AI model compares each same-moment group side by side and picks the keeper, with a why-line per photo. Runs whenever enrichment is idle; needs `ENRICH_ENABLED`. **UI** |
 | `CURATE_REFEREE_PROVIDER` | *(empty)* | Referee provider; empty = follow the provider currently selected on Enrich. Lives under Settings → Curate. **UI** |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -36,7 +36,7 @@ deliberately testing another published tag.
 
 | Variable | Default | Notes |
 | --- | --- | --- |
-| `PICTARIA_IMAGE_TAG` | `1.1.0` | Published container image tag selected by `docker-compose.yml`. Image tags omit the `v` used by Git release refs (`1.1.0` versus `v1.1.0`). |
+| `PICTARIA_IMAGE_TAG` | `1.2.0` | Published container image tag selected by `docker-compose.yml`. Image tags omit the `v` used by Git release refs (`1.2.0` versus `v1.2.0`). |
 
 ## Required
 

--- a/docs/ENRICH-DISCOVERY-PROTOTYPE.md
+++ b/docs/ENRICH-DISCOVERY-PROTOTYPE.md
@@ -3,7 +3,7 @@
 Status: historical isolated experiment, September 2026. The scripts remain
 separate from production. The production implementation and its deliberate
 freshness limits are now described in [Enrich](ENRICH.md#library-discovery-and-freshness)
-and [Upgrading](UPGRADING.md#enrich-discovery-unreleased-v12-work). In particular,
+and [Upgrading](UPGRADING.md#discovery-history-and-processing-behavior). In particular,
 production preserves timeline-image eligibility, does not adopt the synthetic
 stack-child rule, and uses daily full reconciliation for late timestamp-boundary
 arrivals. The measurements and open questions below record the prototype stage;

--- a/docs/ENRICH.md
+++ b/docs/ENRICH.md
@@ -16,6 +16,25 @@ Voice **Interesting** command is separate
 from Enrich and can send a preview plus photo metadata to its selected model
 even while enrichment is off.
 
+## Start here
+
+Configure your model under **Settings → AI Providers**, enable Enrich under
+**Settings → Enrich**, then choose the provider and active profile on the
+**Enrich** page. Start with a small library sweep. **My profile** is the initial
+setup; you can use it as-is or customize it in Settings.
+
+- [Enrichment profiles](#enrichment-profiles): create or edit prompts and tags,
+  and understand which settings new runs use.
+- [Run history](#run-history): inspect saved run settings, retry failures, and
+  choose how much history to retain.
+- [Performance and photo details](#performance-comparison-and-photo-details):
+  find per-photo timing and compare setups.
+- [Caption writeback](#writing-captions-to-immich-descriptions): optionally
+  copy captions into Immich descriptions. AI tags sync automatically after
+  successful enrichment, independently of **Send to Curate**.
+- [Upgrading to v1.2.0](UPGRADING.md#upgrading-to-v120): profile migration,
+  discovery, historical results, and rollback.
+
 ## The pipeline
 
 For each photo, one *processing run*:
@@ -378,7 +397,8 @@ captions, and search; existing human decisions remain authoritative.
   unless its run finishes cleanly, and running it again continues where it
   left off (already-enriched photos are skipped).
 - **Recent runs** starts with the newest 20 summaries. **Load more** walks
-  through all 100 retained summaries without loading their potentially large
+  through the configured number of retained summaries (100 by default, up to
+  1,000) without loading their potentially large
   logs; each log is fetched only when you open it. Retry actions remain
   available on older loaded runs and always recalculate which failed photos
   still need work before starting.
@@ -692,8 +712,8 @@ credentials are excluded. Custom prompts and taxonomy are user-authored data
 stored in the local database and included in backups.
 
 Snapshots are deduplicated and referenced by job summaries and per-photo
-processing records. Pruning the newest-100 job summary history never deletes a
-snapshot referenced by a photo’s history. The per-photo caption endpoint also
+processing records. Pruning job summaries to the configured history limit
+never deletes a snapshot referenced by a photo’s history. The per-photo caption endpoint also
 returns its latest successful configuration ID, so those inputs remain
 inspectable after their job summary is pruned. Two runs can have different complete
 configuration IDs but the same inference ID—for example, after changing only
@@ -702,8 +722,8 @@ review thresholds or labels.
 **Re-run failed photos** keeps the original provider and uses settings at the
 retry’s start, with a new snapshot and a link to its source run. This lets a
 corrected prompt fix earlier failures. Automatic retries within an execution
-use its frozen configuration. Replaying historical settings exactly and named
-profile selection are separate future features.
+use its frozen configuration. Named profiles are available now; exact replay
+of historical settings and a per-job profile override are not supported.
 
 The Enrich page lists recent runs: what ran (slice title or library sweep),
 when, provider + model, taxonomy + prompt versions, counters
@@ -1399,7 +1419,9 @@ and expect the queue to breathe a little while enrichment is running.
 ### Enrich master switch and dependent features
 
 Turning off **Enable AI enrichment** prevents new manual and Daily Enrich runs
-and pauses caption writeback. Settings disables Daily Enrich and caption controls
+and pauses caption writeback and automatic AI-tag sync. Pending tag sync stays
+queued; Curate's human-decision sync remains available. Settings disables
+Daily Enrich and caption controls
 with “Paused while Enrich is off,” preserving their saved preferences. Turning
 Enrich back on restores those preferences; the normal Daily Enrich catch-up
 rules still apply. An enrichment execution already started keeps its run settings.

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -76,7 +76,7 @@ else waits on them.
   the Insights page is your library's story — start clicking.
   ([How it works.](INSIGHTS.md))
 
-- [ ] **Install Pictaria Frame** on the device that will be your frame.
+- [ ] *Optional* — **Install Pictaria Frame** on the device that will be your frame.
   Its setup wizard asks for Immich, your photo albums, this server's URL
   and password, and a **device name** — that name is how the frame appears
   in the Remote page, the Frame stats, and Settings → Devices. Run several
@@ -84,16 +84,30 @@ else waits on them.
 
 - [ ] *Optional* — **Enable Enrich.** AI tagging and captions are **off by
   default** because each run sends the selected image rendition to its chosen
-  model. Configure the connection and
-  model identifier under Settings → AI Providers, then open Enrich and choose
-  the provider for new runs. That choice is remembered across visits and
-  server restarts. Ollama and LM Studio keep everything on your own hardware;
+  model. Turn on **Enable AI enrichment** under Settings → Enrich. Configure
+  the connection and model identifier under Settings → AI Providers, then
+  open Enrich and choose the provider and active profile for new runs.
+  **My profile** is the initial prompt/taxonomy setup; keep it or edit/create
+  profiles under **Settings → Enrichment profiles**. The active choices are
+  remembered across visits and server restarts and apply to library sweeps,
+  queued jobs, and Daily Enrich when they start. Running work keeps its saved
+  inputs. Ollama and LM Studio keep everything on your own hardware;
   OpenAI, OpenRouter, Venice, and Ollama's cloud models are the cloud routes.
+  Start with a small library sweep. Newly successful photos automatically
+  sync their `ai/*` tags to Immich, even with **Send to Curate** off; that
+  checkbox only controls whether photos enter human review. Pictaria manages
+  the `ai/*` namespace, so keep your own tags outside it. The Status card
+  shows any pending/failed **Immich tag sync** and its retry action.
+
   Captions are stored in Pictaria by default; Immich descriptions remain
   unchanged unless you separately turn on **Write captions to Immich
   descriptions**. Use **Write existing captions now** to copy captions made
   before enabling that option.
-  ([Pipeline, providers, taxonomy.](ENRICH.md))
+  Open **View details** in Recent runs for photo timings, or **Enrich
+  performance** to browse runs and compare setups. **View run settings**
+  shows the inputs saved for a run. Settings → Enrich → Run history controls
+  how many summaries and logs are retained.
+  ([Profiles, discovery, performance, and the full pipeline.](ENRICH.md))
 
 - [ ] *Optional* — **Get a free Geoapify key** for place names. Weather
   needs no account or key: it sends the frame's city or US ZIP to Open-Meteo

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -24,7 +24,7 @@ upgrade.
 ## Upgrade — Docker
 
 ```sh
-PICTARIA_RELEASE=v1.1.0 # replace with the release you are installing
+PICTARIA_RELEASE=v1.2.0 # replace with the release you are installing
 curl -fsSL -o docker-compose.release.yml \
   "https://raw.githubusercontent.com/pictaria-ai/pictaria-server/${PICTARIA_RELEASE}/docker-compose.yml"
 diff -u docker-compose.yml docker-compose.release.yml
@@ -45,7 +45,7 @@ docker compose -f docker-compose.release.yml config --images
 ```
 
 The printed image must end in the numeric image version corresponding to the
-source release you selected (`v1.1.0` uses image tag `1.1.0`). Next, make a
+source release you selected (`v1.2.0` uses image tag `1.2.0`). Next, make a
 rollback definition from the currently running Compose file. It should already
 resolve to the version you noted under Settings → Server; verify it before
 replacing the active definition:
@@ -72,7 +72,7 @@ test -z "$(git status --porcelain)" || {
   echo "Stop: preserve or reconcile local changes before upgrading."
   exit 1
 }
-PICTARIA_RELEASE=v1.1.0 # replace with the release you are installing
+PICTARIA_RELEASE=v1.2.0 # replace with the release you are installing
 git fetch --tags --prune
 git switch --detach "$PICTARIA_RELEASE"
 docker compose up -d --build
@@ -97,7 +97,7 @@ test -z "$(git status --porcelain)" || {
   echo "Stop: preserve or reconcile local changes before upgrading."
   exit 1
 }
-PICTARIA_RELEASE=v1.1.0 # replace with the release you are installing
+PICTARIA_RELEASE=v1.2.0 # replace with the release you are installing
 git fetch --tags --prune
 git switch --detach "$PICTARIA_RELEASE"
 ```
@@ -259,84 +259,85 @@ pre-flight checklist — see
 Do not upgrade both on the same day. If something breaks afterwards, you want
 to know which upgrade caused it.
 
-## Named Enrich profiles (unreleased v1.2 work)
+## Upgrading to v1.2.0
 
-Schema 9 / persistent-state contract 11 provides profiles and one server-saved
-active choice. Earlier v1.2 previews used contract 10 with per-item queue pins.
-Upgrading preserves the saved default as the active profile and clears pending
-queue pins; photo selections, immutable revisions, and run history are retained.
-The physical `is_default` column stores the active choice, and the nullable
-queue pin column is retained for compatibility but is no longer used.
-Contract 11 ensures a recovery point before this behavior/state conversion.
-For installations without profiles, first boot copies effective prompts/taxonomy
-into the initial active profile, My profile; it does not launch enrichment. Verify
-the active profile contains your customization and the queue still shows its
-expected slices. Subsequent inference edits belong in Settings → Enrichment
-profiles; Settings retains the shared live Curate policy. Changing configured files later does not rewrite saved profiles.
-See [profile behavior and migration](ENRICH.md#enrichment-profiles).
+v1.2.0 upgrades persistent-state contract 8 from v1.1.0 to **contract 15**,
+with **Enrich schema 12** and **settings version 7**. Upgrades from earlier
+v1.2 development builds follow any remaining migrations. The release does
+not require a new Immich or Pictaria Frame version.
 
-Startup takes the usual complete pre-migration snapshot before mutation.
-Rollback requires restoring that snapshot into a clean volume with the older
-image; do not run an older server directly against the new database. Profile
-revisions and the active choice live in enrichment.sqlite and are included
-in standard backups.
+### Before and after first startup
 
+Create a complete backup using the checklist above. Startup also creates a
+complete pre-migration recovery snapshot before changing persistent state.
+Retain that snapshot and the previous image/version. Existing enrichment
+results, human decisions, queued photo selections, and retained history are
+preserved, subject to the configured history limits.
 
-## Enrich history retention (unreleased v1.2 work)
+After startup, check:
 
-Settings version 7 / persistent-state contract 14 adds bounded run-summary
-and diagnostic-log preferences. The Enrich database remains at schema 11.
-Existing installations retain the defaults of 100 summaries and 100 logs;
-migration does not create overrides that would hide environment preferences.
-The same summary limit applies to Performance timing-run entries, while
-photo/request detail retains its separate bounds.
+- **Settings → Enrichment profiles:** existing effective prompts and taxonomy
+  seed the initial active profile, **My profile**, once. Verify your
+  customization, then edit inference content through profiles. The shared
+  live Curate review policy remains separate. Changes to configured prompt
+  files do not subsequently rewrite saved profiles.
+- **Enrich:** confirm the active profile and provider. Every new execution,
+  including Daily Enrich and queued jobs, uses the active revision at start;
+  running work and automatic retries retain captured inputs. Earlier v1.2
+  preview queue pins are cleared without removing selected photos or history.
+- **Immich tag sync:** newly successful enrichments sync AI tags whether or
+  not Send to Curate is selected. Ensure the API key has the required tag
+  permissions; pending/failed status and retry are on Enrich. Older enriched
+  photos are not automatically backfilled.
+- **Run history:** defaults retain 100 summaries/Performance entries and logs
+  for 100 runs. Settings can retain 100–1,000 summaries and independently
+  0–100 logs. Lower limits prune immediately after confirmation; raising a
+  limit does not recover deleted records. Photo/request detail is separately
+  bounded.
 
-The normal recovery point is created before settings migration and startup
-pruning. It preserves the prior version-6 settings and retained history.
-Settings and databases are included in normal backups, so restoring a current
-backup also restores its retention preferences. Lowering a configured limit
-prunes immediately on save or startup; raising it cannot restore old records.
-For rollback, restore the pre-upgrade snapshot with its matching older build;
-do not run older code directly against contract-14 state.
+Pictaria reconciles all tags within its **ai/** namespace, including stale or
+manually added tags within that prefix. Automatic AI sync preserves human
+**frame/** decisions and tags outside **ai/**. Tag-based searches and albums
+can now include enriched photos before they have been curated.
 
-## Enrich discovery (unreleased v1.2 work)
+### Discovery, history, and processing behavior
 
-Schema 11 / persistent-state contract 13 adds a rebuildable Enrich inventory,
-a staging table, and a checkpoint/lease record to enrichment.sqlite. Existing
-processing history, results, queues, profiles, and human decisions remain
-unchanged. No historical assets are assumed to form a complete inventory;
-the first budgeted library sweep constructs one from Immich.
+The first budgeted library sweep builds a resumable inventory. Later sweeps
+fetch changed metadata, including uploads with older capture dates, and use
+local SQL to select work. A full metadata reconciliation occurs on the first
+sweep after 24 hours and can also follow a burst of stale candidates. This is
+expected metadata work, not re-enrichment of the whole library.
 
-The standard pre-migration recovery point is created before this migration.
-Normal backups include both the published inventory and any saved in-progress
-scan. Resume uses the same source credentials; a URL/key change starts a fresh
-inventory without clearing enrichment history. A restored active lease can
-delay discovery for up to five minutes before it expires.
+Bounded or interrupted discovery retains its checkpoint. An incomplete result
+asks for another run instead of claiming the library is caught up. Daily
+Enrich keeps its once-per-day attempt policy. See
+[library discovery and freshness](ENRICH.md#library-discovery-and-freshness)
+for eligibility, timing-boundary and pagination limits.
 
-Rollback requires the pre-upgrade snapshot and its matching older build. Do
-not run an older server directly against contract-13 state. The upgrade tests
-verify that a contract-12/schema-10 recovery snapshot contains neither the
-new tables nor changes to existing job history.
+**Only unenriched** continues to skip every previous success. With it off,
+legacy results with unknown configuration inputs may be reprocessed. Legacy
+failures no longer count toward the current configuration's failure limit,
+so later sweeps may make fresh provider calls for previously stuck photos.
+A library sweep sends only its new successful results to Curate; explicitly
+targeted selections can still send existing results.
 
-## Enrich timing (unreleased v1.2 work)
+Historical settings and timing are not reconstructed from logs. Saved
+configuration and timing records identify new runs; older or expired details
+remain explicitly unavailable. On restart, unfinished photo/request timing
+records become interrupted while completed measurements remain intact.
 
-Schema 10 / persistent-state contract 12 adds timing runs, photo executions,
-and provider attempts, plus a nullable `job_runs.timing_run_id` link. No
-historical measurements are reconstructed from logs or processing-row
-creation timestamps. Older job summaries have no timing link. Enrichment
-results, active profiles and immutable revisions, queue selections, and
-human decisions keep their existing meaning.
+### Backup and rollback
 
-The automatic pre-migration recovery point precedes this change. Timing
-records live in enrichment.sqlite and are covered by the existing complete
-backup/restore path. Tests cover upgrading the schema-9 profile release,
-restoring its pre-upgrade snapshot with contract 11 and no timing tables,
-and round-tripping new measurements and profile attribution through backup.
-Rollback requires that snapshot and the corresponding older server; never
-open contract-12 state with an older build.
+Standard complete backups include profiles, configuration snapshots, timing,
+inventory/checkpoints, history preferences, and pending AI-tag synchronization.
+A restored discovery lease can delay new discovery for up to five minutes.
+Changing the Immich URL or API key rebuilds only the inventory, preserving
+enrichment history and human decisions.
 
-On startup, unfinished photo executions and requests become **interrupted**,
-with unknown finish times/durations left null. Completed requests retain
-their measurements, even when the enclosing run never wrote a job summary.
-Repeated startup does not replace completed measurements or invent elapsed
-wall time. See [timing and retention](ENRICH.md#photo-and-provider-request-timing).
+For rollback, stop the server and restore the **complete pre-upgrade snapshot**
+into a clean data directory/volume with the matching older build, following
+[Rolling back](#rolling-back). Never run v1.1.0 or an older development build directly
+against state already upgraded beyond its supported contract.
+
+Restoring Pictaria state does not undo tags or captions already written to
+Immich, or changes made in Immich itself.

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -262,8 +262,9 @@ to know which upgrade caused it.
 ## Upgrading to v1.2.0
 
 v1.2.0 upgrades persistent-state contract 8 from v1.1.0 to **contract 15**,
-with **Enrich schema 12** and **settings version 7**. Upgrades from earlier
-v1.2 development builds follow any remaining migrations. The release does
+with **Enrich schema 12** and **settings version 7**. v1.0.x installations can
+also upgrade directly to v1.2.0; installing v1.1.0 first is not required.
+Upgrades from earlier v1.2 development builds follow any remaining migrations. The release does
 not require a new Immich or Pictaria Frame version.
 
 ### Before and after first startup

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pictaria-server",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",


### PR DESCRIPTION
**Published:** [v1.2.0](https://github.com/pictaria-ai/pictaria-server/releases/tag/v1.2.0), source `629543820956f19ac2f05d46b3b13e90e4f98aaf`. Multi-platform image and `latest` verified; PIC-349 is Done. The preparation/publication-pending text below is historical.

Pictaria Server v1.2.0 packages the reviewed Enrich hardening work: reusable profiles and immutable run settings, per-photo performance, resumable library discovery, configurable history, and automatic AI-tag sync. This PR sets package/Compose/install defaults to 1.2.0, consolidates the changelog and migration guide, and aligns first-run, configuration, backup, and architecture documentation with the final workflow. No application behavior or persistent schema changes are introduced here.

Related to PIC-349.

### Validation

- All 1,146 tests passed on Node 22 after the final documentation pass, with no failures, cancellations, or skips. Publication hygiene, whitespace checks, and 62 local documentation links/anchors pass.
- The direct actual-source v1.1.0 rehearsal migrated Enrich schema 7/settings 6/contract 8 to 12/7/15 while preserving results, human tags, queue selections, and custom prompts. Verified recovery snapshot, v1.2 restart and complete backup/restore, old-version refusal of upgraded state, and clean snapshot rollback.
- Claude independently approved the earlier preparation at fa8877a after actual-source v1.1.0 and v1.0.1 upgrade/rollback rehearsals with a tag-capable fake Immich. All four CI checks passed on the subsequent documentation follow-up d210556. Claude also independently reviewed and approved the final documentation at 70d49fb, checking behavior/UI labels, all Markdown links and release anchors, and all four passing CI checks.
- David now reports a live rehearsal with newly installed Immich and Pictaria v1.1: enrichment worked, settings remained after upgrade to v1.2, enrichment worked again, and a return to v1.1 also worked. Exact build IDs and restore steps were not supplied in that report; it is recorded as user acceptance, not proof of code-only downgrade support or the full Immich 3.2 checklist.
- Final documentation commit: 70d49fb. All four CI checks on that head pass. Public website updates are tracked separately in PIC-355 for coordinated publication.

### Release and rollback

Review the [v1.2 changelog](https://github.com/pictaria-ai/pictaria-server/blob/pic-349-release-1.2.0/CHANGELOG.md) and [upgrade guide](https://github.com/pictaria-ai/pictaria-server/blob/pic-349-release-1.2.0/docs/UPGRADING.md#upgrading-to-v120). Startup takes a complete pre-migration recovery snapshot. Rollback requires that snapshot and its matching old build; reverting code alone is unsupported. Restoring Pictaria does not undo Immich tags/captions.

Publication remains pending: merge the approved preparation PR, tag the merged commit v1.2.0, verify amd64/arm64 image publication, and record the manifest digest and exact source commit in the GitHub release. No tag/image/GitHub release is published by this PR. Update the release date before tagging if publication happens on a later day. Immich 3.2 follow-ups PIC-350 through PIC-354 are planned after v1.2.0.

Prepared and validated by Codex; independent review of the earlier preparation is described above. The final pass fixes outdated profile labels, missing history environment variables, fixed-100/future-profile text, and incomplete first-run/backup guidance. It adds a short starting-point index to the detailed Enrich guide. Runtime behavior and tests are unchanged.


