### PR TITLE
PIC-350: Recover missing tag IDs after incomplete Immich upserts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to Pictaria Server are documented here. This project follows
 
 ## Unreleased
 
+### Fixed
+
+- Enrich and Curate tag sync now recover missing IDs from an incomplete
+  successful Immich tag-creation response by refreshing the tag list once.
+  This avoids a fallback incompatible with hierarchical tags on Immich 3.2;
+  unresolved tags remain visible errors handled by the existing sync queues.
+
 ## 1.2.0 - 2026-09-10
 
 This release focuses on Enrich: reusable profiles, predictable run settings,

--- a/docs/ENRICH.md
+++ b/docs/ENRICH.md
@@ -72,6 +72,12 @@ failure does not fail enrichment or repeat an AI call. Enable **Tags** under
 and retry there. Deleted photos are skipped. Turning Enrich off pauses this
 queue while preserving pending work; it does not block Curate sync.
 
+Enrich and Curate create missing tag hierarchies through Immich's bulk tag
+upsert. If a successful response omits requested tag IDs, Pictaria refreshes
+the tag list once. Any IDs still missing produce an **Unable to resolve
+Immich tag IDs** error and follow the existing sync retry behavior; requested
+tags are never silently dropped. Complete responses need no extra read.
+
 AI sync has a separate durable queue with one row per photo and no historical
 tag payload. Repeated enrichment coalesces to the newest local result. A
 processing-run generation prevents an older in-flight completion or failure

--- a/src/enrich/runner.mjs
+++ b/src/enrich/runner.mjs
@@ -624,13 +624,10 @@ export async function ensureImmichTagIds(immich, tags) {
   if (missing.length > 0) {
     Object.assign(existing, tagMap(await immich.upsertTags(missing)));
   }
-  for (const tag of tags.filter((candidate) => !(candidate in existing))) {
-    const created = await immich.createTag(tag);
-    const value = tagValue(created);
-    const identifier = tagId(created);
-    if (value && identifier) {
-      existing[value] = identifier;
-    }
+  if (tags.some((tag) => !(tag in existing))) {
+    // A successful upsert can leave IDs unresolved. Re-read once instead of
+    // using single-tag creation, which rejects hierarchical names in Immich 3.2.
+    Object.assign(existing, tagMap(await immich.listTags()));
   }
   const unresolved = tags.filter((tag) => !(tag in existing));
   if (unresolved.length > 0) {

--- a/src/immich.mjs
+++ b/src/immich.mjs
@@ -266,10 +266,6 @@ export class ImmichClient {
     return isPlainObject(response) && Array.isArray(response.tags) ? response.tags : [];
   }
 
-  async createTag(tag) {
-    return this.requestJson('/tags', { method: 'POST', body: { name: tag } });
-  }
-
   async tagAssetsBulk({ assetIds, tagIds }) {
     if (!assetIds.length || !tagIds.length) {
       return { count: 0 };

--- a/test/enrich/aiTagSync.test.mjs
+++ b/test/enrich/aiTagSync.test.mjs
@@ -72,6 +72,33 @@ test('AI sync reconciles stale tags, preserves frame and user tags, and makes no
   });
 });
 
+test('unresolved tag IDs defer AI sync without removing tags and recover on retry', async () => {
+  await fixture(async ({ repo, immich, sync, seed }) => {
+    const assetId = seed(1);
+    const originalTags = ['ai/scene/old', 'frame/favorite', 'holiday'];
+    for (const tag of originalTags) immich.photos.get(assetId).add(tag);
+    const upsert = immich.upsertTags.bind(immich);
+    immich.upsertTags = async () => []; // Successful response, no IDs in the refresh either.
+    await sync.tick();
+    assert.deepEqual([...immich.photos.get(assetId)], originalTags);
+    assert.equal(immich.calls.filter(([kind]) => kind === 'list').length, 2);
+    assert.equal(repo.aiTagSync.status().pending, 1);
+    assert.equal(repo.aiTagSync.status().written, 0);
+    assert.match(repo.aiTagSync.status().lastError, /Unable to resolve Immich tag IDs/);
+    assert.ok(repo.aiTagSync.status().retryAfter > Date.now());
+    assert.equal(await sync.tick(), false);
+
+    // Immich creates the tags but omits them from its successful upsert response.
+    immich.upsertTags = async tags => { await upsert(tags); return []; };
+    sync.retry();
+    await sync.tick();
+    assert.equal(repo.aiTagSync.status().written, 1);
+    assert.equal(repo.aiTagSync.status().pending, 0);
+    assert.deepEqual([...immich.photos.get(assetId)].sort(), ['ai/scene/mountains', 'frame/favorite', 'holiday']);
+    assert.equal(repo.pendingSyncJobCount(), 0);
+  });
+});
+
 test('new enrichment during an HTTP write survives stale completion and converges to latest tags', async () => {
   await fixture(async ({ immich, sync, seed, repo }) => {
     const assetId = seed(1); const entered = deferred(); const release = deferred();

--- a/test/enrich/reviewService.test.mjs
+++ b/test/enrich/reviewService.test.mjs
@@ -251,6 +251,41 @@ test('legacy sync jobs reconcile remote work in bounded slices', async () => {
   });
 });
 
+test('Curate retains an unresolved tag job and completes it after tag-list recovery', async () => {
+  await withService(async ({ repo, immich, service }) => {
+    const waitForWorker = async condition => {
+      const deadline = Date.now() + 5000;
+      while (!condition()) {
+        assert.ok(Date.now() < deadline, 'sync worker did not reach the expected state within 5 seconds');
+        await new Promise(resolve => setTimeout(resolve, 5));
+      }
+    };
+    seedAsset(repo, DECISION_ID);
+    immich.tags = [];
+    immich.assetTags.set(DECISION_ID, new Set(['holiday']));
+    const upsert = immich.upsertTags.bind(immich);
+    immich.upsertTags = async () => [];
+    service.applyDecision({ action: 'approve', assetIds: [DECISION_ID] });
+    service.startSyncWorker();
+    try {
+      await waitForWorker(() => repo.nextSyncJob()?.attempts > 0);
+    } finally { await service.stopSyncWorker(); }
+    assert.equal(repo.nextSyncJob().attempts, 1);
+    assert.equal(repo.pendingSyncJobCount(), 1);
+    assert.deepEqual([...immich.assetTags.get(DECISION_ID)], ['holiday']);
+
+    immich.upsertTags = async tags => { await upsert(tags); return []; };
+    service.startSyncWorker();
+    try {
+      await waitForWorker(() => repo.pendingSyncJobCount() === 0);
+    } finally { await service.stopSyncWorker(); }
+    assert.equal(repo.pendingSyncJobCount(), 0);
+    assert.ok(immich.assetTags.get(DECISION_ID).has('frame/eligible'));
+    assert.ok(immich.assetTags.get(DECISION_ID).has('ai/quality/frame-worthy'));
+    assert.ok(immich.assetTags.get(DECISION_ID).has('holiday'));
+  });
+});
+
 test('successful sync slices advance durably before a later slice fails', async () => {
   await withService(async ({ repo, immich, service }) => {
     const assetIds = Array.from({ length: 75 }, (_, index) => syncAssetId(index));

--- a/test/enrich/reviewService.test.mjs
+++ b/test/enrich/reviewService.test.mjs
@@ -49,10 +49,6 @@ class FakeImmich {
     return created;
   }
 
-  async createTag(tag) {
-    return { id: `tag-${tag}`, value: tag };
-  }
-
   async tagAssetsBulk({ assetIds, tagIds }) {
     this.calls.push(['tag', tagIds, assetIds]);
     for (const assetId of assetIds) {

--- a/test/enrich/tagResolution.test.mjs
+++ b/test/enrich/tagResolution.test.mjs
@@ -1,0 +1,97 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { ImmichClient, ImmichApiError } from '../../src/immich.mjs';
+import { ensureImmichTagIds, syncTagDecisions } from '../../src/enrich/runner.mjs';
+
+// Full-path value and leaf name are shared by Immich 2.7.5 and 3.2's tag
+// responses. This tests the production HTTP client with simulated responses,
+// including incomplete successful upserts; it is not live-version acceptance.
+const mountain = { id: 'mountain-id', value: 'ai/scene/mountains', name: 'mountains' };
+const water = { id: 'water-id', value: 'ai/scene/water', name: 'water' };
+const favorite = { id: 'favorite-id', value: 'frame/favorite', name: 'favorite' };
+
+function transport(steps) {
+  const calls = [];
+  const immich = new ImmichClient({
+    baseUrl: 'http://immich.test', apiKey: 'test-key',
+    fetchImpl: async (url, options) => {
+      const call = { method: options.method, path: new URL(url).pathname,
+        body: options.body ? JSON.parse(options.body) : undefined };
+      calls.push(call);
+      const step = steps[calls.length - 1];
+      assert.ok(step, `Unexpected request: ${call.method} ${call.path}`);
+      assert.equal(call.method, step.method);
+      assert.equal(call.path, '/api/tags');
+      if (step.request) assert.deepEqual(call.body, step.request);
+      if (step.error) throw step.error;
+      return Response.json(step.response, { status: step.status ?? 200 });
+    },
+  });
+  return { immich, calls, assertComplete: () => assert.equal(calls.length, steps.length) };
+}
+
+test('existing hierarchical tags need only the initial read', async () => {
+  const f = transport([{ method: 'GET', response: [mountain, water] }]);
+  assert.deepEqual(await ensureImmichTagIds(f.immich, [mountain.value]), { [mountain.value]: mountain.id });
+  f.assertComplete();
+});
+
+test('complete upserts resolve all requested tags without a refresh', async () => {
+  const f = transport([
+    { method: 'GET', response: [favorite] },
+    { method: 'PUT', request: { tags: [mountain.value, water.value] }, response: [mountain, water] },
+  ]);
+  assert.deepEqual(await ensureImmichTagIds(f.immich, [favorite.value, mountain.value, water.value]), {
+    [favorite.value]: favorite.id, [mountain.value]: mountain.id, [water.value]: water.id,
+  });
+  f.assertComplete();
+});
+
+for (const wrapped of [false, true]) {
+  for (const partial of [false, true]) {
+    test(`${partial ? 'partial' : 'empty'} upsert recovers from one ${wrapped ? 'wrapped' : 'array'} tag listing`, async () => {
+      const response = tags => wrapped ? { tags } : tags;
+      const f = transport([
+        { method: 'GET', response: response([favorite]) },
+        { method: 'PUT', request: { tags: [mountain.value, water.value] }, response: response(partial ? [mountain] : []) },
+        // Deliberately omit already-resolved IDs: the refresh must merge them.
+        { method: 'GET', response: response(partial ? [water] : [mountain, water]) },
+      ]);
+      assert.deepEqual(await ensureImmichTagIds(f.immich, [favorite.value, mountain.value, water.value]), {
+        [favorite.value]: favorite.id, [mountain.value]: mountain.id, [water.value]: water.id,
+      });
+      f.assertComplete(); // No POST /tags, even when the successful upsert is empty.
+    });
+  }
+}
+
+test('unresolved IDs stop tag writes after one refresh instead of silently dropping tags', async () => {
+  const f = transport([
+    { method: 'GET', response: [] },
+    { method: 'PUT', response: [mountain] },
+    { method: 'GET', response: [mountain, { value: water.value }] },
+  ]);
+  await assert.rejects(syncTagDecisions(f.immich, {
+    'photo-id': [{ tag: mountain.value }, { tag: water.value }],
+  }), { message: `Unable to resolve Immich tag IDs for: ${JSON.stringify([water.value])}` });
+  f.assertComplete();
+});
+
+for (const stage of ['initial read', 'upsert', 'refresh']) {
+  for (const status of [401, 403, 500, null]) {
+    test(`${stage} ${status ?? 'transport'} failure propagates without creation or refresh retries`, async () => {
+      const steps = [];
+      if (stage !== 'initial read') steps.push({ method: 'GET', response: [] });
+      if (stage === 'refresh') steps.push({ method: 'PUT', response: [] });
+      steps.push({ method: stage === 'upsert' ? 'PUT' : 'GET', status,
+        response: { message: 'Unavailable' }, error: status === null ? new Error('connection lost') : undefined });
+      const f = transport(steps);
+      await assert.rejects(ensureImmichTagIds(f.immich, [mountain.value]), error => {
+        assert.ok(error instanceof ImmichApiError);
+        assert.equal(error.status, status);
+        return true;
+      });
+      f.assertComplete();
+    });
+  }
+}


### PR DESCRIPTION
When a successful Immich tag upsert omits requested IDs, Enrich and Curate currently fall back to single-tag creation. That request rejects hierarchical names on Immich 3.2. Resolve missing IDs with one fresh tag listing instead, merging with already-resolved IDs. Complete responses keep their existing request count; unresolved IDs and upstream errors retain existing queue retry behavior.

The shared resolver handles the behavior change; the now-unused single-tag creation helper and its test stub are also removed. Add regression coverage through the production Immich client for existing tags, complete/partial/empty responses, array/wrapped listings, missing IDs, and permission/server/transport errors. Queue tests exercise Enrich backoff and Curate job retention, recovery, and preservation of unrelated photo tags. Update the changelog and Enrich documentation.

Validation: all 1,167 tests passed on Node 22, including 90 focused tests; publication hygiene and diff checks passed. All four CI checks passed on the reviewed implementation at `7fc7ec6`; all four checks also passed after the cleanup at `af14c7f`. All four CI checks passed after the update onto main. Merged with owner approval at `2b1cd96`; final main is byte-for-byte identical to the tested candidate tree. The shared tag response contract was checked against upstream [2.7.5](https://github.com/immich-app/immich/blob/v2.7.5/server/src/dtos/tag.dto.ts) and [3.2.0](https://github.com/immich-app/immich/blob/v3.2.0/server/src/dtos/tag.dto.ts). Test transports simulate responses; this is not live Immich compatibility acceptance. Final real-instance coverage remains tracked in PIC-351.

Risk/rollback: one extra tag-list read only after incomplete successful upserts. No UI, schema, settings, or queue-policy changes. Revert this commit to restore the prior behavior; no data migration is needed. Updated onto merged PIC-359 (#44). The tree at `5a4a93b` exactly matches combined candidate `8be13ef`, which passed automated checks and user-reported live testing on Immich 2.7.5, 3.1, and 3.2.

Implemented and locally verified by Codex. Claude independently reviewed commit `7fc7ec6` and approved it for v1.2.1, including an HTTP A/B reproduction with a simulated Immich 3.2 server. The optional removal of the unused single-tag creation helper is included as review follow-up. Target: v1.2.1.

Related to PIC-350. Compatibility acceptance: PIC-351.
